### PR TITLE
mlir is not a python dependency, so we cannot have it in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(
     author="Anaconda, Inc.",
     packages=find_packages(include=["mlir_graphblas", "mlir_graphblas.*"]),
     include_package_data=True,
-    install_requires=["grblas", "mlir"],
+    install_requires=["grblas", "pymlir"],
 )


### PR DESCRIPTION
Adding pymlir as dependencies because we will likely need it in the future.