### PR TITLE
Use Python 3.8 instead of 3.9 for upload

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -121,6 +121,9 @@ jobs:
           echo "AC_LABEL=main" >> $GITHUB_ENV
       - name: Create env
         uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: 3.8
       - name: Deploy to Anaconda Cloud
         shell: bash -l {0}
         run: |
@@ -131,4 +134,4 @@ jobs:
           ls -la .
           UPLOAD=`ls .`
           echo "Uploading $UPLOAD with label=${{ env.AC_LABEL }}"
-          anaconda -t ${{ secrets.ANACONDA_ORG_TOKEN }} upload -u metagraph -l ${{ env.AC_LABEL }} --no-progress --force --register $UPLOAD
+          anaconda -t ${{ secrets.ANACONDA_ORG_TOKEN }} upload -u metagraph -l ${{ env.AC_LABEL }} --no-progress --force --no-register $UPLOAD


### PR DESCRIPTION
Total shot in the dark here. Not sure why conda package upload is failing, but I'm going to try to use Python 3.8 instead of the default 3.9 install and see if that makes any difference.