### PR TITLE
Add install instructions to documentation

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -12,7 +12,16 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+        pyver:
+          - 3.8
+    runs-on: ${{ matrix.os }}
+    env:
+      ARTIFACT_NAME: built_package_py${{matrix.pyver}}_${{matrix.os}}.tar.bz2
     defaults:
       run:
         shell: bash -l {0}
@@ -45,7 +54,7 @@ jobs:
           coveralls --service=github
       - name: Conda Build
         run: |
-          conda build -c metagraph -c conda-forge continuous_integration/conda
+          conda build -c metagraph -c conda-forge --python ${{ matrix.pyver }} continuous_integration/conda
           # This doesn't rebuild, but simply computes the name of the file that was previously built
           OUTPUT=$(conda build --output -c metagraph -c conda-forge continuous_integration/conda)
           echo $OUTPUT
@@ -60,26 +69,30 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v2
         with:
-          name: built_package
+          name: ${{ env.ARTIFACT_NAME }}
           path: ${{ env.CONDA_BUILD_OUTPUT }}
           retention-days: 7
 
   test_pyver:
-    runs-on: ubuntu-latest
     needs: build
     defaults:
       run:
         shell: bash -l {0}
     strategy:
       matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
         pyver:
-          - 3.7
           - 3.8
+    runs-on: ${{ matrix.os }}
+    env:
+      ARTIFACT_NAME: built_package_py${{matrix.pyver}}_${{matrix.os}}.tar.bz2
     steps:
       - name: Download build artifact
         uses: actions/download-artifact@v2
         with:
-          name: built_package
+          name: ${{ env.ARTIFACT_NAME }}
           path: ./artifact_storage
       - name: Create env
         uses: conda-incubator/setup-miniconda@v2
@@ -104,16 +117,24 @@ jobs:
           python -m mlir_graphblas.tests
 
   dev_deploy:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+        pyver:
+          - 3.8
+    runs-on: ${{ matrix.os }}
     needs: test_pyver
     if: (github.ref == 'refs/heads/main') || contains(github.ref, 'refs/tags/')
     env:
+      ARTIFACT_NAME: built_package_py${{matrix.pyver}}_${{matrix.os}}.tar.bz2
       AC_LABEL: dev
     steps:
       - name: Download build artifact
         uses: actions/download-artifact@v2
         with:
-          name: built_package
+          name: ${{ env.ARTIFACT_NAME }}
           path: ./artifact_storage
       - name: Determine label
         if: contains(github.ref, 'refs/tags/')

--- a/continuous_integration/conda/meta.yaml
+++ b/continuous_integration/conda/meta.yaml
@@ -7,19 +7,18 @@ source:
 
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0)|int }}
-  string: py_{{GIT_DESCRIBE_HASH}}_{{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
-  noarch: python
+  string: py{{PY_VER}}_{{GIT_DESCRIBE_HASH}}_{{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
 
 requirements:
   host:
-    - python=3.8
+    - python
     - numpy
     - cython
-    - metagraph::mlir
+    - mlir
 
   run:
-    - python=3.8
-    - metagraph::mlir
+    - python
+    - mlir
     - pymlir
     - llvmlite
     - pygments

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,5 +13,6 @@ mlir-graphblas is licensed under the `Apache 2.0 license <https://www.apache.org
 .. toctree::
    :maxdepth: 2
 
+   installation/index
    implementation/index
    tools/index

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -5,9 +5,7 @@ Installation
 
 mlir-graphblas is implemented via Python and Cython.
 
-Building from source is possible, but the recommended method to install is via ``conda``.
-
-It is assumed by mlir-graphblas that it is installed using ``conda`` or ``venv``. Thus, installing using one of those two methods is recommended.
+Building from source or installing from ``pip`` is possible, but the recommended method to install is using ``conda``.
 
 Python version support
 ----------------------
@@ -38,7 +36,7 @@ These should be automatically installed when mlir-graphblas is installed
 
   - `numpy <https://numpy.org>`__
   - `PyMLIR <https://github.com/metagraph-dev/pymlir>`__
-  - `lvmlite <https://llvmlite.readthedocs.io/en/latest/>`__
+  - `llvmlite <https://llvmlite.readthedocs.io/en/latest/>`__
   - `pygments <https://pygments.org/>`__
   - `donfig <https://donfig.readthedocs.io/>`__
   - `panel <https://panel.holoviz.org/>`__

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -1,0 +1,46 @@
+.. _installation:
+
+Installation
+============
+
+mlir-graphblas is implemented via Python and Cython.
+
+Building from source is possible, but the recommended method to install is via ``conda``.
+
+It is assumed by mlir-graphblas that it is installed using ``conda`` or ``venv``. Thus, installing using one of those two methods is recommended.
+
+Python version support
+----------------------
+
+Python 3.8 and above is supported.
+
+Installing using conda
+----------------------
+
+::
+
+    conda install -c conda-forge -c metagraph mlir-graphblas
+
+Installing from source
+----------------------
+
+Instructions for building from source are currently a work in progress.
+
+Installing using venv
+---------------------
+
+Instructions for installing via venv are currently a work in progress.
+
+Required Dependencies
+---------------------
+
+These should be automatically installed when mlir-graphblas is installed
+
+  - `numpy <https://numpy.org>`__
+  - `PyMLIR <https://github.com/metagraph-dev/pymlir>`__
+  - `lvmlite <https://llvmlite.readthedocs.io/en/latest/>`__
+  - `pygments <https://pygments.org/>`__
+  - `donfig <https://donfig.readthedocs.io/>`__
+  - `panel <https://panel.holoviz.org/>`__
+  - `bokeh <https://bokeh.org/>`__
+

--- a/mlir_graphblas/tests/test_jit_engine.py
+++ b/mlir_graphblas/tests/test_jit_engine.py
@@ -5,7 +5,7 @@ import mlir_graphblas.sparse_utils
 import pytest
 import numpy as np
 
-SIMPLE_TEST_CASES = [  # elements are ( mlir_template, args, expected_result x)
+SIMPLE_TEST_CASES = [  # elements are ( mlir_template, args, expected_result )
     pytest.param(  # arbitrary size tensor , arbitrary size tensor -> arbitrary size tensor
         """
 #trait_add = {{
@@ -210,6 +210,18 @@ func @{func_name}(%scalar: {mlir_type}, %arg0: tensor<?x!mlir_type_alias>, %arg1
         [2, np.arange(8), np.arange(5),],
         9,
         id="simple_and_nested_type_aliases",
+    ),
+    pytest.param(  # partially fixed size tensor -> scalar
+        """
+func @{func_name}(%arg_tensor: tensor<?x4x{mlir_type}>) -> {mlir_type} {{
+  %c0 = constant 0 : index
+  %ans = tensor.extract %arg_tensor[%c0, %c0] : tensor<?x4x{mlir_type}>
+  return %ans : {mlir_type}
+}}
+""",
+        [np.full([7, 4], 100)],
+        100,
+        id="partial_to_scalar",
     ),
 ]
 

--- a/mlir_graphblas/tests/test_jit_engine_bad_inputs.py
+++ b/mlir_graphblas/tests/test_jit_engine_bad_inputs.py
@@ -158,6 +158,13 @@ BAD_INPUT_TEST_CASES = [  # elements are ( error_type, error_match_string, bad_a
         "bad_input_string",
         id="string_for_sparse_tensor",
     ),
+    pytest.param(
+        TypeError,
+        " cannot be cast to ",
+        4,
+        np.float64(np.finfo(np.dtype('float32')).max**8),
+        id="f64_for_f32_scalar",
+    ),
 ]
 
 for np_type in (

--- a/mlir_graphblas/tests/test_jit_engine_bad_inputs.py
+++ b/mlir_graphblas/tests/test_jit_engine_bad_inputs.py
@@ -162,7 +162,7 @@ BAD_INPUT_TEST_CASES = [  # elements are ( error_type, error_match_string, bad_a
         TypeError,
         " cannot be cast to ",
         4,
-        np.float64(np.finfo(np.dtype('float32')).max**8),
+        np.float64(np.finfo(np.dtype("float32")).max ** 8),
         id="f64_for_f32_scalar",
     ),
 ]

--- a/mlir_graphblas/tests/test_jit_engine_bad_inputs.py
+++ b/mlir_graphblas/tests/test_jit_engine_bad_inputs.py
@@ -1,0 +1,223 @@
+from .jit_engine_test_utils import STANDARD_PASSES
+
+import mlir_graphblas
+import mlir_graphblas.sparse_utils
+import pytest
+import numpy as np
+
+#################
+# Test Fixtures #
+#################
+
+
+@pytest.fixture(scope="module")
+def compiled_func_and_valid_args():
+    mlir_text = """
+
+!SparseTensor = type !llvm.ptr<i8>
+
+func @many_inputs_constant_output(
+   %arg_arbitrary_size_tensor: tensor<?x?xf32>,
+   %arg_fixed_size_tensor: tensor<2x3xf32>,
+   %arg_partially_fixed_size_tensor: tensor<2x?xf32>,
+   %arg_sparse_tensor: !SparseTensor,
+   %arg_f32: f32
+) -> i32 {
+ %c1234 = constant 1234 : i32
+ return %c1234 : i32
+}
+"""
+    engine = mlir_graphblas.MlirJitEngine()
+    assert engine.add(mlir_text, STANDARD_PASSES) == ["many_inputs_constant_output"]
+    callable_func = engine.many_inputs_constant_output
+
+    indices = np.array([[0, 0, 0], [1, 1, 1]], dtype=np.uint64)
+    values = np.array([1.2, 3.4], dtype=np.float32)
+    sizes = np.array([10, 20, 30], dtype=np.uint64)
+    sparsity = np.array([True, True, True], dtype=np.bool8)
+    sparse_tensor = mlir_graphblas.sparse_utils.MLIRSparseTensor(
+        indices, values, sizes, sparsity
+    )
+
+    valid_args = [
+        np.arange(7, dtype=np.float32).reshape([7, 1]),
+        np.arange(6, dtype=np.float32).reshape([2, 3]),
+        np.arange(8, dtype=np.float32).reshape([2, 4]),
+        sparse_tensor,
+        123.456,
+    ]
+
+    assert callable_func(*valid_args) == 1234
+
+    return callable_func, valid_args
+
+
+##############
+# Test Cases #
+##############
+
+BAD_INPUT_TEST_CASES = [  # elements are ( error_type, error_match_string, bad_arg_index, bad_arg )
+    pytest.param(
+        ValueError,
+        "is expected to have rank",
+        0,
+        np.arange(10).astype(np.float32),
+        id="bad_rank_for_arbitrary_size_tensor",
+    ),
+    pytest.param(
+        ValueError,
+        "is expected to have rank",
+        1,
+        np.arange(10).astype(np.float32),
+        id="bad_rank_for_fixed_size_tensor",
+    ),
+    pytest.param(
+        ValueError,
+        r"is expected to have size [0-9]+ in the [0-9]+th dimension but has size [0-9]+",
+        2,
+        np.arange(10).astype(np.float32).reshape([5, 2]),
+        id="bad_size_for_partially_fixed_size_tensor",
+    ),
+    pytest.param(
+        TypeError,
+        "is expected to be an instance of",
+        0,
+        12.34,
+        id="scalar_for_arbitrary_size_tensor",
+    ),
+    pytest.param(
+        TypeError,
+        "is expected to be an instance of",
+        1,
+        -1234,
+        id="scalar_for_fixed_size_tensor",
+    ),
+    pytest.param(
+        TypeError,
+        "is expected to be an instance of",
+        2,
+        0,
+        id="scalar_for_partially_fixed_size_tensor",
+    ),
+    pytest.param(
+        TypeError,
+        "is expected to be an instance of",
+        0,
+        "bad_input_string",
+        id="string_for_arbitrary_size_tensor",
+    ),
+    pytest.param(
+        TypeError,
+        "is expected to be an instance of",
+        1,
+        "bad_input_string",
+        id="string_for_fixed_size_tensor",
+    ),
+    pytest.param(
+        TypeError,
+        "is expected to be an instance of",
+        2,
+        "bad_input_string",
+        id="string_for_partially_fixed_size_tensor",
+    ),
+    pytest.param(
+        TypeError, "cannot be cast to", 4, "bad_input_string", id="string_for_scalar",
+    ),
+    pytest.param(
+        TypeError,
+        "is expected to be a scalar with dtype",
+        4,
+        np.arange(10).astype(np.float32).reshape([5, 2]),
+        id="array_for_scalar",
+    ),
+    pytest.param(
+        TypeError,
+        "is expected to be an instance of",
+        3,
+        99,
+        id="int_for_sparse_tensor",
+    ),
+    pytest.param(
+        TypeError,
+        "is expected to be an instance of",
+        3,
+        12.34,
+        id="float_for_sparse_tensor",
+    ),
+    pytest.param(
+        TypeError,
+        "is expected to be an instance of",
+        3,
+        np.arange(10).astype(np.float32).reshape([5, 2]),
+        id="array_for_sparse_tensor",
+    ),
+    pytest.param(
+        TypeError,
+        "is expected to be an instance of",
+        3,
+        "bad_input_string",
+        id="string_for_sparse_tensor",
+    ),
+]
+
+for np_type in (
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.longlong,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.ulonglong,
+    np.float16,
+    np.float64,
+    np.float128,
+    np.complex64,
+    np.complex128,
+    np.complex256,
+    np.record,
+    np.bool,
+):
+    BAD_INPUT_TEST_CASES += [
+        pytest.param(
+            TypeError,
+            "is expected to have dtype",
+            0,
+            np.arange(10).astype(np_type),
+            id=f"bad_type_{np_type.__name__}_for_arbitrary_size_tensor",
+        ),
+        pytest.param(
+            TypeError,
+            "is expected to have dtype",
+            1,
+            np.arange(10).astype(np_type),
+            id=f"bad_type_{np_type.__name__}_for_fixed_size_tensor",
+        ),
+    ]
+
+#########
+# Tests #
+#########
+
+
+@pytest.mark.parametrize("error_type,match,bad_arg_index,bad_arg", BAD_INPUT_TEST_CASES)
+def test_jit_engine_bad_inputs(
+    compiled_func_and_valid_args, error_type, match, bad_arg_index, bad_arg
+):
+    compiled_func, valid_args = compiled_func_and_valid_args
+    with pytest.raises(error_type, match=match):
+        invalid_args = list(valid_args)
+        invalid_args[bad_arg_index] = bad_arg
+        compiled_func(*invalid_args)
+
+
+def test_jit_engine_incorrect_number_of_inputs(compiled_func_and_valid_args):
+    compiled_func, valid_args = compiled_func_and_valid_args
+    with pytest.raises(ValueError, match=r"[0-9] args but got [0-9]"):
+        invalid_args = valid_args + valid_args
+        compiled_func(*invalid_args)
+
+    with pytest.raises(ValueError, match=r"[0-9] args but got 0."):
+        compiled_func()


### PR DESCRIPTION
This PR adds some documentation on how to install `mlir-graphblas` via `conda`. Instructions for building from source or installing using `venv` are currently not present.

It's intended to squash the changes before merging. 