### PR TITLE
Bad input tests

### DIFF
--- a/mlir_graphblas/tests/test_jit_engine.py
+++ b/mlir_graphblas/tests/test_jit_engine.py
@@ -5,7 +5,7 @@ import mlir_graphblas.sparse_utils
 import pytest
 import numpy as np
 
-SIMPLE_TEST_CASES = [  # elements are ( mlir_template, args, expected_result x)
+SIMPLE_TEST_CASES = [  # elements are ( mlir_template, args, expected_result )
     pytest.param(  # arbitrary size tensor , arbitrary size tensor -> arbitrary size tensor
         """
 #trait_add = {{
@@ -210,6 +210,18 @@ func @{func_name}(%scalar: {mlir_type}, %arg0: tensor<?x!mlir_type_alias>, %arg1
         [2, np.arange(8), np.arange(5),],
         9,
         id="simple_and_nested_type_aliases",
+    ),
+    pytest.param(  # partially fixed size tensor -> scalar
+        """
+func @{func_name}(%arg_tensor: tensor<?x4x{mlir_type}>) -> {mlir_type} {{
+  %c0 = constant 0 : index
+  %ans = tensor.extract %arg_tensor[%c0, %c0] : tensor<?x4x{mlir_type}>
+  return %ans : {mlir_type}
+}}
+""",
+        [np.full([7, 4], 100)],
+        100,
+        id="partial_to_scalar",
     ),
 ]
 

--- a/mlir_graphblas/tests/test_jit_engine_bad_inputs.py
+++ b/mlir_graphblas/tests/test_jit_engine_bad_inputs.py
@@ -158,6 +158,13 @@ BAD_INPUT_TEST_CASES = [  # elements are ( error_type, error_match_string, bad_a
         "bad_input_string",
         id="string_for_sparse_tensor",
     ),
+    pytest.param(
+        TypeError,
+        " cannot be cast to ",
+        4,
+        np.float64(np.finfo(np.dtype('float32')).max**8),
+        id="f64_for_f32_scalar",
+    ),
 ]
 
 for np_type in (

--- a/mlir_graphblas/tests/test_jit_engine_bad_inputs.py
+++ b/mlir_graphblas/tests/test_jit_engine_bad_inputs.py
@@ -162,7 +162,7 @@ BAD_INPUT_TEST_CASES = [  # elements are ( error_type, error_match_string, bad_a
         TypeError,
         " cannot be cast to ",
         4,
-        np.float64(np.finfo(np.dtype('float32')).max**8),
+        np.float64(np.finfo(np.dtype("float32")).max ** 8),
         id="f64_for_f32_scalar",
     ),
 ]

--- a/mlir_graphblas/tests/test_jit_engine_bad_inputs.py
+++ b/mlir_graphblas/tests/test_jit_engine_bad_inputs.py
@@ -1,0 +1,223 @@
+from .jit_engine_test_utils import STANDARD_PASSES
+
+import mlir_graphblas
+import mlir_graphblas.sparse_utils
+import pytest
+import numpy as np
+
+#################
+# Test Fixtures #
+#################
+
+
+@pytest.fixture(scope="module")
+def compiled_func_and_valid_args():
+    mlir_text = """
+
+!SparseTensor = type !llvm.ptr<i8>
+
+func @many_inputs_constant_output(
+   %arg_arbitrary_size_tensor: tensor<?x?xf32>,
+   %arg_fixed_size_tensor: tensor<2x3xf32>,
+   %arg_partially_fixed_size_tensor: tensor<2x?xf32>,
+   %arg_sparse_tensor: !SparseTensor,
+   %arg_f32: f32
+) -> i32 {
+ %c1234 = constant 1234 : i32
+ return %c1234 : i32
+}
+"""
+    engine = mlir_graphblas.MlirJitEngine()
+    assert engine.add(mlir_text, STANDARD_PASSES) == ["many_inputs_constant_output"]
+    callable_func = engine.many_inputs_constant_output
+
+    indices = np.array([[0, 0, 0], [1, 1, 1]], dtype=np.uint64)
+    values = np.array([1.2, 3.4], dtype=np.float32)
+    sizes = np.array([10, 20, 30], dtype=np.uint64)
+    sparsity = np.array([True, True, True], dtype=np.bool8)
+    sparse_tensor = mlir_graphblas.sparse_utils.MLIRSparseTensor(
+        indices, values, sizes, sparsity
+    )
+
+    valid_args = [
+        np.arange(7, dtype=np.float32).reshape([7, 1]),
+        np.arange(6, dtype=np.float32).reshape([2, 3]),
+        np.arange(8, dtype=np.float32).reshape([2, 4]),
+        sparse_tensor,
+        123.456,
+    ]
+
+    assert callable_func(*valid_args) == 1234
+
+    return callable_func, valid_args
+
+
+##############
+# Test Cases #
+##############
+
+BAD_INPUT_TEST_CASES = [  # elements are ( error_type, error_match_string, bad_arg_index, bad_arg )
+    pytest.param(
+        ValueError,
+        "is expected to have rank",
+        0,
+        np.arange(10).astype(np.float32),
+        id="bad_rank_for_arbitrary_size_tensor",
+    ),
+    pytest.param(
+        ValueError,
+        "is expected to have rank",
+        1,
+        np.arange(10).astype(np.float32),
+        id="bad_rank_for_fixed_size_tensor",
+    ),
+    pytest.param(
+        ValueError,
+        r"is expected to have size [0-9]+ in the [0-9]+th dimension but has size [0-9]+",
+        2,
+        np.arange(10).astype(np.float32).reshape([5, 2]),
+        id="bad_size_for_partially_fixed_size_tensor",
+    ),
+    pytest.param(
+        TypeError,
+        "is expected to be an instance of",
+        0,
+        12.34,
+        id="scalar_for_arbitrary_size_tensor",
+    ),
+    pytest.param(
+        TypeError,
+        "is expected to be an instance of",
+        1,
+        -1234,
+        id="scalar_for_fixed_size_tensor",
+    ),
+    pytest.param(
+        TypeError,
+        "is expected to be an instance of",
+        2,
+        0,
+        id="scalar_for_partially_fixed_size_tensor",
+    ),
+    pytest.param(
+        TypeError,
+        "is expected to be an instance of",
+        0,
+        "bad_input_string",
+        id="string_for_arbitrary_size_tensor",
+    ),
+    pytest.param(
+        TypeError,
+        "is expected to be an instance of",
+        1,
+        "bad_input_string",
+        id="string_for_fixed_size_tensor",
+    ),
+    pytest.param(
+        TypeError,
+        "is expected to be an instance of",
+        2,
+        "bad_input_string",
+        id="string_for_partially_fixed_size_tensor",
+    ),
+    pytest.param(
+        TypeError, "cannot be cast to", 4, "bad_input_string", id="string_for_scalar",
+    ),
+    pytest.param(
+        TypeError,
+        "is expected to be a scalar with dtype",
+        4,
+        np.arange(10).astype(np.float32).reshape([5, 2]),
+        id="array_for_scalar",
+    ),
+    pytest.param(
+        TypeError,
+        "is expected to be an instance of",
+        3,
+        99,
+        id="int_for_sparse_tensor",
+    ),
+    pytest.param(
+        TypeError,
+        "is expected to be an instance of",
+        3,
+        12.34,
+        id="float_for_sparse_tensor",
+    ),
+    pytest.param(
+        TypeError,
+        "is expected to be an instance of",
+        3,
+        np.arange(10).astype(np.float32).reshape([5, 2]),
+        id="array_for_sparse_tensor",
+    ),
+    pytest.param(
+        TypeError,
+        "is expected to be an instance of",
+        3,
+        "bad_input_string",
+        id="string_for_sparse_tensor",
+    ),
+]
+
+for np_type in (
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.longlong,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.ulonglong,
+    np.float16,
+    np.float64,
+    np.float128,
+    np.complex64,
+    np.complex128,
+    np.complex256,
+    np.record,
+    np.bool,
+):
+    BAD_INPUT_TEST_CASES += [
+        pytest.param(
+            TypeError,
+            "is expected to have dtype",
+            0,
+            np.arange(10).astype(np_type),
+            id=f"bad_type_{np_type.__name__}_for_arbitrary_size_tensor",
+        ),
+        pytest.param(
+            TypeError,
+            "is expected to have dtype",
+            1,
+            np.arange(10).astype(np_type),
+            id=f"bad_type_{np_type.__name__}_for_fixed_size_tensor",
+        ),
+    ]
+
+#########
+# Tests #
+#########
+
+
+@pytest.mark.parametrize("error_type,match,bad_arg_index,bad_arg", BAD_INPUT_TEST_CASES)
+def test_jit_engine_bad_inputs(
+    compiled_func_and_valid_args, error_type, match, bad_arg_index, bad_arg
+):
+    compiled_func, valid_args = compiled_func_and_valid_args
+    with pytest.raises(error_type, match=match):
+        invalid_args = list(valid_args)
+        invalid_args[bad_arg_index] = bad_arg
+        compiled_func(*invalid_args)
+
+
+def test_jit_engine_incorrect_number_of_inputs(compiled_func_and_valid_args):
+    compiled_func, valid_args = compiled_func_and_valid_args
+    with pytest.raises(ValueError, match=r"[0-9] args but got [0-9]"):
+        invalid_args = valid_args + valid_args
+        compiled_func(*invalid_args)
+
+    with pytest.raises(ValueError, match=r"[0-9] args but got 0."):
+        compiled_func()


### PR DESCRIPTION
This commit adds several tests to make sure that we get exceptions when we pass in inappropriate inputs to callables generated by the JIT engine. 
