### PR TITLE
set minimum mlir

### DIFF
--- a/continuous_integration/conda/meta.yaml
+++ b/continuous_integration/conda/meta.yaml
@@ -14,11 +14,11 @@ requirements:
     - python
     - numpy
     - cython
-    - mlir
+    - mlir >=12.0
 
   run:
     - python
-    - mlir
+    - mlir >=12.0
     - pymlir
     - llvmlite
     - pygments


### PR DESCRIPTION
Older MLIR is available on conda-forge, which is missing functionality we require