### PR TITLE
Allow initial styling of explorer

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -42,6 +42,7 @@ jobs:
           pip install -e .
       - name: Lint with Black
         run: |
+          black --version
           black mlir_graphblas *.py --check --diff
       - name: Pytest
         run: |

--- a/continuous_integration/environment.yml
+++ b/continuous_integration/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - coverage
   - pytest
   - pytest-cov
-  - black=19.10b0
+  - black=20.8b1
 
 
 # dependencies (so setup.py develop doesn't pip install them)

--- a/mlir_graphblas/cli.py
+++ b/mlir_graphblas/cli.py
@@ -178,7 +178,19 @@ class DebugResult:
             ret.append(f"{i:{offset}}|{line}")
         return "\n".join(ret)
 
-    def explore(self, embed=False):
+    def explore(self, embed=False, initial_style=None):
+        """
+        Open an interactive explorer view of the passes
+
+        :param embed: If True, embeds the explorer in the notebook output
+                      If False (default), open the explorer in a new tab
+        :param initial_style: dict of styles to apply for the initial view of the explorer
+            line_numbers: bool
+            highlight_style: str
+            tab: str
+            pass: str
+            pass2: str (only applies if tab=="Double")
+        """
         from .explorer import Explorer
 
-        return Explorer(self).show(embed=embed)
+        return Explorer(self).show(embed=embed, initial_style=initial_style)

--- a/mlir_graphblas/engine.py
+++ b/mlir_graphblas/engine.py
@@ -291,7 +291,8 @@ def input_type_to_ctypes(mlir_type: mlir.astnodes.Type) -> Tuple[list, Callable]
 
 
 def _resolve_type_aliases(
-    node: Any, type_alias_table: Dict[str, mlir.astnodes.PrettyDialectType],
+    node: Any,
+    type_alias_table: Dict[str, mlir.astnodes.PrettyDialectType],
 ) -> Any:
     if isinstance(node, (mlir.astnodes.Node, mlir.astnodes.Module)):
         for field in node._fields_:

--- a/mlir_graphblas/explorer.py
+++ b/mlir_graphblas/explorer.py
@@ -65,15 +65,23 @@ class Explorer:
         # Apply initial styles
         if initial_style is None:
             initial_style = {}
-        self.show_line_numbers = initial_style.get("line_numbers", self.show_line_numbers)
-        self.highlight_style = initial_style.get("highlight_style", self.highlight_style)
+        self.show_line_numbers = initial_style.get(
+            "line_numbers", self.show_line_numbers
+        )
+        self.highlight_style = initial_style.get(
+            "highlight_style", self.highlight_style
+        )
         self.build()
         if "tab" in initial_style:
             tab_name = initial_style.get("tab", "sequential").lower()
             pass_name = initial_style.get("pass", "Initial")
-            ipass = 0 if pass_name == "Initial" else self.dr._find_pass_index(pass_name) + 1
+            ipass = (
+                0 if pass_name == "Initial" else self.dr._find_pass_index(pass_name) + 1
+            )
             if tab_name == "sequential":
-                assert pass_name != "Initial", "Sequential tab does not have Initial option"
+                assert (
+                    pass_name != "Initial"
+                ), "Sequential tab does not have Initial option"
                 self._ui["seq_select"].value = pass_name
                 self._shown_stages[0] = ipass - 1
                 self._shown_stages[1] = ipass
@@ -84,7 +92,11 @@ class Explorer:
             elif tab_name == "double":
                 self._ui["tabs"].active = 2
                 pass2_name = initial_style.get("pass2", self.dr.passes[0])
-                ipass2 = 0 if pass2_name == "Initial" else self.dr._find_pass_index(pass2_name) + 1
+                ipass2 = (
+                    0
+                    if pass2_name == "Initial"
+                    else self.dr._find_pass_index(pass2_name) + 1
+                )
                 self._ui["dbl_select_left"].value = pass_name
                 self._ui["dbl_select_right"].value = pass2_name
                 self._shown_stages[3] = ipass
@@ -120,7 +132,10 @@ class Explorer:
             name="Show Line Numbers", value=self.show_line_numbers, width=150
         )
         style_select = pn.widgets.Select(
-            name="Highlighting Style", options=list(styles.get_all_styles()), value=self.highlight_style, width=150
+            name="Highlighting Style",
+            options=list(styles.get_all_styles()),
+            value=self.highlight_style,
+            width=150,
         )
         tabs = pn.Tabs()
 
@@ -146,7 +161,9 @@ class Explorer:
         seq_code_row[0, 0] = seq_code_left
         seq_code_row[0, 1] = seq_code_right
         sequential[0, 0] = pn.Column(
-            seq_select, pn.Row(seq_btn_left, seq_btn_right), seq_code_row,
+            seq_select,
+            pn.Row(seq_btn_left, seq_btn_right),
+            seq_code_row,
         )
         tabs.append(("Sequential", sequential))
 

--- a/mlir_graphblas/tests/test_jit_engine.py
+++ b/mlir_graphblas/tests/test_jit_engine.py
@@ -28,7 +28,7 @@ func @{func_name}(%arga: tensor<?x?x{mlir_type}>, %argb: tensor<?x?x{mlir_type}>
  return %answer : tensor<?x?x{mlir_type}>
 }}
 """,
-        [np.arange(2 * 4).reshape((2, 4)), np.full([2, 4], 10),],
+        [np.arange(2 * 4).reshape((2, 4)), np.full([2, 4], 10)],
         np.array([[10, 11, 12, 13], [14, 15, 16, 17]]),
         id="arbitrary_arbitrary_to_arbitrary",
     ),
@@ -54,7 +54,7 @@ func @{func_name}(%arga: tensor<2x4x{mlir_type}>, %argb: tensor<2x4x{mlir_type}>
  return %answer : tensor<2x4x{mlir_type}>
 }}
 """,
-        [np.arange(2 * 4).reshape((2, 4)), np.full([2, 4], 10),],
+        [np.arange(2 * 4).reshape((2, 4)), np.full([2, 4], 10)],
         np.array([[10, 11, 12, 13], [14, 15, 16, 17]]),
         id="fixed_fixed_to_fixed",
     ),
@@ -80,7 +80,7 @@ func @{func_name}(%arga: tensor<?x?x{mlir_type}>, %argb: tensor<2x4x{mlir_type}>
  return %answer : tensor<?x?x{mlir_type}>
 }}
 """,
-        [np.arange(2 * 4).reshape((2, 4)), np.full([2, 4], 10),],
+        [np.arange(2 * 4).reshape((2, 4)), np.full([2, 4], 10)],
         np.array([[10, 11, 12, 13], [14, 15, 16, 17]]),
         id="arbitrary_fixed_to_arbitrary",
     ),
@@ -172,7 +172,7 @@ func @{func_name}(%arg0: tensor<?x{mlir_type}>, %arg1: tensor<?x{mlir_type}>) ->
   return %ans : {mlir_type}
 }}
 """,
-        [np.arange(8), np.arange(5),],
+        [np.arange(8), np.arange(5)],
         7,
         id="arbitrary_arbitrary_to_scalar",
     ),
@@ -188,7 +188,7 @@ func @{func_name}(%scalar: {mlir_type}, %arg0: tensor<?x{mlir_type}>, %arg1: ten
   return %ans : {mlir_type}
 }}
 """,
-        [2, np.arange(8), np.arange(5),],
+        [2, np.arange(8), np.arange(5)],
         9,
         id="scalar_arbitrary_arbitrary_to_scalar",
     ),
@@ -207,7 +207,7 @@ func @{func_name}(%scalar: {mlir_type}, %arg0: tensor<?x!mlir_type_alias>, %arg1
   return %ans : !mlir_type_alias
 }}
 """,
-        [2, np.arange(8), np.arange(5),],
+        [2, np.arange(8), np.arange(5)],
         9,
         id="simple_and_nested_type_aliases",
     ),

--- a/mlir_graphblas/tests/test_jit_engine_bad_inputs.py
+++ b/mlir_graphblas/tests/test_jit_engine_bad_inputs.py
@@ -121,7 +121,11 @@ BAD_INPUT_TEST_CASES = [  # elements are ( error_type, error_match_string, bad_a
         id="string_for_partially_fixed_size_tensor",
     ),
     pytest.param(
-        TypeError, "cannot be cast to", 4, "bad_input_string", id="string_for_scalar",
+        TypeError,
+        "cannot be cast to",
+        4,
+        "bad_input_string",
+        id="string_for_scalar",
     ),
     pytest.param(
         TypeError,


### PR DESCRIPTION
Style the explorer by calling `debug_results.explore(initial_style={})`

Style options:

- line_numbers: True or False
- highlight_style: name of any valid style
- tab: tab name to show initially
- pass: MLIR pass to show initially on the selected tab
- pass2: same as pass, but for the 2nd code block on the Double tab