### PR TITLE
workaround to be able to hide blocks of MLIR from pymlir

### DIFF
--- a/mlir_graphblas/engine.py
+++ b/mlir_graphblas/engine.py
@@ -292,7 +292,8 @@ def input_type_to_ctypes(mlir_type: mlir.astnodes.Type) -> Tuple[list, Callable]
 
 
 def _resolve_type_aliases(
-    node: Any, type_alias_table: Dict[str, mlir.astnodes.PrettyDialectType],
+    node: Any,
+    type_alias_table: Dict[str, mlir.astnodes.PrettyDialectType],
 ) -> Any:
     if isinstance(node, (mlir.astnodes.Node, mlir.astnodes.Module)):
         for field in node._fields_:


### PR DESCRIPTION
We only need pymlir to be able to parse the function signature of the callable, so this creates a workaround to hide un-parseable blocks of code from pymlir.  Bracket the offending code section in:

```
// pymlir-skip: begin

[can't parse this stuff]

// pymlir-skip: end
```

Note that this is very unforgiving about whitespace and cannot be nested since we find these blocks with a regex.
