### PR TITLE
Initial commit of MLIR function builder

### DIFF
--- a/mlir_graphblas/mlir_builder.py
+++ b/mlir_graphblas/mlir_builder.py
@@ -1,0 +1,139 @@
+"""
+An IR builder for MLIR.
+"""
+
+###########
+# Imports #
+###########
+
+import jinja2
+from collections import OrderedDict
+from .sparse_utils import MLIRSparseTensor
+from .functions import BaseFunction
+from .engine import parse_mlir_string
+
+from typing import Dict, List, Tuple
+
+#############
+# IR Builer #
+#############
+
+
+class MLIRVar:
+
+    """Input variables to be used by MLIRFunctionBuilder."""
+
+    def __init__(self, var_name: str, var_type: str) -> None:
+        """var_type is the type as represented in MLIR code."""
+        self.var_name = var_name
+        self.var_type = var_type
+        return
+
+    @property
+    def var_string(self) -> str:
+        return f"%{self.var_name}"
+
+
+class MLIRFunctionBuilder(BaseFunction):
+
+    # TODO consider making this class have a method to return a BaseFunction and not be a subclass of BaseFunction
+    # In other words, make it a "builder" that creates BaseFunction subclasses or instances instead of being a BaseFunction itself
+
+    function_wrapper_text = jinja2.Template(
+        """
+      func {% if private_func %}private{% endif %}@{{func_name}}({{signature}}) -> {{return_type}} {
+        {{statements}}
+      }
+"""
+    )  # TODO make this hard-coded indentation not hard-coded
+
+    def __init__(
+        self, func_name: str, *input_variables: MLIRVar, return_type: str
+    ) -> None:
+        # TODO mlir functions can return zero or more results https://mlir.llvm.org/docs/LangRef/#operations
+        # handle the cases where the number of return types is not 1
+        self.func_name = func_name
+        self.input_variables = input_variables
+        self.return_type = return_type
+
+        self.var_name_counter = 0
+        self.function_body_statements: List[str] = []
+
+        # function_name -> (function_mlir_definition, input_mlir_types, return_mlir_type)
+        self.needed_function_table: Dict[
+            str, Tuple[str, List[str], str]
+        ] = OrderedDict()
+
+        return
+
+    def get_mlir(self, make_private=True) -> str:
+        joined_statements = "\n".join(self.function_body_statements)
+        signature = ", ".join(
+            f"{var.var_string}: {var.var_type}" for var in self.input_variables
+        )
+        needed_function_definitions = "\n\n".join(
+            func_def for func_def, _, _ in self.needed_function_table.values()
+        )
+        return needed_function_definitions + self.function_wrapper_text.render(
+            private_func=make_private,
+            func_name=self.func_name,
+            signature=signature,
+            return_type=self.return_type,
+            statements=joined_statements,
+        )
+
+    def return_var(self, returned_value: MLIRVar) -> None:
+        if self.return_type != returned_value.var_type:
+            raise TypeError(
+                f"Type of {returned_value} does not match function return type of {self.return_type}."
+            )
+        returned_value_string = (
+            returned_value.var_string
+            if isinstance(returned_value, MLIRVar)
+            else str(returned_value)
+        )
+        statement = f"return {returned_value_string} : {self.return_type}"
+        self.function_body_statements.append(statement)
+        return
+
+    def call(
+        self,
+        function: BaseFunction,
+        *inputs: MLIRVar,
+    ) -> MLIRVar:
+
+        if function.func_name in self.needed_function_table:
+            function_mlir_text, input_types, return_type = self.needed_function_table[
+                function.func_name
+            ]
+            assert function.get_mlir(make_private=True) == function_mlir_text
+        else:
+            function_mlir_text = function.get_mlir(make_private=True)
+            (function_ast,) = parse_mlir_string(function_mlir_text).body
+            input_types = [arg.type.dump() for arg in function_ast.args]
+            return_type = function_ast.result_types.dump()
+            self.needed_function_table[function.func_name] = (
+                function_mlir_text,
+                input_types,
+                return_type,
+            )
+
+        result_var = MLIRVar(f"var_{self.var_name_counter}", return_type)
+        self.var_name_counter += 1
+        statement = "".join(
+            [
+                f"{result_var.var_string} = call @{function.func_name}(",
+                ", ".join(
+                    f"{input_val.var_string}"
+                    if isinstance(input_val, MLIRVar)
+                    else str(input_val)
+                    for input_val in inputs
+                ),
+                ") : (",
+                ", ".join(input_types),
+                ") -> ",
+                return_type,
+            ]
+        )
+        self.function_body_statements.append(statement)
+        return result_var

--- a/mlir_graphblas/tests/test_mlir_builder.py
+++ b/mlir_graphblas/tests/test_mlir_builder.py
@@ -1,0 +1,273 @@
+import mlir
+import pytest
+import numpy as np
+
+from mlir_graphblas import MlirJitEngine
+from mlir_graphblas.engine import parse_mlir_string
+from mlir_graphblas.sparse_utils import MLIRSparseTensor
+from mlir_graphblas.mlir_builder import MLIRVar, MLIRFunctionBuilder
+from mlir_graphblas.functions import (
+    Transpose,
+    MatrixSelect,
+    MatrixReduceToScalar,
+    MatrixMultiply,
+    create_empty_matrix,
+)
+
+from typing import List
+
+
+@pytest.fixture(scope="module")
+def engine():
+    jit_engine = MlirJitEngine()
+
+    jit_engine.add(
+        """
+#trait_densify = {
+  indexing_maps = [
+    affine_map<(i,j) -> (i,j)>,
+    affine_map<(i,j) -> (i,j)>
+  ],
+  iterator_types = ["parallel", "parallel"],
+  sparse = [
+    [ "D", "S" ],
+    [ "D", "D" ]
+  ],
+  sparse_dim_map = [
+    affine_map<(i,j) -> (j,i)>,
+    affine_map<(i,j) -> (i,j)>
+  ]
+}
+
+!SparseTensor = type !llvm.ptr<i8>
+
+func @densify(%argA: !SparseTensor) -> tensor<8x8xf64> {
+  %output_storage = constant dense<0.0> : tensor<8x8xf64>
+  %arga = linalg.sparse_tensor %argA : !SparseTensor to tensor<8x8xf64>
+  %0 = linalg.generic #trait_densify
+    ins(%arga: tensor<8x8xf64>)
+    outs(%output_storage: tensor<8x8xf64>) {
+      ^bb(%A: f64, %x: f64):
+        linalg.yield %A : f64
+    } -> tensor<8x8xf64>
+  return %0 : tensor<8x8xf64>
+}
+""",
+        [
+            "--test-sparsification=lower",
+            "--linalg-bufferize",
+            "--convert-scf-to-std",
+            "--func-bufferize",
+            "--tensor-bufferize",
+            "--tensor-constant-bufferize",
+            "--finalizing-bufferize",
+            "--convert-linalg-to-loops",
+            "--convert-scf-to-std",
+            "--convert-std-to-llvm",
+        ],
+    )
+    return jit_engine
+
+
+def test_ir_builder_transpose_wrapper(engine: MlirJitEngine):
+    # Build Function
+    transpose_function = Transpose()
+
+    input_var = MLIRVar("input_tensor", "!llvm.ptr<i8>")
+    output_var = MLIRVar("output_tensor", "!llvm.ptr<i8>")
+
+    ir_builder = MLIRFunctionBuilder(
+        "transpose_wrapper", output_var, input_var, return_type="index"
+    )
+    transpose_result = ir_builder.call(transpose_function, output_var, input_var)
+    ir_builder.return_var(transpose_result)
+
+    assert ir_builder.get_mlir()
+
+    # Test Compiled Function
+    transpose_wrapper_callable = ir_builder.compile(engine=engine)
+
+    indices = np.array(
+        [
+            [1, 2],
+            [4, 3],
+        ],
+        dtype=np.uint64,
+    )
+    values = np.array([1.2, 4.3], dtype=np.float64)
+    sizes = np.array([8, 8], dtype=np.uint64)
+    sparsity = np.array([False, True], dtype=np.bool8)
+
+    input_tensor = MLIRSparseTensor(indices, values, sizes, sparsity)
+    output_tensor = create_empty_matrix(
+        *input_tensor.shape, nnz=input_tensor.pointers[1][-1]
+    )
+
+    dense_input_tensor = np.zeros([8, 8], dtype=np.float64)
+    dense_input_tensor[1, 2] = 1.2
+    dense_input_tensor[4, 3] = 4.3
+    assert np.isclose(dense_input_tensor, engine.densify(input_tensor)).all()
+
+    assert 0 == transpose_wrapper_callable(output_tensor, input_tensor)
+
+    assert np.isclose(
+        dense_input_tensor, engine.densify(input_tensor)
+    ).all(), f"{input_tensor} values unexpectedly changed."
+    assert np.isclose(dense_input_tensor.T, engine.densify(output_tensor)).all()
+
+    return
+
+
+def test_ir_builder_double_transpose(engine: MlirJitEngine):
+    # Build Function
+
+    input_var = MLIRVar("input_tensor", "!llvm.ptr<i8>")
+    scratch_var = MLIRVar(
+        "transposed_tensor", "!llvm.ptr<i8>"
+    )  # for throw away intermediate values
+
+    ir_builder = MLIRFunctionBuilder(
+        "in_place_double_transpose", scratch_var, input_var, return_type="index"
+    )
+    # Use different instances of Tranpose to ideally get exactly one transpose helper in the final MLIR text
+    _ = ir_builder.call(Transpose(), scratch_var, input_var)
+    dummy_return_var = ir_builder.call(Transpose(), input_var, scratch_var)
+    ir_builder.return_var(dummy_return_var)
+
+    mlir_text = ir_builder.get_mlir(make_private=False)
+    ast = parse_mlir_string(mlir_text)
+    # verify there are exactly two functions
+    private_func, public_func = [
+        node for node in ast.body if isinstance(node, mlir.astnodes.Function)
+    ]
+    assert private_func.name.value == "transpose"
+    assert private_func.visibility == "private"
+    assert public_func.name.value == "in_place_double_transpose"
+    assert public_func.visibility == "public"
+
+    # verify in_place_double_transpose has two transpose calls
+    region = public_func.body
+    (block,) = region.body
+    call_op_1, call_op_2, return_op = block.body
+    assert call_op_1.op.func.value == call_op_2.op.func.value == "transpose"
+    (return_op_type,) = [
+        t for t in mlir.dialects.standard.ops if t.__name__ == "ReturnOperation"
+    ]
+    assert isinstance(return_op.op, return_op_type)
+
+    # Test Compiled Function
+    in_place_double_transpose_callable = ir_builder.compile(engine=engine)
+
+    indices = np.array(
+        [
+            [1, 2],
+            [4, 3],
+        ],
+        dtype=np.uint64,
+    )
+    values = np.array([1.2, 4.3], dtype=np.float64)
+    sizes = np.array([8, 8], dtype=np.uint64)
+    sparsity = np.array([False, True], dtype=np.bool8)
+
+    input_tensor = MLIRSparseTensor(indices, values, sizes, sparsity)
+    transposed_tensor = create_empty_matrix(
+        *input_tensor.shape, nnz=input_tensor.pointers[1][-1]
+    )
+
+    dense_input_tensor = np.zeros([8, 8], dtype=np.float64)
+    dense_input_tensor[1, 2] = 1.2
+    dense_input_tensor[4, 3] = 4.3
+    assert np.isclose(dense_input_tensor, engine.densify(input_tensor)).all()
+
+    assert 0 == in_place_double_transpose_callable(transposed_tensor, input_tensor)
+
+    assert np.isclose(
+        dense_input_tensor, engine.densify(input_tensor)
+    ).all(), f"{input_tensor} values unexpectedly changed."
+    assert np.isclose(dense_input_tensor.T, engine.densify(transposed_tensor)).all()
+
+    return
+
+
+def test_ir_builder_triangle_count(engine: MlirJitEngine):
+    # Build Function
+    transpose_function = Transpose()
+    matrix_select_triu_function = MatrixSelect("TRIU")
+    matrix_select_tril_function = MatrixSelect("TRIL")
+    matrix_reduce_function = MatrixReduceToScalar()
+    mxm_plus_pair_function = MatrixMultiply("plus_pair", mask=True)
+
+    A_var = MLIRVar("A", "!llvm.ptr<i8>")
+    U_var = MLIRVar("U", "!llvm.ptr<i8>")
+    L_var = MLIRVar("L", "!llvm.ptr<i8>")
+    UT_var = MLIRVar("UT", "!llvm.ptr<i8>")
+    C_var = MLIRVar("C", "!llvm.ptr<i8>")
+
+    ir_builder = MLIRFunctionBuilder(
+        "triangle_count", A_var, L_var, U_var, UT_var, C_var, return_type="f64"
+    )
+    ir_builder.call(matrix_select_triu_function, U_var, A_var)
+    ir_builder.call(matrix_select_tril_function, L_var, A_var)
+    ir_builder.call(transpose_function, UT_var, U_var)
+    ir_builder.call(mxm_plus_pair_function, C_var, L_var, UT_var, L_var)
+    reduce_result = ir_builder.call(matrix_reduce_function, C_var)
+    ir_builder.return_var(reduce_result)
+
+    assert ir_builder.get_mlir()
+
+    # Test Compiled Function
+    triangle_count_internal = ir_builder.compile(engine=engine)
+
+    def triangle_count(A: MLIRSparseTensor) -> int:
+        U = create_empty_matrix(*A.shape, nnz=A.pointers[1][-1])
+        L = create_empty_matrix(*A.shape, nnz=A.pointers[1][-1])
+        UT = create_empty_matrix(*U.shape, nnz=U.pointers[1][-1])
+        C = create_empty_matrix(*A.shape, nnz=L.pointers[1][-1])
+        answer = triangle_count_internal(A, U, L, UT, C)
+        answer = int(answer)
+        return answer
+
+    # 0 - 1    5 - 6
+    # | X |    | /
+    # 3 - 4 -- 2 - 7
+    # fmt: off
+    indices = np.array(
+        [
+            [0, 1],
+            [0, 3],
+            [0, 4],
+            [1, 0],
+            [1, 3],
+            [1, 4],
+            [2, 4],
+            [2, 5],
+            [2, 6],
+            [2, 7],
+            [3, 0],
+            [3, 1],
+            [3, 4],
+            [4, 0],
+            [4, 1],
+            [4, 2],
+            [4, 3],
+            [5, 2],
+            [5, 6],
+            [6, 2],
+            [6, 5],
+            [7, 2],
+        ],
+        dtype=np.uint64,
+    )
+    values = np.array([
+        100, 200, 300, 100, 400, 500, 99, 50, 55, 75, 200,
+        400, 600, 300, 500, 99, 600, 50, 60, 55, 60, 75],
+        dtype=np.float64,
+    )
+    # fmt: on
+    sizes = np.array([8, 8], dtype=np.uint64)
+    sparsity = np.array([False, True], dtype=np.bool8)
+    input_tensor = MLIRSparseTensor(indices, values, sizes, sparsity)
+
+    assert 5 == triangle_count(input_tensor)
+
+    return


### PR DESCRIPTION
This is the initial implementation of the IR builder. 

Here's how we can implement triangle counting:
```
    # Grab functions used by triangle count
    transpose_function = Transpose()
    matrix_select_triu_function = MatrixSelect("TRIU")
    matrix_select_tril_function = MatrixSelect("TRIL")
    matrix_reduce_function = MatrixReduceToScalar()
    mxm_plus_pair_function = MatrixMultiply("plus_pair", mask=True)

    # Inputs to triangle count (includes sparse tensors to store intermediate values)
    A_var = MLIRBuilderVar("A", "!llvm.ptr<i8>")
    U_var = MLIRBuilderVar("U", "!llvm.ptr<i8>")
    L_var = MLIRBuilderVar("L", "!llvm.ptr<i8>")
    UT_var = MLIRBuilderVar("UT", "!llvm.ptr<i8>")
    C_var = MLIRBuilderVar("C", "!llvm.ptr<i8>")

    # Initialize the IR builder with the input variables and return type 
    # (zero or multiple return types are WIP)
    ir_builder = MLIRFunctionBuilder("triangle_count", A_var, L_var, U_var, UT_var, C_var, return_type="f64")

    # Call the functions / implement triangle count
    ir_builder.add_function_call(matrix_select_triu_function, U_var, A_var)
    ir_builder.add_function_call(matrix_select_tril_function, L_var, A_var)
    ir_builder.add_function_call(transpose_function, UT_var, U_var)
    ir_builder.add_function_call(mxm_plus_pair_function, C_var, L_var, UT_var, L_var)
    reduce_result = ir_builder.add_function_call(matrix_reduce_function, C_var)

    # Return the answer
    ir_builder.add_return_statement(reduce_result)

    # Tell the IR builder to compile for us a Python callable
    triangle_count_internal = ir_builder.compile(engine=engine)

    # A wrapper function (needed to allocate sparse tensors for intermediate values)
    def triangle_count(A: MLIRSparseTensor) -> int:
        U = create_empty_matrix(*A.shape, nnz=A.pointers[1][-1])
        L = create_empty_matrix(*A.shape, nnz=A.pointers[1][-1])
        UT = create_empty_matrix(*U.shape, nnz=U.pointers[1][-1])
        C = create_empty_matrix(*A.shape, nnz=L.pointers[1][-1])
        answer = triangle_count_internal(A, U, L, UT, C)
        answer = int(answer)
        return answer
```

There are tests in `mlir-graphblas/mlir_graphblas/tests/test_mlir_builder.py` that demonstrate how to use the IR builder. 

This PR also refactors `engine.py` (intended to be a no-op).