### PR TITLE
IR Builder Improvements, e.g. support for scf.for, and JIT Engine Improvements, e.g. support for !llvm.ptr

### DIFF
--- a/mlir_graphblas/engine.py
+++ b/mlir_graphblas/engine.py
@@ -152,6 +152,7 @@ def return_tensor_to_ctypes(
 
     return CtypesType, decoder
 
+
 def return_llvm_pointer_to_ctypes(
     mlir_type: _DIALECT_TYPES["llvm"]["LLVMPtr"],
 ) -> Tuple[type, Callable]:
@@ -162,7 +163,7 @@ def return_llvm_pointer_to_ctypes(
         type_string = mlir_type.type.dump()
         ctypes_type = LLVM_DIALECT_TYPE_STRING_TO_CTYPES_POINTER_TYPE[type_string]
 
-        def decoder(arg):
+        def decoder(arg) -> int:
             # TODO we blindly assume that an i8 pointer points to a sparse tensor
             # since MLIR's sparse tensor support is currently up-in-the-air and this
             # is how they currently handle sparse tensors
@@ -171,13 +172,14 @@ def return_llvm_pointer_to_ctypes(
             # To create the MLIRSparseTensor, use MLIRSparseTensor.from_raw_pointer(),
             # which we can't do here because we are missing dtype information.
             return ctypes.cast(arg, ctypes.c_void_p).value
-        
+
     else:
         raise NotImplementedError(
             f"Converting {mlir_type} to ctypes not yet supported."
         )
-        
+
     return ctypes_type, decoder
+
 
 def return_llvm_type_to_ctypes(mlir_type: mlir.astnodes.Type) -> Tuple[type, Callable]:
     if isinstance(mlir_type, _DIALECT_TYPES["llvm"]["LLVMPtr"]):
@@ -191,6 +193,7 @@ def return_llvm_type_to_ctypes(mlir_type: mlir.astnodes.Type) -> Tuple[type, Cal
             f"Converting {mlir_type} to ctypes not yet supported."
         )
     return result
+
 
 def return_scalar_to_ctypes(mlir_type: mlir.astnodes.Type) -> Tuple[type, Callable]:
     np_type, ctypes_type = convert_mlir_atomic_type(mlir_type)
@@ -206,7 +209,7 @@ def return_scalar_to_ctypes(mlir_type: mlir.astnodes.Type) -> Tuple[type, Callab
 
 
 def return_type_to_ctypes(mlir_type: mlir.astnodes.Type) -> Tuple[type, Callable]:
-    """Returns a single ctypes type for a single given MLIR type."""
+    """Returns a single ctypes type for a single given MLIR type as well as a decoder."""
     # TODO handle all other child classes of mlir.astnodes.Type
     # TODO consider inlining this if it only has 2 cases
 
@@ -277,6 +280,7 @@ def input_pretty_dialect_type_to_ctypes(
 ) -> Tuple[list, Callable]:
     # Pretty dialect types must be special-cased since they're arbitrarily structured.
     raise NotImplementedError(f"Converting {pretty_type} to ctypes not yet supported.")
+
 
 def input_tensor_to_ctypes(
     tensor_type: mlir.astnodes.RankedTensorType,

--- a/mlir_graphblas/engine.py
+++ b/mlir_graphblas/engine.py
@@ -12,6 +12,14 @@ from functools import reduce
 from .cli import MlirOptCli, MlirOptError
 from typing import Tuple, List, Dict, Callable, Union, Any
 
+# TODO we need O(1) access to the types of each dialect ; make this part of PyMLIR
+_DIALECT_TYPES = {
+    dialect.name: {
+        dialect_type.__name__: dialect_type for dialect_type in dialect.types
+    }
+    for dialect in mlir.dialects.STANDARD_DIALECTS
+}
+
 _CURRENT_MODULE_DIR = os.path.dirname(__file__)
 _SPARSE_UTILS_SO_FILE_PATTERN = os.path.join(_CURRENT_MODULE_DIR, "SparseUtils*.so")
 _SPARSE_UTILS_SO_FILES = glob.glob(_SPARSE_UTILS_SO_FILE_PATTERN)
@@ -105,22 +113,8 @@ def convert_mlir_atomic_type(
 def return_pretty_dialect_type_to_ctypes(
     pretty_type: mlir.astnodes.PrettyDialectType,
 ) -> Tuple[type, Callable]:
-    # TODO do pretty dialect types vary widely in how their ASTs are structured?
-    # i.e. are we required to special case them all like we're doing here?
-    if (
-        pretty_type.dialect == "llvm"
-        and pretty_type.type == "ptr"
-        and pretty_type.body == ["i8"]
-    ):
-        # TODO handle this MLIRSparseTensor case
-        raise NotImplementedError(
-            f"Converting {mlir_type} to ctypes not yet supported."
-        )
-    else:
-        raise NotImplementedError(
-            f"Converting {mlir_type} to ctypes not yet supported."
-        )
-    return CtypesType, decoder
+    # Pretty dialect types must be special-cased since they're arbitrarily structured.
+    raise NotImplementedError(f"Converting {mlir_type} to ctypes not yet supported.")
 
 
 def return_tensor_to_ctypes(
@@ -173,7 +167,7 @@ def return_scalar_to_ctypes(mlir_type: mlir.astnodes.Type) -> Tuple[type, Callab
 
 
 def return_type_to_ctypes(mlir_type: mlir.astnodes.Type) -> Tuple[type, Callable]:
-    """Returns a ctypes type for the given MLIR type."""
+    """Returns a single ctypes type for a single given MLIR type."""
     # TODO handle all other child classes of mlir.astnodes.Type
     # TODO consider inlining this if it only has 2 cases
 
@@ -185,6 +179,42 @@ def return_type_to_ctypes(mlir_type: mlir.astnodes.Type) -> Tuple[type, Callable
         result = return_scalar_to_ctypes(mlir_type)
 
     return result
+
+
+def mlir_function_return_decoder(
+    mlir_function: mlir.astnodes.Function,
+) -> Tuple[type, Callable]:
+    mlir_types = mlir_function.result_types
+
+    if not isinstance(mlir_types, list):
+        ctypes_type, decoder = return_type_to_ctypes(mlir_types)
+    elif len(mlir_types) == 0:
+        ctypes_type = ctypes.c_char  # arbitrary dummy type
+        decoder = lambda *args: None
+    else:
+        ctypes_return_types, element_decoders = zip(
+            *map(return_type_to_ctypes, mlir_types)
+        )
+        field_names = [f"result_{i}" for i in range(len(ctypes_return_types))]
+
+        class ctypes_type(ctypes.Structure):
+            _fields_ = [
+                (field_name, return_type)
+                for field_name, return_type in zip(field_names, ctypes_return_types)
+            ]
+
+        def decoder(encoded_result: ctypes_type) -> tuple:
+            encoded_elements = (
+                getattr(encoded_result, field_name) for field_name in field_names
+            )
+            return tuple(
+                element_decoder(encoded_element)
+                for element_decoder, encoded_element in zip(
+                    element_decoders, encoded_elements
+                )
+            )
+
+    return ctypes_type, decoder
 
 
 ###########################
@@ -201,37 +231,8 @@ LLVM_DIALECT_TYPE_STRING_TO_CTYPES_POINTER_TYPE: Dict[str, "_ctypes._CData"] = {
 def input_pretty_dialect_type_to_ctypes(
     pretty_type: mlir.astnodes.PrettyDialectType,
 ) -> Tuple[list, Callable]:
-    # TODO do pretty dialect types vary widely in how their ASTs are structured?
-    # i.e. are we required to special case them all like we're doing here?
-    if (
-        pretty_type.dialect == "llvm"
-        and pretty_type.type == "ptr"
-        and pretty_type.body == ["i8"]
-    ):
-        (type_string,) = pretty_type.body
-        ctypes_type = LLVM_DIALECT_TYPE_STRING_TO_CTYPES_POINTER_TYPE[type_string]
-        ctypes_input_types = [ctypes_type]
-
-        def encoder(arg: MLIRSparseTensor) -> list:
-            # TODO we blindly assume that an i8 pointer points to a sparse tensor
-            # since MLIR's sparse tensor support is currently up-in-the-air and this
-            # is how they currently handle sparse tensors
-
-            # protocol for indicating an object can be interpreted as a MLIRSparseTensor
-            if hasattr(arg, "__mlir_sparse__"):
-                arg = arg.__mlir_sparse__
-
-            if not isinstance(arg, MLIRSparseTensor):
-                raise TypeError(
-                    f"{repr(arg)} is expected to be an instance of {MLIRSparseTensor.__qualname__}"
-                )
-            return [ctypes.cast(arg.data, ctypes_type)]
-
-    else:
-        raise NotImplementedError(
-            f"Converting {mlir_type} to ctypes not yet supported."
-        )
-    return ctypes_input_types, encoder
+    # Pretty dialect types must be special-cased since they're arbitrarily structured.
+    raise NotImplementedError(f"Converting {pretty_type} to ctypes not yet supported.")
 
 
 def input_tensor_to_ctypes(
@@ -284,6 +285,68 @@ def input_tensor_to_ctypes(
     return input_c_types, encoder
 
 
+def input_llvm_pointer_to_ctypes(
+    mlir_type: _DIALECT_TYPES["llvm"]["LLVMPtr"],
+) -> Tuple[list, Callable]:
+    if (
+        isinstance(mlir_type.type, mlir.astnodes.IntegerType)
+        and int(mlir_type.type.width) == 8
+    ):
+        # TODO we blindly assume that an i8 pointer points to a sparse tensor
+        # since MLIR's sparse tensor support is currently up-in-the-air and this
+        # is how they currently handle sparse tensors
+        type_string = mlir_type.type.dump()
+        ctypes_type = LLVM_DIALECT_TYPE_STRING_TO_CTYPES_POINTER_TYPE[type_string]
+        ctypes_input_types = [ctypes_type]
+
+        def encoder(arg: MLIRSparseTensor) -> list:
+            # protocol for indicating an object can be interpreted as a MLIRSparseTensor
+            if hasattr(arg, "__mlir_sparse__"):
+                arg = arg.__mlir_sparse__
+
+            if not isinstance(arg, MLIRSparseTensor):
+                raise TypeError(
+                    f"{repr(arg)} is expected to be an instance of {MLIRSparseTensor.__qualname__}"
+                )
+            return [ctypes.cast(arg.data, ctypes_type)]
+
+    else:
+        # TODO treat the pointer as an array (intended to represent a Python sequence).
+        element_ctypes_input_types, element_encoder = input_type_to_ctypes(
+            mlir_type.type
+        )
+        # element_ctypes_input_types has exactly one element type since
+        # a pointer type can only point to one type
+        (element_ctypes_input_type,) = element_ctypes_input_types
+        ctypes_input_types = [ctypes.POINTER(element_ctypes_input_type)]
+
+        def encoder(arg: Union[list, tuple]) -> list:
+            if not isinstance(arg, (list, tuple)):
+                raise TypeError(
+                    f"{repr(arg)} is expected to be an instance of {list} or {tuple}."
+                )
+            ArrayType = element_ctypes_input_type * len(arg)
+            encoded_elements = sum(map(element_encoder, arg), [])
+            array = ArrayType(*encoded_elements)
+            return [array]
+
+    return ctypes_input_types, encoder
+
+
+def input_llvm_type_to_ctypes(mlir_type: mlir.astnodes.Type) -> Tuple[list, Callable]:
+    if isinstance(mlir_type, _DIALECT_TYPES["llvm"]["LLVMPtr"]):
+        result = input_llvm_pointer_to_ctypes(mlir_type)
+    elif isinstance(mlir_type, _DIALECT_TYPES["llvm"]["LLVMVec"]):
+        raise NotImplementedError(
+            f"Converting {mlir_type} to ctypes not yet supported."
+        )
+    else:
+        raise NotImplementedError(
+            f"Converting {mlir_type} to ctypes not yet supported."
+        )
+    return result
+
+
 def input_scalar_to_ctypes(mlir_type: mlir.astnodes.Type) -> Tuple[list, Callable]:
     np_type, ctypes_type = convert_mlir_atomic_type(mlir_type)
     ctypes_input_types = [ctypes_type]
@@ -312,9 +375,26 @@ def input_type_to_ctypes(mlir_type: mlir.astnodes.Type) -> Tuple[list, Callable]
         result = input_pretty_dialect_type_to_ctypes(mlir_type)
     elif isinstance(mlir_type, mlir.astnodes.RankedTensorType):
         result = input_tensor_to_ctypes(mlir_type)
+    elif any(
+        isinstance(mlir_type, llvm_type)
+        for llvm_type in _DIALECT_TYPES["llvm"].values()
+    ):
+        result = input_llvm_type_to_ctypes(mlir_type)
     else:
         result = input_scalar_to_ctypes(mlir_type)
     return result
+
+
+def mlir_function_input_encoders(
+    mlir_function: mlir.astnodes.Function,
+) -> Tuple[List[type], List[Callable]]:
+    ctypes_input_types = []
+    encoders: List[Callable] = []
+    for arg in mlir_function.args:
+        arg_ctypes_input_types, encoder = input_type_to_ctypes(arg.type)
+        ctypes_input_types += arg_ctypes_input_types
+        encoders.append(encoder)
+    return ctypes_input_types, encoders
 
 
 ####################
@@ -411,16 +491,8 @@ class MlirJitEngine:
                 f"The address for the function {repr(name)} is the null pointer."
             )
 
-        mlir_result_type = mlir_function.result_types
-        ctypes_return_type, decoder = return_type_to_ctypes(mlir_result_type)
-
-        ctypes_input_types = []
-        encoders: List[Callable] = []
-        for arg in mlir_function.args:
-            arg_ctypes_input_types, encoder = input_type_to_ctypes(arg.type)
-            ctypes_input_types += arg_ctypes_input_types
-            encoders.append(encoder)
-
+        ctypes_return_type, decoder = mlir_function_return_decoder(mlir_function)
+        ctypes_input_types, encoders = mlir_function_input_encoders(mlir_function)
         c_callable = ctypes.CFUNCTYPE(ctypes_return_type, *ctypes_input_types)(
             function_pointer
         )
@@ -431,14 +503,14 @@ class MlirJitEngine:
                     f"{name} expected {len(mlir_function.args)} args but got {len(args)}."
                 )
             encoded_args = (encoder(arg) for arg, encoder in zip(args, encoders))
-            encoded_args = reduce(operator.add, encoded_args)
+            encoded_args = sum(encoded_args, [])
             encoded_result = c_callable(*encoded_args)
             result = decoder(encoded_result)
 
             return result
 
         # python_callable only tracks the function pointer, not the
-        # function itself. If self._engine, gets garbage deallocated,
+        # function itself. If self._engine, gets garbage collected,
         # we get a seg fault. Thus, we must keep the engine alive.
         setattr(python_callable, "jit_engine", self)
 

--- a/mlir_graphblas/mlir_builder.py
+++ b/mlir_graphblas/mlir_builder.py
@@ -7,37 +7,44 @@ An IR builder for MLIR.
 ###########
 
 import jinja2
-import regex
 import mlir
 from contextlib import contextmanager
-from collections import OrderedDict, namedtuple
+from collections import OrderedDict
 from .sparse_utils import MLIRSparseTensor
 from .functions import BaseFunction
 from .engine import parse_mlir_string
 
-from typing import Dict, List, Tuple, Sequence, Generator, Optional, Union, Iterable
+from typing import Dict, List, Tuple, Sequence, Generator, Optional, Union
 
 #############
 # IR Builer #
 #############
 
+
 def _canonicalize_mlir_type_string(type_string: str) -> str:
-    '''Canonicalize by round-tripping through PyMLIR.'''
-    return mlir.parse_string(f'!dummy_alias = type {type_string}').body[0].value.dump()
+    """Canonicalize by round-tripping through PyMLIR."""
+    return mlir.parse_string(f"!dummy_alias = type {type_string}").body[0].value.dump()
+
 
 def mlir_type_strings_equal(type_1: str, type_2: str) -> bool:
     # The type strings can vacuously differ (e.g. in white space).
     # Thus, we must deterministically canonicalize the type strings.
     if type_1 == type_2:
         return True
-    if _canonicalize_mlir_type_string(type_1) == _canonicalize_mlir_type_string(type_2):
+    elif _canonicalize_mlir_type_string(type_1) == _canonicalize_mlir_type_string(
+        type_2
+    ):
         return True
     return False
+
 
 class MLIRVar:
 
     """Input variables to be used by MLIRFunctionBuilder."""
-    
+
+    # TODO consider making a separate class for single type MLIR variables
+    # and multi-type MLIR variables.
+
     def __init__(self, var_name: str, *var_types: str) -> None:
         """Elements of var_types are types as represented in MLIR code."""
         assert len(var_types) > 0
@@ -45,10 +52,10 @@ class MLIRVar:
         self.var_types = var_types
         return
 
-    def __eq__(self, other: 'MLIRVar') -> bool:
+    def __eq__(self, other: "MLIRVar") -> bool:
         return (
-            isinstance(other, MLIRVar) 
-            and self.var_name == other.var_name 
+            isinstance(other, MLIRVar)
+            and self.var_name == other.var_name
             and all(
                 mlir_type_strings_equal(*type_pair)
                 for type_pair in zip(self.var_types, other.var_types)
@@ -63,13 +70,15 @@ class MLIRVar:
     def var_type(self) -> str:
         if not len(self.var_types) == 1:
             raise TypeError(f"{self} has multiple types.")
-        var_type, = self.var_types
+        (var_type,) = self.var_types
         return var_type
 
     def __repr__(self) -> str:
-        attributes_string = ', '.join(f'{k}={repr(self.__dict__[k])}' for k in sorted(self.__dict__.keys()))
-        return f'{self.__class__.__name__}({attributes_string})'
-    
+        attributes_string = ", ".join(
+            f"{k}={repr(self.__dict__[k])}" for k in sorted(self.__dict__.keys())
+        )
+        return f"{self.__class__.__name__}({attributes_string})"
+
     def assign_string(self) -> str:
         # TODO specify number of expected returned values as arg and sanity check
         answer = f"%{self.var_name}"
@@ -81,11 +90,15 @@ class MLIRVar:
         answer = f"%{self.var_name}"
         if index is None:
             if self.num_values != 1:
-                raise RuntimeError("Attempting to use variable containing multiple values as a singleton variable.")
+                raise ValueError(
+                    "Attempting to use variable containing multiple values as a singleton variable."
+                )
         elif not isinstance(index, int):
-            raise LookupError(f"{self.__class__} only supports integer indexing.")
-        elif index<0 or self.num_values<=index:
-            raise IndexError(f"Index must be an integer in the range [0, {self.num_values}).")
+            raise TypeError(f"{self.__class__} only supports integer indexing.")
+        elif index < 0 or self.num_values <= index:
+            raise IndexError(
+                f"Index must be an integer in the range [0, {self.num_values})."
+            )
         else:
             answer += f"#{index}"
         return answer
@@ -93,7 +106,9 @@ class MLIRVar:
     def __getitem__(self, index: int) -> Tuple["MLIRVar", int]:
         # Convenience function for use with methods like MLIRFunctionBuilder.return_vars
         if not isinstance(index, int):
-            raise TypeError(f"{self.__class__.__name__} indices must be integers, not {type(index)}.")
+            raise TypeError(
+                f"{self.__class__.__name__} indices must be integers, not {type(index)}."
+            )
         return (self, index)
 
 
@@ -110,12 +125,14 @@ class MLIRFunctionBuilder(BaseFunction):
     default_indentation_size = 6
     indentation_delta_size = 2
     function_wrapper_text = jinja2.Template(
-        "\n"+
-        (" "*default_indentation_size)+"func {% if private_func %}private{% endif %}@{{func_name}}({{signature}}) -> {{return_type}} {"+
-        "\n"+
-        "{{statements}}"+
-        "\n"+
-        (" "*default_indentation_size)+"}"
+        "\n"
+        + (" " * default_indentation_size)
+        + "func {% if private_func %}private{% endif %}@{{func_name}}({{signature}}) -> {{return_type}} {"
+        + "\n"
+        + "{{statements}}"
+        + "\n"
+        + (" " * default_indentation_size)
+        + "}"
     )
 
     def __init__(
@@ -137,27 +154,29 @@ class MLIRFunctionBuilder(BaseFunction):
 
         self.indentation_level = 1
         return
-    
+
     #######################################
     # MLIR Generation/Compilation Methods #
     #######################################
-    
+
     def compile(self, engine=None, passes=None):
         func = super().compile(engine, passes)
 
         indices_of_returned_sparse_tensors = {
-            i for i, return_type in enumerate(self.return_types)
+            i
+            for i, return_type in enumerate(self.return_types)
             if mlir_type_strings_equal(return_type, "!llvm.ptr<i8>")
         }
-        
+
         if len(indices_of_returned_sparse_tensors) != 0:
-            
+
             def func_wrapper(*args, **kwargs):
                 # Find an MLIRSparseTensor in the inputs, then use its dtypes
                 # TODO find a more principled approach
                 try:
                     input_sparse_tensor = next(
-                        x for x in list(args) + list(kwargs.values())
+                        x
+                        for x in list(args) + list(kwargs.values())
                         if isinstance(x, MLIRSparseTensor)
                     )
                 except StopIteration:
@@ -169,22 +188,22 @@ class MLIRFunctionBuilder(BaseFunction):
                 raw_results = func(*args, **kwargs)
                 if len(self.return_types) == 1:
                     raw_results = (raw_results,)
-                    
+
                 dwimmed_results = tuple(
                     MLIRSparseTensor.from_raw_pointer(
                         raw_result,
                         input_sparse_tensor.pointer_dtype,
                         input_sparse_tensor.index_dtype,
-                        input_sparse_tensor.value_dtype
+                        input_sparse_tensor.value_dtype,
                     )
                     if i in indices_of_returned_sparse_tensors
                     else raw_result
                     for i, raw_result in enumerate(raw_results)
                 )
-                
+
                 if len(self.return_types) == 1:
-                    dwimmed_results, = dwimmed_results
-                
+                    (dwimmed_results,) = dwimmed_results
+
                 return dwimmed_results
 
             return func_wrapper
@@ -224,12 +243,13 @@ class MLIRFunctionBuilder(BaseFunction):
         yield
         self.indentation_level -= num_levels
         return
-    
+
     def add_statement(self, statement: str) -> None:
-        for line in map(str.strip, statement.split('\n')):
+        for line in map(str.strip, statement.split("\n")):
             self.function_body_statements.append(
-                " "*self.default_indentation_size+
-                " "*self.indentation_delta_size*self.indentation_level + line
+                " " * self.default_indentation_size
+                + " " * self.indentation_delta_size * self.indentation_level
+                + line
             )
         return
 
@@ -247,47 +267,58 @@ class MLIRFunctionBuilder(BaseFunction):
         var = self.new_var(var_type)
         self.add_statement(f"{var.assign_string()} = constant {var_value} : {var_type}")
         return var
-    
-    def return_vars(self, *returned_values: Union[Tuple[MLIRVar, int], MLIRVar]) -> None:
+
+    def return_vars(
+        self, *returned_values: Union[Tuple[MLIRVar, int], MLIRVar]
+    ) -> None:
+        # TODO instead of accepting Tuple[MLIRVar, int], consider having
+        # MLIRVar.__getitem__ return a new MLIRVar instance with an "index"
+        # attribute (default to None) set the desired index.
         var_index_pairs = []
         for value in returned_values:
             if isinstance(value, MLIRVar):
                 var_index_pair = value, None
-            elif isinstance(value, tuple) and len(value) == 2 and isinstance(value[0], MLIRVar) and isinstance(value[1], int):
+            elif (
+                isinstance(value, tuple)
+                and len(value) == 2
+                and isinstance(value[0], MLIRVar)
+                and isinstance(value[1], int)
+            ):
                 var_index_pair = value
             else:
                 raise TypeError(f"{value} does not denote a valid return value.")
             var_index_pairs.append(var_index_pair)
         if not all(
-                mlir_type_strings_equal(expected, var.var_type if index is None else var.var_types[index])
-                for expected, (var, index) in zip(self.return_types, var_index_pairs)
+            mlir_type_strings_equal(
+                expected, var.var_type if index is None else var.var_types[index]
+            )
+            for expected, (var, index) in zip(self.return_types, var_index_pairs)
         ):
             returned_types = tuple(var.var_type for var, _ in var_index_pairs)
             raise TypeError(
                 f"Types for {returned_types} do not match function "
                 f"return types of {tuple(self.return_types)}."
             )
-        returned_value_string = ", ".join(
+        returned_values_string = ", ".join(
             var.access_string(index) for var, index in var_index_pairs
         )
         returned_types_string = ", ".join(
             return_types for return_types in self.return_types
         )
-        statement = f"return {returned_value_string} : {returned_types_string}"
+        statement = f"return {returned_values_string} : {returned_types_string}"
         self.add_statement(statement)
         return
 
     class ForLoopVars:
-        
         def __init__(
-                self, 
-                iter_var_index: MLIRVar,
-                lower_var_index: MLIRVar,
-                upper_var_index: MLIRVar,
-                step_var_index: MLIRVar,
-                iter_vars: Sequence[MLIRVar],
-                returned_variable: MLIRVar,
-                builder: 'MLIRFunctionBuilder',
+            self,
+            iter_var_index: MLIRVar,
+            lower_var_index: MLIRVar,
+            upper_var_index: MLIRVar,
+            step_var_index: MLIRVar,
+            iter_vars: Sequence[MLIRVar],
+            returned_variable: Optional[MLIRVar],
+            builder: "MLIRFunctionBuilder",
         ) -> None:
             self.iter_var_index = iter_var_index
             self.lower_var_index = lower_var_index
@@ -302,28 +333,38 @@ class MLIRFunctionBuilder(BaseFunction):
             var_strings = []
             var_types = []
             if len(yielded_vars) != len(self.iter_vars):
-                raise ValueError(f"Expected {len(self.iter_vars)} yielded values, but got {len(yielded_vars)}.")
+                raise ValueError(
+                    f"Expected {len(self.iter_vars)} yielded values, but got {len(yielded_vars)}."
+                )
             for var, iter_var in zip(yielded_vars, self.iter_vars):
                 if not mlir_type_strings_equal(var.var_type, iter_var.var_type):
                     raise TypeError(f"{var} and {iter_var} have different types.")
                 var_strings.append(var.access_string())
                 var_types.append(var.var_type)
-            self.builder.add_statement(f"scf.yield {', '.join(var_strings)} : {', '.join(var_types)}")
+            self.builder.add_statement(
+                f"scf.yield {', '.join(var_strings)} : {', '.join(var_types)}"
+            )
             return
-    
+
     @contextmanager
     def for_loop(
-            self,
-            lower: Union[int, MLIRVar],
-            upper: Union[int, MLIRVar],
-            step: Union[int, MLIRVar] = 1,
-            *, 
-            iter_vars: Optional[Sequence[Tuple[MLIRVar, MLIRVar]]] = None,
+        self,
+        lower: Union[int, MLIRVar],
+        upper: Union[int, MLIRVar],
+        step: Union[int, MLIRVar] = 1,
+        *,
+        iter_vars: Optional[Sequence[Tuple[MLIRVar, MLIRVar]]] = None,
     ) -> Generator[ForLoopVars, None, None]:
         iter_var_index = self.new_var("index")
-        lower_var_index = lower if isinstance(lower, MLIRVar) else self.constant(lower, "index")
-        upper_var_index = upper if isinstance(upper, MLIRVar) else self.constant(upper, "index")
-        step_var_index = step if isinstance(step, MLIRVar) else self.constant(step, "index")
+        lower_var_index = (
+            lower if isinstance(lower, MLIRVar) else self.constant(lower, "index")
+        )
+        upper_var_index = (
+            upper if isinstance(upper, MLIRVar) else self.constant(upper, "index")
+        )
+        step_var_index = (
+            step if isinstance(step, MLIRVar) else self.constant(step, "index")
+        )
         for_loop_open_statment = (
             f"scf.for {iter_var_index.assign_string()} = {lower_var_index.access_string()} "
             f"to {upper_var_index.access_string()} step {step_var_index.access_string()}"
@@ -336,17 +377,25 @@ class MLIRFunctionBuilder(BaseFunction):
                 if not mlir_type_strings_equal(iter_var.var_type, init_var.var_type):
                     raise TypeError(f"{iter_var} and {init_var} have different types.")
                 _iter_vars.append(iter_var)
-                iter_var_init_strings.append(f"{iter_var.assign_string()}={init_var.access_string()}")
+                iter_var_init_strings.append(
+                    f"{iter_var.assign_string()}={init_var.access_string()}"
+                )
                 iter_var_types.append(iter_var.var_type)
             for_loop_open_statment += (
-                f" iter_args("+
-                ", ".join(iter_var_init_strings) +
-                ") -> (" +
-                ", ".join(iter_var_types) + 
-                ")"
+                f" iter_args("
+                + ", ".join(iter_var_init_strings)
+                + ") -> ("
+                + ", ".join(iter_var_types)
+                + ")"
             )
-        returned_var = self.new_var(*(var.var_type for var in _iter_vars))
-        for_loop_open_statment = f"{returned_var.assign_string()} = {for_loop_open_statment} {{"
+        for_loop_open_statment += " {"
+        if len(_iter_vars) > 0:
+            returned_var = self.new_var(*(var.var_type for var in _iter_vars))
+            for_loop_open_statment = (
+                f"{returned_var.assign_string()} = {for_loop_open_statment}"
+            )
+        else:
+            returned_var = None
         self.add_statement(for_loop_open_statment)
         with self.more_indentation():
             yield self.ForLoopVars(
@@ -356,11 +405,11 @@ class MLIRFunctionBuilder(BaseFunction):
                 step_var_index,
                 _iter_vars,
                 returned_var,
-                self
+                self,
             )
         self.add_statement("}")
         return
-    
+
     def call(
         self,
         function: BaseFunction,
@@ -380,21 +429,23 @@ class MLIRFunctionBuilder(BaseFunction):
             function_mlir_text = function.get_mlir(make_private=True)
             (function_ast,) = parse_mlir_string(function_mlir_text).body
             input_types = [arg.type.dump() for arg in function_ast.args]
-            return_type = function_ast.result_types.dump()  # TODO handle non-singleton returns here
+            return_type = (
+                function_ast.result_types.dump()
+            )  # TODO handle non-singleton returns here
             self.needed_function_table[function.func_name] = (
                 function_mlir_text,
                 input_types,
                 return_type,  # TODO handle non-singleton returns here
             )
 
-        result_var = self.new_var(return_type) # TODO handle non-singleton returns here
+        result_var = self.new_var(return_type)  # TODO handle non-singleton returns here
         statement = "".join(
             [
-                f"{result_var.assign_string()} = call @{function.func_name}(", # TODO handle non-singleton returns here
+                f"{result_var.assign_string()} = call @{function.func_name}(",  # TODO handle non-singleton returns here
                 ", ".join(
                     f"{input_val.access_string()}"
                     if isinstance(input_val, MLIRVar)
-                    else str(input_val) # TODO add test for this else case
+                    else str(input_val)  # TODO add test for this else case
                     for input_val in inputs
                 ),
                 ") : (",

--- a/mlir_graphblas/tests/jit_engine_test_utils.py
+++ b/mlir_graphblas/tests/jit_engine_test_utils.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 from mlir_graphblas.sparse_utils import MLIRSparseTensor
 
@@ -25,18 +24,23 @@ MLIR_TYPE_TO_NP_TYPE = {
     "f32": np.float32,
     "f64": np.float64,
 }
- 
-def sparsify_array(input_array: np.ndarray, sparsity_values: Sequence[bool]) -> MLIRSparseTensor:
-    '''Converts a numpy array into a MLIRSparseTensor.'''
-    
+
+
+def sparsify_array(
+    input_array: np.ndarray, sparsity_values: Sequence[bool]
+) -> MLIRSparseTensor:
+    """Converts a numpy array into a MLIRSparseTensor."""
+
     indices = np.array(
         list(zip(*input_array.nonzero())),
         dtype=np.uint64,
     )
-    values = np.array([input_array[coordinate] for coordinate in map(tuple, indices)], dtype=input_array.dtype)
+    values = np.array(
+        [input_array[coordinate] for coordinate in map(tuple, indices)],
+        dtype=input_array.dtype,
+    )
     sizes = np.array(input_array.shape, dtype=np.uint64)
     sparsity = np.array(sparsity_values, dtype=np.bool8)
-    
+
     sparse_tensor = MLIRSparseTensor(indices, values, sizes, sparsity)
     return sparse_tensor
- 

--- a/mlir_graphblas/tests/test_jit_engine.py
+++ b/mlir_graphblas/tests/test_jit_engine.py
@@ -1,7 +1,8 @@
 from .jit_engine_test_utils import MLIR_TYPE_TO_NP_TYPE, STANDARD_PASSES
 
+import itertools
 import mlir_graphblas
-import mlir_graphblas.sparse_utils
+from mlir_graphblas.sparse_utils import MLIRSparseTensor
 import pytest
 import numpy as np
 
@@ -319,7 +320,7 @@ func @{func_name}(%argA: !SparseTensor) -> {mlir_type} {{
     sizes = np.array([10, 20, 30], dtype=np.uint64)
     sparsity = np.array([True, True, True], dtype=np.bool8)
 
-    a = mlir_graphblas.sparse_utils.MLIRSparseTensor(indices, values, sizes, sparsity)
+    a = MLIRSparseTensor(indices, values, sizes, sparsity)
 
     assert engine.add(mlir_text, STANDARD_PASSES) == [func_name]
 
@@ -335,6 +336,258 @@ Inputs: {args}
 Result: {result}
 Expected Result: {expected_result}
 """
+
+
+# def test_jit_engine_multiple_return_values(engine):
+#     mlir_text = '''
+# func @func_main() -> (i32, f32) {
+#     %a = constant 99 : i32
+#     %b = constant 12.34 : f32
+#     return %a, %b : i32, f32
+# }
+# '''
+#     assert engine.add(mlir_text, STANDARD_PASSES) == ['func_main']
+#     assert (99, 12.34) == engine.func_main()
+
+#     return
+
+
+def test_jit_engine_sequence_of_sparse_tensor_input(engine):
+    mlir_text = """
+#trait_sum_reduction = {
+  indexing_maps = [
+    affine_map<(i,j) -> (i,j)>,
+    affine_map<(i,j) -> ()>
+  ],
+  sparse = [
+    [ "S", "S" ],
+    [ ]
+  ],
+  iterator_types = ["reduction", "reduction"],
+  doc = "Sparse Tensor Sum"
+}
+
+func @sparse_tensors_summation(%sequence: !llvm.ptr<!llvm.ptr<i8>>, %sequence_length: index) -> f64 {
+  // Take an array of sparse 2x3 matrices
+
+  // pymlir-skip: begin
+
+  %output_storage = constant dense<0.0> : tensor<f64>
+
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %ci0 = constant 0 : i64
+  %ci1 = constant 1 : i64
+  %sum_memref = memref.alloc() : memref<f64>
+
+  scf.for %i = %c0 to %sequence_length step %c1 iter_args(%iter=%ci0) -> (i64) {
+    
+    // llvm.getelementptr just does pointer arithmetic
+    %sparse_tensor_ptr_ptr = llvm.getelementptr %sequence[%iter] : (!llvm.ptr<!llvm.ptr<i8>>, i64) -> !llvm.ptr<!llvm.ptr<i8>>
+    
+    // dereference %sparse_tensor_ptr_ptr to get an !llvm.ptr<i8>
+    %sparse_tensor_ptr = llvm.load %sparse_tensor_ptr_ptr : !llvm.ptr<!llvm.ptr<i8>>
+    
+    %sparse_tensor = linalg.sparse_tensor %sparse_tensor_ptr : !llvm.ptr<i8> to tensor<2x3xf64>
+    
+    %reduction = linalg.generic #trait_sum_reduction
+        ins(%sparse_tensor: tensor<2x3xf64>)
+        outs(%output_storage: tensor<f64>) {
+          ^bb(%a: f64, %x: f64):
+            %0 = addf %x, %a : f64
+            linalg.yield %0 : f64
+      } -> tensor<f64>
+    %reduction_value = tensor.extract %reduction[] : tensor<f64>
+
+    %current_sum = memref.load %sum_memref[] : memref<f64>
+    %updated_sum = addf %reduction_value, %current_sum : f64
+    memref.store %updated_sum, %sum_memref[] : memref<f64>
+
+    %plus_one = addi %iter, %ci1 : i64
+    scf.yield %plus_one : i64
+  }
+
+  %sum = memref.load %sum_memref[] : memref<f64>
+
+  // pymlir-skip: end
+
+  return %sum : f64
+}
+"""
+    assert engine.add(mlir_text, STANDARD_PASSES) == ["sparse_tensors_summation"]
+
+    num_sparse_tensors = 10
+
+    # generate values
+    sqrt_values = np.sqrt(np.arange(1, num_sparse_tensors + 1, 0.5))
+    value_iter = iter(sqrt_values)
+    next_values = lambda: np.array(
+        [next(value_iter), next(value_iter)], dtype=np.float64
+    )
+
+    # generate coordinates
+    coordinate_iter = itertools.cycle(range(2 * 3))
+    next_indices = lambda: np.array(
+        [next(coordinate_iter) for _ in range(4)], dtype=np.uint64
+    ).reshape([2, 2])
+
+    sparse_tensors = []
+    for _ in range(num_sparse_tensors):
+        indices = next_indices()
+        values = next_values()
+        sizes = np.array([2, 3], dtype=np.uint64)
+        sparsity = np.array([True, True], dtype=np.bool8)
+        sparse_tensor = MLIRSparseTensor(indices, values, sizes, sparsity)
+        sparse_tensors.append(sparse_tensor)
+
+    expected_sum = sqrt_values.sum()
+    assert np.isclose(
+        expected_sum,
+        engine.sparse_tensors_summation(sparse_tensors, num_sparse_tensors),
+    )
+
+    return
+
+
+def test_jit_engine_multiple_zero_values(engine):
+    # TODO move this densify helper to the pytest fixture and make it work with any input shape
+    engine.add(
+        """
+#trait_densify = {
+  indexing_maps = [
+    affine_map<(i,j) -> (i,j)>,
+    affine_map<(i,j) -> (i,j)>
+  ],
+  iterator_types = ["parallel", "parallel"],
+  sparse = [
+    [ "D", "S" ],
+    [ "D", "D" ]
+  ],
+  sparse_dim_map = [
+    affine_map<(i,j) -> (j,i)>,
+    affine_map<(i,j) -> (i,j)>
+  ]
+}
+
+!SparseTensor = type !llvm.ptr<i8>
+
+func @densify2x2(%argA: !SparseTensor) -> tensor<2x2xf64> {
+  %output_storage = constant dense<0.0> : tensor<2x2xf64>
+  %arga = linalg.sparse_tensor %argA : !SparseTensor to tensor<2x2xf64>
+  %0 = linalg.generic #trait_densify
+    ins(%arga: tensor<2x2xf64>)
+    outs(%output_storage: tensor<2x2xf64>) {
+      ^bb(%A: f64, %x: f64):
+        linalg.yield %A : f64
+    } -> tensor<2x2xf64>
+  return %0 : tensor<2x2xf64>
+}
+""",
+        STANDARD_PASSES,
+    )
+
+    mlir_text = """
+    module  {
+      func private @sparseValuesF64(!llvm.ptr<i8>) -> memref<?xf64>
+      func private @sparseIndices64(!llvm.ptr<i8>, index) -> memref<?xindex>
+      func private @sparsePointers64(!llvm.ptr<i8>, index) -> memref<?xindex>
+      func private @sparseDimSize(!llvm.ptr<i8>, index) -> index
+
+      func @transpose(%output: !llvm.ptr<i8>, %input: !llvm.ptr<i8>) {
+        %c0 = constant 0 : index
+        %c1 = constant 1 : index
+
+        // pymlir-skip: begin
+
+        %n_row = call @sparseDimSize(%input, %c0) : (!llvm.ptr<i8>, index) -> index
+        %n_col = call @sparseDimSize(%input, %c1) : (!llvm.ptr<i8>, index) -> index
+        %Ap = call @sparsePointers64(%input, %c1) : (!llvm.ptr<i8>, index) -> memref<?xindex>
+        %Aj = call @sparseIndices64(%input, %c1) : (!llvm.ptr<i8>, index) -> memref<?xindex>
+        %Ax = call @sparseValuesF64(%input) : (!llvm.ptr<i8>) -> memref<?xf64>
+        %Bp = call @sparsePointers64(%output, %c1) : (!llvm.ptr<i8>, index) -> memref<?xindex>
+        %Bi = call @sparseIndices64(%output, %c1) : (!llvm.ptr<i8>, index) -> memref<?xindex>
+        %Bx = call @sparseValuesF64(%output) : (!llvm.ptr<i8>) -> memref<?xf64>
+
+        %nnz = memref.load %Ap[%n_row] : memref<?xindex>
+
+        // compute number of non-zero entries per column of A
+        scf.for %arg2 = %c0 to %n_col step %c1 {
+          memref.store %c0, %Bp[%arg2] : memref<?xindex>
+        }
+        scf.for %n = %c0 to %nnz step %c1 {
+          %colA = memref.load %Aj[%n] : memref<?xindex>
+          %colB = memref.load %Bp[%colA] : memref<?xindex>
+          %colB1 = addi %colB, %c1 : index
+          memref.store %colB1, %Bp[%colA] : memref<?xindex>
+        }
+
+        // cumsum the nnz per column to get Bp
+        memref.store %c0, %Bp[%n_col] : memref<?xindex>
+        scf.for %col = %c0 to %n_col step %c1 {
+          %temp = memref.load %Bp[%col] : memref<?xindex>
+          %cumsum = memref.load %Bp[%n_col] : memref<?xindex>
+          memref.store %cumsum, %Bp[%col] : memref<?xindex>
+          %cumsum2 = addi %cumsum, %temp : index
+          memref.store %cumsum2, %Bp[%n_col] : memref<?xindex>
+        }
+
+        scf.for %row = %c0 to %n_row step %c1 {
+          %j_start = memref.load %Ap[%row] : memref<?xindex>
+          %row_plus1 = addi %row, %c1 : index
+          %j_end = memref.load %Ap[%row_plus1] : memref<?xindex>
+          scf.for %jj = %j_start to %j_end step %c1 {
+            %col = memref.load %Aj[%jj] : memref<?xindex>
+            %dest = memref.load %Bp[%col] : memref<?xindex>
+
+            memref.store %row, %Bi[%dest] : memref<?xindex>
+            %axjj = memref.load %Ax[%jj] : memref<?xf64>
+            memref.store %axjj, %Bx[%dest] : memref<?xf64>
+
+            // Bp[col]++
+            %bp_inc = memref.load %Bp[%col] : memref<?xindex>
+            %bp_inc1 = addi %bp_inc, %c1 : index
+            memref.store %bp_inc1, %Bp[%col]: memref<?xindex>
+          }
+        }
+
+        %last_last = memref.load %Bp[%n_col] : memref<?xindex>
+        memref.store %c0, %Bp[%n_col] : memref<?xindex>
+        scf.for %col = %c0 to %n_col step %c1 {
+          %temp = memref.load %Bp[%col] : memref<?xindex>
+          %last = memref.load %Bp[%n_col] : memref<?xindex>
+          memref.store %last, %Bp[%col] : memref<?xindex>
+          memref.store %temp, %Bp[%n_col] : memref<?xindex>
+        }
+        memref.store %last_last, %Bp[%n_col] : memref<?xindex>
+
+        // pymlir-skip: end
+        return
+      }
+    }
+    """
+
+    indices = np.array(
+        [
+            [0, 0],
+            [1, 0],
+        ],
+        dtype=np.uint64,
+    )
+    values = np.array([8, 9], dtype=np.float64)
+    sizes = np.array([2, 2], dtype=np.uint64)
+    sparsity = np.array([False, True], dtype=np.bool8)
+
+    input_tensor = MLIRSparseTensor(indices, values, sizes, sparsity)
+    output_tensor = MLIRSparseTensor(indices, values, sizes, sparsity)
+
+    assert engine.add(mlir_text, STANDARD_PASSES) == ["transpose"]
+    assert engine.transpose(output_tensor, input_tensor) is None
+    assert np.isclose(engine.densify2x2(input_tensor), np.array([[8, 0], [9, 0]])).all()
+    assert np.isclose(
+        engine.densify2x2(output_tensor), np.array([[8, 9], [0, 0]])
+    ).all()
+
+    return
 
 
 def test_jit_engine_skip(engine):

--- a/mlir_graphblas/tests/test_jit_engine_bad_inputs.py
+++ b/mlir_graphblas/tests/test_jit_engine_bad_inputs.py
@@ -46,7 +46,7 @@ func @many_inputs_constant_output(
         np.arange(8, dtype=np.float32).reshape([2, 4]),
         sparse_tensor,
         123.456,
-        (10,20,30),
+        (10, 20, 30),
     ]
 
     assert callable_func(*valid_args) == 1234
@@ -174,37 +174,39 @@ BAD_INPUT_TEST_CASES = [  # elements are ( error_type, error_match_string, bad_a
 ]
 
 for np_type in (
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.longlong,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.ulonglong,
-        np.float16,
-        np.float64,
-        np.float128,
-        np.complex64,
-        np.complex128,
-        np.complex256,
-        np.record,
-        np.bool_,
-        bool,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.longlong,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.ulonglong,
+    np.float16,
+    np.float64,
+    np.float128,
+    np.complex64,
+    np.complex128,
+    np.complex256,
+    np.record,
+    np.bool_,
+    bool,
 ):
     if not issubclass(np_type, (bool, np.record, np.integer)):
         error_match_string = r".*12\.3.* cannot be cast to "
         if np_type is np.bool_:
             error_match_string = r"True is expected to be a scalar with dtype "
-        BAD_INPUT_TEST_CASES.append(pytest.param(
-            TypeError,
-            error_match_string,
-            5,
-            [np_type(12.3)],
-            id=f"{np_type.__name__}_array_for_i64_array",
-        ))
+        BAD_INPUT_TEST_CASES.append(
+            pytest.param(
+                TypeError,
+                error_match_string,
+                5,
+                [np_type(12.3)],
+                id=f"{np_type.__name__}_array_for_i64_array",
+            )
+        )
     BAD_INPUT_TEST_CASES += [
         pytest.param(
             TypeError,

--- a/mlir_graphblas/tests/test_mlir_builder.py
+++ b/mlir_graphblas/tests/test_mlir_builder.py
@@ -8,7 +8,6 @@ from mlir_graphblas import MlirJitEngine
 from mlir_graphblas.engine import parse_mlir_string
 from mlir_graphblas.sparse_utils import MLIRSparseTensor
 from mlir_graphblas.mlir_builder import MLIRVar, MLIRFunctionBuilder
-from mlir_graphblas.algorithms import dense_neural_network
 from mlir_graphblas.functions import (
     Transpose,
     MatrixSelect,
@@ -24,6 +23,7 @@ from typing import List, Callable
 # TODO a lot of these tests take sums or reductions over an scf.for loop by storing into a memref
 # It's better practice to use as demonstrated
 # at https://mlir.llvm.org/docs/Dialects/SCFDialect/#scffor-mlirscfforop
+
 
 @pytest.fixture(scope="module")
 def engine():
@@ -202,13 +202,15 @@ def test_ir_builder_triangle_count(engine: MlirJitEngine):
     mxm_plus_pair_function = MatrixMultiply("plus_pair", mask=True)
 
     A_var = MLIRVar("A", "!llvm.ptr<i8>")
-    
-    ir_builder = MLIRFunctionBuilder("triangle_count", input_vars=[A_var], return_types=["f64"])
+
+    ir_builder = MLIRFunctionBuilder(
+        "triangle_count", input_vars=[A_var], return_types=["f64"]
+    )
     U_var = ir_builder.call(matrix_select_triu_function, A_var)
     L_var = ir_builder.call(matrix_select_tril_function, A_var)
     U_csc = ir_builder.call(csr_to_csc_function, U_var)
     C_var = ir_builder.call(mxm_plus_pair_function, L_var, U_csc, L_var)
-    
+
     reduce_result = ir_builder.call(matrix_reduce_function, C_var)
     ir_builder.return_vars(reduce_result)
 
@@ -266,23 +268,39 @@ def test_ir_builder_triangle_count(engine: MlirJitEngine):
 
     return
 
-def  test_ir_builder_for_loop_simple(engine: MlirJitEngine):
+
+def test_ir_builder_for_loop_simple(engine: MlirJitEngine):
     # Build Function
-    
+
     input_var = MLIRVar("input_value", "f64")
-    
-    ir_builder = MLIRFunctionBuilder("times_three", input_vars=[input_var], return_types=["f64"])
+
+    ir_builder = MLIRFunctionBuilder(
+        "times_three", input_vars=[input_var], return_types=["f64"]
+    )
     zero_f64 = ir_builder.constant(0.0, "f64")
-    ir_builder.add_statement("// pymlir-skip: begin")
-    ir_builder.add_statement("%sum_memref = memref.alloc() : memref<f64>")
-    ir_builder.add_statement(f"memref.store {zero_f64.access_string()}, %sum_memref[] : memref<f64>")
+    ir_builder.add_statement(
+        f"""
+// pymlir-skip: begin
+%sum_memref = memref.alloc() : memref<f64>
+memref.store {zero_f64.access_string()}, %sum_memref[] : memref<f64>
+"""
+    )
     with ir_builder.for_loop(0, 3) as for_vars:
-        ir_builder.add_statement("%current_sum = memref.load %sum_memref[] : memref<f64>")
-        ir_builder.add_statement(f"%updated_sum = addf {input_var.access_string()}, %current_sum : f64")
-        ir_builder.add_statement("memref.store %updated_sum, %sum_memref[] : memref<f64>")
-    ir_builder.add_statement("%sum = memref.load %sum_memref[] : memref<f64>")
+        ir_builder.add_statement(
+            f"""
+%current_sum = memref.load %sum_memref[] : memref<f64>
+%updated_sum = addf {input_var.access_string()}, %current_sum : f64
+memref.store %updated_sum, %sum_memref[] : memref<f64>
+"""
+        )
+    assert for_vars.returned_variable is None
     result_var = MLIRVar("sum", "f64")
-    ir_builder.add_statement("// pymlir-skip: end")
+    ir_builder.add_statement(
+        f"""
+{result_var.assign_string()} = memref.load %sum_memref[] : memref<f64>
+// pymlir-skip: end
+"""
+    )
     ir_builder.return_vars(result_var)
 
     assert ir_builder.get_mlir()
@@ -293,6 +311,7 @@ def  test_ir_builder_for_loop_simple(engine: MlirJitEngine):
 
     return
 
+
 def test_ir_builder_for_loop_float_iter(engine: MlirJitEngine):
     # Build Function
 
@@ -301,50 +320,61 @@ def test_ir_builder_for_loop_float_iter(engine: MlirJitEngine):
     delta_i = 1
     lower_float = 0.0
     delta_float = 7.8
-    
+
     input_var = MLIRVar("input_value", "f64")
-    
-    ir_builder = MLIRFunctionBuilder("plus_6x7_8", input_vars=[input_var], return_types=["f64"])
-    ir_builder.add_statement("// pymlir-skip: begin")
-    ir_builder.add_statement("%sum_memref = memref.alloc() : memref<f64>")
-    ir_builder.add_statement(f"memref.store {input_var.access_string()}, %sum_memref[] : memref<f64>")
+
+    ir_builder = MLIRFunctionBuilder(
+        "plus_6x7_8", input_vars=[input_var], return_types=["f64"]
+    )
+    ir_builder.add_statement(
+        f"""
+// pymlir-skip: begin
+%sum_memref = memref.alloc() : memref<f64>
+memref.store {input_var.access_string()}, %sum_memref[] : memref<f64>
+"""
+    )
 
     float_lower_var = ir_builder.constant(lower_float, "f64")
     float_iter_var = MLIRVar("float_iter", "f64")
     float_delta_var = ir_builder.constant(delta_float, "f64")
     with ir_builder.for_loop(
-            lower_i,
-            upper_i,
-            delta_i,
-            iter_vars=[(float_iter_var, float_lower_var)]
+        lower_i, upper_i, delta_i, iter_vars=[(float_iter_var, float_lower_var)]
     ) as for_vars:
         assert [float_iter_var] == for_vars.iter_vars
-        ir_builder.add_statement("%current_sum = memref.load %sum_memref[] : memref<f64>")
-        ir_builder.add_statement(f"%updated_sum = addf {float_iter_var.access_string()}, %current_sum : f64")
-        ir_builder.add_statement("memref.store %updated_sum, %sum_memref[] : memref<f64>")
-        # increment float_iter_var
         incremented_float_var = MLIRVar("incremented_float", "f64")
-        ir_builder.add_statement(f"{incremented_float_var.assign_string()} = addf {float_iter_var.access_string()}, {float_delta_var.access_string()} : f64")
+        ir_builder.add_statement(
+            f"""
+%current_sum = memref.load %sum_memref[] : memref<f64>
+%updated_sum = addf {float_iter_var.access_string()}, %current_sum : f64
+memref.store %updated_sum, %sum_memref[] : memref<f64>
+{incremented_float_var.assign_string()} = addf {float_iter_var.access_string()}, {float_delta_var.access_string()} : f64
+"""
+        )
         for_vars.yield_vars(incremented_float_var)
-    ir_builder.add_statement("%sum = memref.load %sum_memref[] : memref<f64>")
     result_var = MLIRVar("sum", "f64")
-    ir_builder.add_statement("// pymlir-skip: end")
+    ir_builder.add_statement(
+        f"""
+{result_var.assign_string()} = memref.load %sum_memref[] : memref<f64>
+// pymlir-skip: end
+"""
+    )
     ir_builder.return_vars(result_var)
 
     assert ir_builder.get_mlir()
 
     # Test Compiled Function
     func = ir_builder.compile(engine=engine)
-    expected_sum = 1.3+sum(range(lower_i, upper_i, delta_i))*delta_float
+    expected_sum = 1.3 + sum(range(lower_i, upper_i, delta_i)) * delta_float
     assert np.isclose(func(1.3), expected_sum)
 
     return
 
+
 def test_ir_builder_for_loop_user_specified_vars(engine: MlirJitEngine):
     # Build Function
-    
+
     input_var = MLIRVar("input_value", "i64")
-    
+
     lower_index = 3
     upper_index = 9
     delta_index = 2
@@ -361,57 +391,72 @@ def test_ir_builder_for_loop_user_specified_vars(engine: MlirJitEngine):
         expected_sum += iter_index * iter_i64
 
     # Build IR
-    ir_builder = MLIRFunctionBuilder("add_user_specified_vars", input_vars=[input_var], return_types=["i64"])
-    ir_builder.add_statement("// pymlir-skip: begin")
-    ir_builder.add_statement("%sum_memref = memref.alloc() : memref<i64>")
-    ir_builder.add_statement(f"memref.store {input_var.access_string()}, %sum_memref[] : memref<i64>")
+    ir_builder = MLIRFunctionBuilder(
+        "add_user_specified_vars", input_vars=[input_var], return_types=["i64"]
+    )
+    ir_builder.add_statement(
+        f"""
+// pymlir-skip: begin
+%sum_memref = memref.alloc() : memref<i64>
+memref.store {input_var.access_string()}, %sum_memref[] : memref<i64>
+"""
+    )
     lower_index_var = ir_builder.constant(lower_index, "index")
     upper_index_var = ir_builder.constant(upper_index, "index")
     delta_index_var = ir_builder.constant(delta_index, "index")
     lower_i64_var = ir_builder.constant(lower_i64, "i64")
     delta_i64_var = ir_builder.constant(delta_i64, "i64")
     iter_i64_var = MLIRVar("iter_i64", "i64")
-    
-    with ir_builder.for_loop(lower_index_var, upper_index_var, delta_index_var, iter_vars=[(iter_i64_var, lower_i64_var)]) as for_vars:
+
+    with ir_builder.for_loop(
+        lower_index_var,
+        upper_index_var,
+        delta_index_var,
+        iter_vars=[(iter_i64_var, lower_i64_var)],
+    ) as for_vars:
         assert lower_index_var == for_vars.lower_var_index
         assert upper_index_var == for_vars.upper_var_index
         assert delta_index_var == for_vars.step_var_index
         assert [iter_i64_var] == for_vars.iter_vars
-        ir_builder.add_statement("%current_sum = memref.load %sum_memref[] : memref<i64>")
-        
-        ir_builder.add_statement(f"%prod_of_index_vars_0 = muli {for_vars.lower_var_index.access_string()}, {for_vars.upper_var_index.access_string()} : index")
-        ir_builder.add_statement(f"%prod_of_index_vars_1 = muli %prod_of_index_vars_0, {for_vars.step_var_index.access_string()} : index")
-        ir_builder.add_statement(f"%prod_of_index_vars = std.index_cast %prod_of_index_vars_1 : index to i64")
-        
-        ir_builder.add_statement(f"%prod_of_i64_vars = muli {lower_i64_var.access_string()}, {delta_i64_var.access_string()} : i64")
-
-        ir_builder.add_statement(f"%iter_index_i64 = std.index_cast {for_vars.iter_var_index.access_string()} : index to i64")
-        ir_builder.add_statement(f"%prod_of_iter_vars = muli %iter_index_i64, {iter_i64_var.access_string()} : i64")
-        
-        ir_builder.add_statement(f"%updated_sum_0 = addi %current_sum, %prod_of_index_vars : i64")
-        ir_builder.add_statement(f"%updated_sum_1 = addi %updated_sum_0, %prod_of_i64_vars : i64")
-        ir_builder.add_statement(f"%updated_sum = addi %updated_sum_1, %prod_of_iter_vars : i64")
-        
-        ir_builder.add_statement("memref.store %updated_sum, %sum_memref[] : memref<i64>")
-        
-        # increment iter_i64_var
         incremented_iter_i64_var = MLIRVar("incremented_iter_i64", "i64")
-        ir_builder.add_statement(f"{incremented_iter_i64_var.assign_string()} = addi {iter_i64_var.access_string()}, {delta_i64_var.access_string()} : i64")
+        ir_builder.add_statement(
+            f"""
+%current_sum = memref.load %sum_memref[] : memref<i64>
+%prod_of_index_vars_0 = muli {for_vars.lower_var_index.access_string()}, {for_vars.upper_var_index.access_string()} : index
+%prod_of_index_vars_1 = muli %prod_of_index_vars_0, {for_vars.step_var_index.access_string()} : index
+%prod_of_index_vars = std.index_cast %prod_of_index_vars_1 : index to i64
+%prod_of_i64_vars = muli {lower_i64_var.access_string()}, {delta_i64_var.access_string()} : i64
+%iter_index_i64 = std.index_cast {for_vars.iter_var_index.access_string()} : index to i64
+%prod_of_iter_vars = muli %iter_index_i64, {iter_i64_var.access_string()} : i64
+%updated_sum_0 = addi %current_sum, %prod_of_index_vars : i64
+%updated_sum_1 = addi %updated_sum_0, %prod_of_i64_vars : i64
+%updated_sum = addi %updated_sum_1, %prod_of_iter_vars : i64
+memref.store %updated_sum, %sum_memref[] : memref<i64>
+{incremented_iter_i64_var.assign_string()} = addi {iter_i64_var.access_string()}, {delta_i64_var.access_string()} : i64
+"""
+        )
         for_vars.yield_vars(incremented_iter_i64_var)
-    ir_builder.add_statement("%sum = memref.load %sum_memref[] : memref<i64>")
     result_var = MLIRVar("sum", "i64")
-    ir_builder.add_statement("// pymlir-skip: end")
+    ir_builder.add_statement(
+        f"""
+{result_var.assign_string()} = memref.load %sum_memref[] : memref<i64>
+// pymlir-skip: end
+"""
+    )
     ir_builder.return_vars(result_var)
-    
-    assert ir_builder.get_mlir() # this generated MLIR is easier to read than the above IR builder calls.
+
+    assert (
+        ir_builder.get_mlir()
+    )  # this generated MLIR is easier to read than the above IR builder calls.
 
     # Test Compiled Function
     func = ir_builder.compile(engine=engine)
-    
+
     calculated_sum = func(7)
     assert np.isclose(calculated_sum, expected_sum)
 
     return
+
 
 DNN_CASES = [
     pytest.param(
@@ -425,11 +470,19 @@ DNN_CASES = [
         10,
         32.0,
         id="random_10_layer",
-    )
+    ),
 ]
 
-@pytest.mark.parametrize("array_initializer, max_num_layers, clamp_threshold", DNN_CASES)
-def test_ir_builder_dnn(engine: MlirJitEngine, array_initializer: Callable, max_num_layers: int, clamp_threshold: float):
+
+@pytest.mark.parametrize(
+    "array_initializer, max_num_layers, clamp_threshold", DNN_CASES
+)
+def test_ir_builder_dnn(
+    engine: MlirJitEngine,
+    array_initializer: Callable,
+    max_num_layers: int,
+    clamp_threshold: float,
+):
     # Needed Functions
     csr_to_csc = Transpose(swap_sizes=False)
     mxm_plus_times = MatrixMultiply("plus_times")
@@ -447,7 +500,7 @@ def test_ir_builder_dnn(engine: MlirJitEngine, array_initializer: Callable, max_
     ir_builder = MLIRFunctionBuilder(
         "dense_neural_network",
         input_vars=[weight_list_var, bias_list_var, num_layers_var, Y0_var],
-        return_types=["!llvm.ptr<i8>"]
+        return_types=["!llvm.ptr<i8>"],
     )
     ir_builder.add_statement("// pymlir-skip: begin")
     c0_var = ir_builder.constant(0, "i64")
@@ -457,91 +510,115 @@ def test_ir_builder_dnn(engine: MlirJitEngine, array_initializer: Callable, max_
     Y_var = MLIRVar("Y", "!llvm.ptr<i8>")
     layer_index_i64_var = MLIRVar("layer_index", "i64")
 
-    with ir_builder.for_loop(0, num_layers_var, iter_vars=[(Y_var, Y0_var), (layer_index_i64_var, c0_var)]) as for_vars:
+    with ir_builder.for_loop(
+        0, num_layers_var, iter_vars=[(Y_var, Y0_var), (layer_index_i64_var, c0_var)]
+    ) as for_vars:
         # Get weight matrix
-        ir_builder.add_statement(f"%weight_matrix_ptr_ptr = llvm.getelementptr {weight_list_var.access_string()}[{layer_index_i64_var.access_string()}] : (!llvm.ptr<!llvm.ptr<i8>>, i64) -> !llvm.ptr<!llvm.ptr<i8>>")
+        ir_builder.add_statement(
+            f"%weight_matrix_ptr_ptr = llvm.getelementptr {weight_list_var.access_string()}[{layer_index_i64_var.access_string()}] : (!llvm.ptr<!llvm.ptr<i8>>, i64) -> !llvm.ptr<!llvm.ptr<i8>>"
+        )
         weight_matrix_ptr_var = MLIRVar("weight_matrix_ptr", "!llvm.ptr<i8>")
-        ir_builder.add_statement(f"{weight_matrix_ptr_var.assign_string()} = llvm.load %weight_matrix_ptr_ptr : !llvm.ptr<!llvm.ptr<i8>>")
+        ir_builder.add_statement(
+            f"{weight_matrix_ptr_var.assign_string()} = llvm.load %weight_matrix_ptr_ptr : !llvm.ptr<!llvm.ptr<i8>>"
+        )
 
         # Get bias matrix
-        ir_builder.add_statement(f"%bias_matrix_ptr_ptr = llvm.getelementptr {bias_list_var.access_string()}[{layer_index_i64_var.access_string()}] : (!llvm.ptr<!llvm.ptr<i8>>, i64) -> !llvm.ptr<!llvm.ptr<i8>>")
+        ir_builder.add_statement(
+            f"%bias_matrix_ptr_ptr = llvm.getelementptr {bias_list_var.access_string()}[{layer_index_i64_var.access_string()}] : (!llvm.ptr<!llvm.ptr<i8>>, i64) -> !llvm.ptr<!llvm.ptr<i8>>"
+        )
         bias_matrix_ptr_var = MLIRVar("bias_matrix_ptr", "!llvm.ptr<i8>")
-        ir_builder.add_statement(f"{bias_matrix_ptr_var.assign_string()} = llvm.load %bias_matrix_ptr_ptr : !llvm.ptr<!llvm.ptr<i8>>")
+        ir_builder.add_statement(
+            f"{bias_matrix_ptr_var.assign_string()} = llvm.load %bias_matrix_ptr_ptr : !llvm.ptr<!llvm.ptr<i8>>"
+        )
 
         # Perform inference
         W_csc_var = ir_builder.call(csr_to_csc, weight_matrix_ptr_var)
         matmul_result_var = ir_builder.call(mxm_plus_times, Y_var, W_csc_var)
-        add_bias_result_var = ir_builder.call(mxm_plus_plus, matmul_result_var, bias_matrix_ptr_var)
+        add_bias_result_var = ir_builder.call(
+            mxm_plus_plus, matmul_result_var, bias_matrix_ptr_var
+        )
         relu_result_var = ir_builder.call(matrix_select_gt0, add_bias_result_var)
-        clamp_result_var = ir_builder.call(matrix_apply_min, relu_result_var, clamp_threshold_var)
+        clamp_result_var = ir_builder.call(
+            matrix_apply_min, relu_result_var, clamp_threshold_var
+        )
 
         # increment iterator vars
         incremented_layer_index_i64_var = MLIRVar("incremented_layer_index", "i64")
-        ir_builder.add_statement(f"{incremented_layer_index_i64_var.assign_string()} = addi {layer_index_i64_var.access_string()}, {c1_var.access_string()} : i64")
+        ir_builder.add_statement(
+            f"{incremented_layer_index_i64_var.assign_string()} = addi {layer_index_i64_var.access_string()}, {c1_var.access_string()} : i64"
+        )
         for_vars.yield_vars(clamp_result_var, incremented_layer_index_i64_var)
-        
+
     ir_builder.add_statement("// pymlir-skip: end")
     ir_builder.return_vars(for_vars.returned_variable[0])
 
     assert ir_builder.get_mlir()
-    
+
     # Test Compiled Function
     func = ir_builder.compile(engine=engine)
-    
-    sparsify_matrix = lambda matrix: sparsify_array(matrix, [False, True])
-    np.random.seed(hash(datetime.date.today()) % 2**32)
 
-    for num_layers in range(1, max_num_layers+1):
-    
+    sparsify_matrix = lambda matrix: sparsify_array(matrix, [False, True])
+    np.random.seed(hash(datetime.date.today()) % 2 ** 32)
+
+    for num_layers in range(1, max_num_layers + 1):
+
         dense_weight_matrices = [array_initializer(64) for _ in range(num_layers)]
-        dense_weight_matrices = [matrix.reshape(8, 8) for matrix in dense_weight_matrices]
-        dense_weight_matrices = [matrix.astype(np.float64) for matrix in dense_weight_matrices]
-        
+        dense_weight_matrices = [m.reshape(8, 8) for m in dense_weight_matrices]
+        dense_weight_matrices = [m.astype(np.float64) for m in dense_weight_matrices]
+
         dense_bias_vectors = [array_initializer(8) for _ in range(num_layers)]
         dense_bias_vectors = [vec.astype(np.float64) for vec in dense_bias_vectors]
         dense_bias_matrices = [np.diag(vec) for vec in dense_bias_vectors]
-        dense_bias_matrices = [np.nan_to_num(matrix) for matrix in dense_bias_matrices]
-        
+        dense_bias_matrices = [np.nan_to_num(m) for m in dense_bias_matrices]
+
         dense_input_tensor = array_initializer(64).reshape(8, 8).astype(np.float64)
-        
-        expected_dense_result = dense_input_tensor
-        for dense_weight_matrix, dense_bias_vector in zip(dense_weight_matrices, dense_bias_vectors):
-            expected_dense_result = expected_dense_result @ dense_weight_matrix
-            expected_dense_result = expected_dense_result + dense_bias_vector
-            expected_dense_result = expected_dense_result * (expected_dense_result > 0).astype(int)
-            expected_dense_result[expected_dense_result > clamp_threshold] = clamp_threshold 
-            
-        sparse_weight_matrices = [sparsify_matrix(matrix) for matrix in dense_weight_matrices]
-        sparse_bias_matrices = [sparsify_matrix(matrix) for matrix in dense_bias_matrices]
+
+        numpy_dense_result = dense_input_tensor
+        for dense_weight_matrix, dense_bias_vector in zip(
+            dense_weight_matrices, dense_bias_vectors
+        ):
+            numpy_dense_result = numpy_dense_result @ dense_weight_matrix
+            numpy_dense_result = numpy_dense_result + dense_bias_vector
+            numpy_dense_result = numpy_dense_result * (dense_bias_vector != 0).astype(
+                int
+            )  # TODO is this correct?
+            numpy_dense_result = numpy_dense_result * (numpy_dense_result > 0).astype(
+                int
+            )
+            numpy_dense_result[numpy_dense_result > clamp_threshold] = clamp_threshold
+
+        sparse_weight_matrices = [
+            sparsify_matrix(matrix) for matrix in dense_weight_matrices
+        ]
+        sparse_bias_matrices = [
+            sparsify_matrix(matrix) for matrix in dense_bias_matrices
+        ]
         sparse_input_tensor = sparsify_matrix(dense_input_tensor)
-        sparse_result = func(sparse_weight_matrices, sparse_bias_matrices, num_layers, sparse_input_tensor)
+        sparse_result = func(
+            sparse_weight_matrices,
+            sparse_bias_matrices,
+            num_layers,
+            sparse_input_tensor,
+        )
         dense_result = engine.densify(sparse_result)
-    
-        slow_sparse_result = dense_neural_network(sparse_weight_matrices, sparse_bias_matrices, sparse_input_tensor, clamp_threshold)
-        slow_dense_result = engine.densify(slow_sparse_result) # TODO is this the correct answer? Or is expected_dense_result the correct answer?
-        
+
         with np.printoptions(suppress=True):
-            assert np.isclose(dense_result, expected_dense_result).all(), f"""
+            error_message = f"""
+num_layers
+{num_layers}
+
 dense_input_tensor
 {dense_input_tensor}
 
 dense_result
 {dense_result}
 
-slow_dense_result
-{slow_dense_result}
+numpy_dense_result
+{numpy_dense_result}
 
-expected_dense_result
-{expected_dense_result}
-
-np.isclose(dense_result, expected_dense_result)
-{np.isclose(dense_result, expected_dense_result)}
-
-np.isclose(dense_result, slow_dense_result).all()
-{np.isclose(dense_result, slow_dense_result).all()}
-
-np.isclose(dense_result, slow_dense_result)
-{np.isclose(dense_result, slow_dense_result)}
+np.isclose(dense_result, numpy_dense_result)
+{np.isclose(dense_result, numpy_dense_result)}
 """
-    
+            assert np.isclose(dense_result, numpy_dense_result).all(), error_message
+
     return

--- a/mlir_graphblas/tests/test_mlir_builder_bad_inputs.py
+++ b/mlir_graphblas/tests/test_mlir_builder_bad_inputs.py
@@ -4,70 +4,80 @@ import pytest
 from mlir_graphblas import MlirJitEngine
 from mlir_graphblas.mlir_builder import MLIRVar, MLIRFunctionBuilder
 
+
 @pytest.fixture(scope="module")
 def engine():
     return MlirJitEngine()
-    
+
+
 def test_ir_builder_bad_input_multi_value_mlir_variable():
-    ir_builder = MLIRFunctionBuilder(
-        "some_func", input_vars=[], return_types=('i8',)
-    )
+    ir_builder = MLIRFunctionBuilder("some_func", input_vars=[], return_types=("i8",))
     ir_builder.add_statement("// pymlir-skip: begin")
-    
+
     iter_i8_var = MLIRVar("iter_i8", "i8")
     lower_i8_var = ir_builder.constant(1, "i8")
     iter_i64_var = MLIRVar("iter_64", "i64")
     lower_i64_var = ir_builder.constant(1, "i64")
     with ir_builder.for_loop(
-            0,
-            1,
-            1,
-            iter_vars=[
-                (iter_i8_var, lower_i8_var),
-                (iter_i64_var, lower_i64_var)
-            ]
+        0, 1, 1, iter_vars=[(iter_i8_var, lower_i8_var), (iter_i64_var, lower_i64_var)]
     ) as for_vars:
         constant_i8_var = ir_builder.constant(8, "i8")
         constant_i64_var = ir_builder.constant(64, "i64")
-        
+
         # Raise when yielding too few values
         with pytest.raises(ValueError, match="Expected 2 yielded values, but got 1."):
             for_vars.yield_vars(constant_i8_var)
-            
+
         # Raise when yielding too many values
         with pytest.raises(ValueError, match="Expected 2 yielded values, but got 3."):
             for_vars.yield_vars(constant_i8_var, constant_i64_var, lower_i64_var)
-            
+
         # Raise when yielding incorrect types
         with pytest.raises(TypeError, match=" have different types."):
             for_vars.yield_vars(constant_i64_var, constant_i8_var)
-            
+
         for_vars.yield_vars(constant_i8_var, constant_i64_var)
-        
+
     # Raise when returning multiple valued variable
     with pytest.raises(TypeError, match=" has multiple types."):
         ir_builder.return_vars(for_vars.returned_variable)
 
     # Raise when using multiple valued variable as operand
-    assigned_to_i8_var = MLIRVar('assigned_to_i8', 'i8')
-    c1_i8_var = ir_builder.constant(1, 'i8')
-    with pytest.raises(RuntimeError, match="Attempting to use variable containing multiple values as a singleton variable."):
-        ir_builder.add_statement(f"{assigned_to_i8_var.assign_string()} = addi {c1_i8_var.access_string()}, {for_vars.returned_variable.access_string()} : i8")
+    assigned_to_i8_var = MLIRVar("assigned_to_i8", "i8")
+    c1_i8_var = ir_builder.constant(1, "i8")
+    with pytest.raises(
+        ValueError,
+        match="Attempting to use variable containing multiple values as a singleton variable.",
+    ):
+        ir_builder.add_statement(
+            f"{assigned_to_i8_var.assign_string()} = addi {c1_i8_var.access_string()}, {for_vars.returned_variable.access_string()} : i8"
+        )
 
     # Raise when using multiple valued variable as operand
-    assigned_to_i64_var = MLIRVar('assigned_to_i64', 'i64')
-    c1_i64_var = ir_builder.constant(1, 'i64')
-    with pytest.raises(RuntimeError, match="Attempting to use variable containing multiple values as a singleton variable."):
-        ir_builder.add_statement(f"{assigned_to_i64_var.assign_string()} = addi {c1_i64_var.access_string()}, {for_vars.returned_variable.access_string()} : i64")
+    assigned_to_i64_var = MLIRVar("assigned_to_i64", "i64")
+    c1_i64_var = ir_builder.constant(1, "i64")
+    with pytest.raises(
+        ValueError,
+        match="Attempting to use variable containing multiple values as a singleton variable.",
+    ):
+        ir_builder.add_statement(
+            f"{assigned_to_i64_var.assign_string()} = addi {c1_i64_var.access_string()}, {for_vars.returned_variable.access_string()} : i64"
+        )
 
     # Raise when using multiple valued variable indexed via non-int as operand
-    with pytest.raises(LookupError, match=" only supports integer indexing."):
-        ir_builder.add_statement(f"{assigned_to_i64_var.assign_string()} = addi {c1_i64_var.access_string()}, {for_vars.returned_variable.access_string('zero')} : i64")
-    
+    with pytest.raises(TypeError, match=" only supports integer indexing."):
+        ir_builder.add_statement(
+            f"{assigned_to_i64_var.assign_string()} = addi {c1_i64_var.access_string()}, {for_vars.returned_variable.access_string('zero')} : i64"
+        )
+
     # Raise when using multiple valued variable indexed via out-of-bound int index as operand
-    with pytest.raises(IndexError, match=r"Index must be an integer in the range \[0, 2\)."):
-        ir_builder.add_statement(f"{assigned_to_i64_var.assign_string()} = addi {c1_i64_var.access_string()}, {for_vars.returned_variable.access_string(9999)} : i64")
-        
+    with pytest.raises(
+        IndexError, match=r"Index must be an integer in the range \[0, 2\)."
+    ):
+        ir_builder.add_statement(
+            f"{assigned_to_i64_var.assign_string()} = addi {c1_i64_var.access_string()}, {for_vars.returned_variable.access_string(9999)} : i64"
+        )
+
     # Raise when indexing into multiple valued variable via slice
     with pytest.raises(TypeError, match=" indices must be integers, not "):
         ir_builder.return_vars(for_vars.returned_variable[:])
@@ -77,21 +87,20 @@ def test_ir_builder_bad_input_multi_value_mlir_variable():
         ir_builder.return_vars(10)
 
     # Raise when returning value incompatible with return type.
-    with pytest.raises(TypeError, match="Types for .+ do not match function return types of .+"):
+    with pytest.raises(
+        TypeError, match="Types for .+ do not match function return types of .+"
+    ):
         ir_builder.return_vars(c1_i64_var)
-        
+
     # Raise when iterator variables have incompatible types
     with pytest.raises(TypeError, match=" have different types."):
         with ir_builder.for_loop(
-                0,
-                1,
-                1,
-                iter_vars=[
-                    (iter_i8_var, lower_i64_var),
-                    (iter_i64_var, lower_i8_var)
-                ]
+            0,
+            1,
+            1,
+            iter_vars=[(iter_i8_var, lower_i64_var), (iter_i64_var, lower_i8_var)],
         ) as bad_for_vars:
             pass
-    
+
     ir_builder.add_statement("// pymlir-skip: end")
     ir_builder.return_vars(for_vars.returned_variable[0])


### PR DESCRIPTION
This PR does the following:
- JIT Engine: Adds support for functions with zero return values.
- JIT Engine: Can support python list or tuple inputs via the MLIR type `!llvm.ptr`
- JIT Engine: Use the recent PyMLIR support for the LLVM dialect instead of pretty dialect types, which is just PyMLIR's mechanism of parsing dialects that aren't explicitly supported in PyMLIR.
- JIT Engine WIP: Partial support for multiple return values. Currently facing some C-ABI issues that need to be resolved. The plan is to address this in a future PR.
- IR Builder: Support for `scf.for`-loops.

NOTE: This PR relies on the latest changes to the [PyMLIR conda package](https://anaconda.org/metagraph/pymlir/files), which current has the `dev` label instead of the `main` label, so the CI tests will currently fail as it won't use the needed version of PyMLIR.

NOTE: This PR contains a currently failing test that tries to implement DNN via the IR builder. The function built by the IR builder gets the same result as `mlir_graphblas.algorithms.dense_neural_network`, but I suspect those results may be incorrect as they're inconsistent with an implementation done via NumPy. I'm currently investigating this. The details are shown below. 
<details>
<pre>
(mlirgraphblas) pnguyen@0584:/Users/pnguyen/code/mlir-graphblas$ pytest
/Users/pnguyen/code/mlir-graphblas/versioneer.py:346: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
  parser = configparser.SafeConfigParser()
/Users/pnguyen/code/mlir-graphblas/versioneer.py:348: DeprecationWarning: This method will be removed in future versions.  Use 'parser.read_file()' instead.
  parser.readfp(f)
running build_ext
copying build/lib.macosx-10.9-x86_64-3.8/mlir_graphblas/sparse_utils.cpython-38-darwin.so -> mlir_graphblas
copying build/lib.macosx-10.9-x86_64-3.8/mlir_graphblas/SparseUtils.cpython-38-darwin.so -> mlir_graphblas
=========================================================================================================== test session starts ===========================================================================================================
platform darwin -- Python 3.8.8, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /Users/pnguyen/code/mlir-graphblas, configfile: setup.cfg, testpaths: mlir_graphblas/tests
plugins: cov-2.11.1
collected 160 items                                                                                                                                                                                                                       

mlir_graphblas/tests/test_algorithms.py .                                                                                                                                                                                           [  0%]
mlir_graphblas/tests/test_cli.py ...                                                                                                                                                                                                [  2%]
mlir_graphblas/tests/test_io.py .......                                                                                                                                                                                             [  6%]
mlir_graphblas/tests/test_jit_engine.py ....................................................................xxxxxxx...                                                                                                              [ 55%]
mlir_graphblas/tests/test_jit_engine_bad_inputs.py ..............................................................                                                                                                                   [ 94%]
mlir_graphblas/tests/test_mlir_builder.py ...F..F.                                                                                                                                                                                  [ 99%]
mlir_graphblas/tests/test_mlir_builder_bad_inputs.py .                                                                                                                                                                              [100%]

================================================================================================================ FAILURES =================================================================================================================
_____________________________________________________________________________________________________ test_ir_builder_for_loop_simple _____________________________________________________________________________________________________

engine = <mlir_graphblas.engine.MlirJitEngine object at 0x7fdd823a3880>

    def  test_ir_builder_for_loop_simple(engine: MlirJitEngine):
        # Build Function
    
        input_var = MLIRVar("input_value", "f64")
    
        ir_builder = MLIRFunctionBuilder("times_three", input_vars=[input_var], return_types=["f64"])
        zero_f64 = ir_builder.constant(0.0, "f64")
        ir_builder.add_statement("// pymlir-skip: begin")
        ir_builder.add_statement("%sum_memref = memref.alloc() : memref<f64>")
        ir_builder.add_statement(f"memref.store {zero_f64.access_string()}, %sum_memref[] : memref<f64>")
>       with ir_builder.for_loop(0, 3) as for_vars:

mlir_graphblas/tests/test_mlir_builder.py:279: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../anaconda3/envs/mlirgraphblas/lib/python3.8/contextlib.py:113: in __enter__
    return next(self.gen)
mlir_graphblas/mlir_builder.py:348: in for_loop
    returned_var = self.new_var(*(var.var_type for var in _iter_vars))
mlir_graphblas/mlir_builder.py:239: in new_var
    return MLIRVar(var_name, *var_types)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = MLIRVar(), var_name = 'var_5', var_types = ()

    def __init__(self, var_name: str, *var_types: str) -> None:
        """Elements of var_types are types as represented in MLIR code."""
>       assert len(var_types) > 0
E       AssertionError

mlir_graphblas/mlir_builder.py:43: AssertionError
__________________________________________________________________________________________________ test_ir_builder_dnn[arange_10_layer] ___________________________________________________________________________________________________

engine = <mlir_graphblas.engine.MlirJitEngine object at 0x7fdd823a3880>, array_initializer = <function <lambda> at 0x7fdd826f1ca0>, max_num_layers = 10, clamp_threshold = 1000000.0

    @pytest.mark.parametrize("array_initializer, max_num_layers, clamp_threshold", DNN_CASES)
    def test_ir_builder_dnn(engine: MlirJitEngine, array_initializer: Callable, max_num_layers: int, clamp_threshold: float):
        # Needed Functions
        csr_to_csc = Transpose(swap_sizes=False)
        mxm_plus_times = MatrixMultiply("plus_times")
        mxm_plus_plus = MatrixMultiply("plus_plus")
        matrix_select_gt0 = MatrixSelect("gt0")
        matrix_apply_min = MatrixApply("min")
    
        # Input Vars
        weight_list_var = MLIRVar("weight_list", "!llvm.ptr<!llvm.ptr<i8>>")
        bias_list_var = MLIRVar("bias_list", "!llvm.ptr<!llvm.ptr<i8>>")
        num_layers_var = MLIRVar("num_layers", "index")
        Y0_var = MLIRVar("Y0", "!llvm.ptr<i8>")
    
        # Build Function
        ir_builder = MLIRFunctionBuilder(
            "dense_neural_network",
            input_vars=[weight_list_var, bias_list_var, num_layers_var, Y0_var],
            return_types=["!llvm.ptr<i8>"]
        )
        ir_builder.add_statement("// pymlir-skip: begin")
        c0_var = ir_builder.constant(0, "i64")
        c1_var = ir_builder.constant(1, "i64")
        clamp_threshold_var = ir_builder.constant(clamp_threshold, "f64")
    
        Y_var = MLIRVar("Y", "!llvm.ptr<i8>")
        layer_index_i64_var = MLIRVar("layer_index", "i64")
    
        with ir_builder.for_loop(0, num_layers_var, iter_vars=[(Y_var, Y0_var), (layer_index_i64_var, c0_var)]) as for_vars:
            # Get weight matrix
            ir_builder.add_statement(f"%weight_matrix_ptr_ptr = llvm.getelementptr {weight_list_var.access_string()}[{layer_index_i64_var.access_string()}] : (!llvm.ptr<!llvm.ptr<i8>>, i64) -> !llvm.ptr<!llvm.ptr<i8>>")
            weight_matrix_ptr_var = MLIRVar("weight_matrix_ptr", "!llvm.ptr<i8>")
            ir_builder.add_statement(f"{weight_matrix_ptr_var.assign_string()} = llvm.load %weight_matrix_ptr_ptr : !llvm.ptr<!llvm.ptr<i8>>")
    
            # Get bias matrix
            ir_builder.add_statement(f"%bias_matrix_ptr_ptr = llvm.getelementptr {bias_list_var.access_string()}[{layer_index_i64_var.access_string()}] : (!llvm.ptr<!llvm.ptr<i8>>, i64) -> !llvm.ptr<!llvm.ptr<i8>>")
            bias_matrix_ptr_var = MLIRVar("bias_matrix_ptr", "!llvm.ptr<i8>")
            ir_builder.add_statement(f"{bias_matrix_ptr_var.assign_string()} = llvm.load %bias_matrix_ptr_ptr : !llvm.ptr<!llvm.ptr<i8>>")
    
            # Perform inference
            W_csc_var = ir_builder.call(csr_to_csc, weight_matrix_ptr_var)
            matmul_result_var = ir_builder.call(mxm_plus_times, Y_var, W_csc_var)
            add_bias_result_var = ir_builder.call(mxm_plus_plus, matmul_result_var, bias_matrix_ptr_var)
            relu_result_var = ir_builder.call(matrix_select_gt0, add_bias_result_var)
            clamp_result_var = ir_builder.call(matrix_apply_min, relu_result_var, clamp_threshold_var)
    
            # increment iterator vars
            incremented_layer_index_i64_var = MLIRVar("incremented_layer_index", "i64")
            ir_builder.add_statement(f"{incremented_layer_index_i64_var.assign_string()} = addi {layer_index_i64_var.access_string()}, {c1_var.access_string()} : i64")
            for_vars.yield_vars(clamp_result_var, incremented_layer_index_i64_var)
    
        ir_builder.add_statement("// pymlir-skip: end")
        ir_builder.return_vars(for_vars.returned_variable[0])
    
        assert ir_builder.get_mlir()
    
        # Test Compiled Function
        func = ir_builder.compile(engine=engine)
    
        sparsify_matrix = lambda matrix: sparsify_array(matrix, [False, True])
        np.random.seed(hash(datetime.date.today()) % 2**32)
    
        for num_layers in range(1, max_num_layers+1):
    
            dense_weight_matrices = [array_initializer(64) for _ in range(num_layers)]
            dense_weight_matrices = [matrix.reshape(8, 8) for matrix in dense_weight_matrices]
            dense_weight_matrices = [matrix.astype(np.float64) for matrix in dense_weight_matrices]
    
            dense_bias_vectors = [array_initializer(8) for _ in range(num_layers)]
            dense_bias_vectors = [vec.astype(np.float64) for vec in dense_bias_vectors]
            dense_bias_matrices = [np.diag(vec) for vec in dense_bias_vectors]
            dense_bias_matrices = [np.nan_to_num(matrix) for matrix in dense_bias_matrices]
    
            dense_input_tensor = array_initializer(64).reshape(8, 8).astype(np.float64)
    
            expected_dense_result = dense_input_tensor
            for dense_weight_matrix, dense_bias_vector in zip(dense_weight_matrices, dense_bias_vectors):
                expected_dense_result = expected_dense_result @ dense_weight_matrix
                expected_dense_result = expected_dense_result + dense_bias_vector
                expected_dense_result = expected_dense_result * (expected_dense_result > 0).astype(int)
                expected_dense_result[expected_dense_result > clamp_threshold] = clamp_threshold
    
            sparse_weight_matrices = [sparsify_matrix(matrix) for matrix in dense_weight_matrices]
            sparse_bias_matrices = [sparsify_matrix(matrix) for matrix in dense_bias_matrices]
            sparse_input_tensor = sparsify_matrix(dense_input_tensor)
            sparse_result = func(sparse_weight_matrices, sparse_bias_matrices, num_layers, sparse_input_tensor)
            dense_result = engine.densify(sparse_result)
    
            slow_sparse_result = dense_neural_network(sparse_weight_matrices, sparse_bias_matrices, sparse_input_tensor, clamp_threshold)
            slow_dense_result = engine.densify(slow_sparse_result) # TODO is this the correct answer? Or is expected_dense_result the correct answer?
    
            with np.printoptions(suppress=True):
>               assert np.isclose(dense_result, expected_dense_result).all(), f"""
    dense_input_tensor
    {dense_input_tensor}
    
    dense_result
    {dense_result}
    
    slow_dense_result
    {slow_dense_result}
    
    expected_dense_result
    {expected_dense_result}
    
    np.isclose(dense_result, expected_dense_result)
    {np.isclose(dense_result, expected_dense_result)}
    
    np.isclose(dense_result, slow_dense_result).all()
    {np.isclose(dense_result, slow_dense_result).all()}
    
    np.isclose(dense_result, slow_dense_result)
    {np.isclose(dense_result, slow_dense_result)}
    """
E               AssertionError: 
E                 dense_input_tensor
E                 [[0.   0.01 0.02 0.03 0.04 0.05 0.06 0.07]
E                  [0.08 0.09 0.1  0.11 0.12 0.13 0.14 0.15]
E                  [0.16 0.17 0.18 0.19 0.2  0.21 0.22 0.23]
E                  [0.24 0.25 0.26 0.27 0.28 0.29 0.3  0.31]
E                  [0.32 0.33 0.34 0.35 0.36 0.37 0.38 0.39]
E                  [0.4  0.41 0.42 0.43 0.44 0.45 0.46 0.47]
E                  [0.48 0.49 0.5  0.51 0.52 0.53 0.54 0.55]
E                  [0.56 0.57 0.58 0.59 0.6  0.61 0.62 0.63]]
E                 
E                 dense_result
E                 [[0.     0.1248 0.1376 0.1504 0.1632 0.176  0.1888 0.2016]
E                  [0.     0.3104 0.3296 0.3488 0.368  0.3872 0.4064 0.4256]
E                  [0.     0.496  0.5216 0.5472 0.5728 0.5984 0.624  0.6496]
E                  [0.     0.6816 0.7136 0.7456 0.7776 0.8096 0.8416 0.8736]
E                  [0.     0.8672 0.9056 0.944  0.9824 1.0208 1.0592 1.0976]
E                  [0.     1.0528 1.0976 1.1424 1.1872 1.232  1.2768 1.3216]
E                  [0.     1.2384 1.2896 1.3408 1.392  1.4432 1.4944 1.5456]
E                  [0.     1.424  1.4816 1.5392 1.5968 1.6544 1.712  1.7696]]
E                 
E                 slow_dense_result
E                 [[0.     0.1248 0.1376 0.1504 0.1632 0.176  0.1888 0.2016]
E                  [0.     0.3104 0.3296 0.3488 0.368  0.3872 0.4064 0.4256]
E                  [0.     0.496  0.5216 0.5472 0.5728 0.5984 0.624  0.6496]
E                  [0.     0.6816 0.7136 0.7456 0.7776 0.8096 0.8416 0.8736]
E                  [0.     0.8672 0.9056 0.944  0.9824 1.0208 1.0592 1.0976]
E                  [0.     1.0528 1.0976 1.1424 1.1872 1.232  1.2768 1.3216]
E                  [0.     1.2384 1.2896 1.3408 1.392  1.4432 1.4944 1.5456]
E                  [0.     1.424  1.4816 1.5392 1.5968 1.6544 1.712  1.7696]]
E                 
E                 expected_dense_result
E                 [[0.112  0.1248 0.1376 0.1504 0.1632 0.176  0.1888 0.2016]
E                  [0.2912 0.3104 0.3296 0.3488 0.368  0.3872 0.4064 0.4256]
E                  [0.4704 0.496  0.5216 0.5472 0.5728 0.5984 0.624  0.6496]
E                  [0.6496 0.6816 0.7136 0.7456 0.7776 0.8096 0.8416 0.8736]
E                  [0.8288 0.8672 0.9056 0.944  0.9824 1.0208 1.0592 1.0976]
E                  [1.008  1.0528 1.0976 1.1424 1.1872 1.232  1.2768 1.3216]
E                  [1.1872 1.2384 1.2896 1.3408 1.392  1.4432 1.4944 1.5456]
E                  [1.3664 1.424  1.4816 1.5392 1.5968 1.6544 1.712  1.7696]]
E                 
E                 np.isclose(dense_result, expected_dense_result)
E                 [[False  True  True  True  True  True  True  True]
E                  [False  True  True  True  True  True  True  True]
E                  [False  True  True  True  True  True  True  True]
E                  [False  True  True  True  True  True  True  True]
E                  [False  True  True  True  True  True  True  True]
E                  [False  True  True  True  True  True  True  True]
E                  [False  True  True  True  True  True  True  True]
E                  [False  True  True  True  True  True  True  True]]
E                 
E                 np.isclose(dense_result, slow_dense_result).all()
E                 True
E                 
E                 np.isclose(dense_result, slow_dense_result)
E                 [[ True  True  True  True  True  True  True  True]
E                  [ True  True  True  True  True  True  True  True]
E                  [ True  True  True  True  True  True  True  True]
E                  [ True  True  True  True  True  True  True  True]
E                  [ True  True  True  True  True  True  True  True]
E                  [ True  True  True  True  True  True  True  True]
E                  [ True  True  True  True  True  True  True  True]
E                  [ True  True  True  True  True  True  True  True]]
E                 
E               assert False
E                +  where False = <built-in method all of numpy.ndarray object at 0x7fdd83915630>()
E                +    where <built-in method all of numpy.ndarray object at 0x7fdd83915630> = array([[False,  True,  True,  True,  True,  True,  True,  True],\n       [False,  True,  True,  True,  True,  True,  Tr...se,  True,  True,  True,  True,  True,  True,  True],\n       [False,  True,  True,  True,  True,  True,  True,  True]]).all
E                +      where array([[False,  True,  True,  True,  True,  True,  True,  True],\n       [False,  True,  True,  True,  True,  True,  Tr...se,  True,  True,  True,  True,  True,  True,  True],\n       [False,  True,  True,  True,  True,  True,  True,  True]]) = <function isclose at 0x7fdd7fa2fe50>(array([[0.    , 0.1248, 0.1376, 0.1504, 0.1632, 0.176 , 0.1888, 0.2016],\n       [0.    , 0.3104, 0.3296, 0.3488, 0.368...896, 1.3408, 1.392 , 1.4432, 1.4944, 1.5456],\n       [0.    , 1.424 , 1.4816, 1.5392, 1.5968, 1.6544, 1.712 , 1.7696]]), array([[0.112 , 0.1248, 0.1376, 0.1504, 0.1632, 0.176 , 0.1888, 0.2016],\n       [0.2912, 0.3104, 0.3296, 0.3488, 0.368...896, 1.3408, 1.392 , 1.4432, 1.4944, 1.5456],\n       [1.3664, 1.424 , 1.4816, 1.5392, 1.5968, 1.6544, 1.712 , 1.7696]]))
E                +        where <function isclose at 0x7fdd7fa2fe50> = np.isclose

mlir_graphblas/tests/test_mlir_builder.py:524: AssertionError
---------------------------------------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------------------------------------
Layer 1 of 1 took 0.00 sec

Total time = 0.00 sec

---------- coverage: platform darwin, python 3.8.8-final-0 -----------
Name                                                   Stmts   Miss  Cover   Missing
------------------------------------------------------------------------------------
mlir_graphblas/cli.py                                    117     51    56%   36-40, 104-111, 114-125, 128-132, 140-154, 158-159, 163-179, 194-196
mlir_graphblas/engine.py                                 289     31    89%   28, 32, 97, 117, 140, 176, 185-190, 200, 214, 239-254, 279, 348, 368, 382-387, 418, 533, 569-572, 603
mlir_graphblas/explorer.py                               192    192     0%   1-394
mlir_graphblas/functions.py                              122      6    95%   41, 50, 240, 380, 450, 551
mlir_graphblas/mlir_builder.py                           191      3    98%   163-164, 203
mlir_graphblas/tests/__main__.py                           7      7     0%   1-10
mlir_graphblas/tests/test_jit_engine.py                  110     24    78%   249, 343-353, 366-448
mlir_graphblas/tests/test_mlir_builder.py                266     11    96%   280-294
mlir_graphblas/tests/test_mlir_builder_bad_inputs.py      49      2    96%   9, 94
------------------------------------------------------------------------------------
TOTAL                                                   1666    327    80%

8 files skipped due to complete coverage.
Coverage HTML written to dir htmlcov

========================================================================================== 2 failed, 151 passed, 7 xfailed in 128.18s (0:02:08) ===========================================================================================
(mlirgraphblas) pnguyen@0584:/Users/pnguyen/code/mlir-graphblas$ 
</pre>
</details>