### PR TITLE
Add MatrixApply to lowering-test

### DIFF
--- a/mlir_graphblas/src/lowering-test/MatrixApply.cpp
+++ b/mlir_graphblas/src/lowering-test/MatrixApply.cpp
@@ -61,8 +61,8 @@ void addMatrixApplyFunc(mlir::ModuleOp mod, const std::string &operation)
     auto nnz = builder.create<mlir::IndexCastOp>(loc, nnz64, indexType);
 
     // Loop over values
-    auto valueLoop = builder.create<scf::ForOp>(loc, c0, nnz, c1);
-    auto valueLoopIdx = valueLoop.getInductionVar();
+    auto valueLoop = builder.create<scf::ParallelOp>(loc, c0.getResult(), nnz.getResult(), c1.getResult());
+    auto valueLoopIdx = valueLoop.getInductionVars();
 
     builder.setInsertionPointToStart(valueLoop.getBody());
     auto val = builder.create<memref::LoadOp>(loc, inputValues, valueLoopIdx);

--- a/mlir_graphblas/src/lowering-test/MatrixApply.cpp
+++ b/mlir_graphblas/src/lowering-test/MatrixApply.cpp
@@ -2,7 +2,10 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/SCF.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Verifier.h"
 #include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
@@ -18,22 +21,63 @@ void addMatrixApplyFunc(mlir::ModuleOp mod, const std::string &operation)
 {
     MLIRContext *context = mod.getContext();
     OpBuilder builder(mod.getBodyRegion());
+    auto loc = builder.getUnknownLoc();
 
+    // Types
     auto valueType = builder.getF64Type();
-    RankedTensorType csrTensor = getCSRTensorType(context, valueType);
+    auto i64Type = builder.getI64Type();
+    auto indexType = builder.getIndexType();
+    auto memref1DI64Type = MemRefType::get({-1}, i64Type);
+    auto memref1DValueType = MemRefType::get({-1}, valueType);
+    RankedTensorType csrTensorType = getCSRTensorType(context, valueType);
 
     builder.setInsertionPointToStart(mod.getBody());
 
     // Create function signature
     string func_name = "matrix_apply_" + operation;
-    auto func = builder.create<FuncOp>(builder.getUnknownLoc(),
+    auto func = builder.create<FuncOp>(loc,
                            func_name,
-                           FunctionType::get(context, {csrTensor, valueType}, csrTensor));
+                           FunctionType::get(context, {csrTensorType, valueType}, csrTensorType));
 
     // Move to function body
     auto &entry_block = *func.addEntryBlock();
     builder.setInsertionPointToStart(&entry_block);
 
+    auto input = entry_block.getArgument(0);
+    auto thunk = entry_block.getArgument(1);
+
+    // Initial constants
+    auto c0 = builder.create<ConstantIndexOp>(loc, 0);
+    auto c1 = builder.create<ConstantIndexOp>(loc, 1);
+
+    // Get sparse tensor info
+    auto output = callDupTensor(builder, mod, loc, input).getResult(0);
+    auto inputPtrs = builder.create<ToPointersOp>(loc, memref1DI64Type, input, c1);
+    auto inputValues = builder.create<ToValuesOp>(loc, memref1DValueType, input);
+    auto outputValues = builder.create<ToValuesOp>(loc, memref1DValueType, output);
+
+    auto nrows = builder.create<memref::DimOp>(loc, input, c0.getResult());
+    auto nnz64 = builder.create<memref::LoadOp>(loc, inputPtrs, nrows.getResult());
+    auto nnz = builder.create<mlir::IndexCastOp>(loc, nnz64, indexType);
+
+    // Loop over values
+    auto valueLoop = builder.create<scf::ForOp>(loc, c0, nnz, c1);
+    auto valueLoopIdx = valueLoop.getInductionVar();
+
+    builder.setInsertionPointToStart(valueLoop.getBody());
+    auto val = builder.create<memref::LoadOp>(loc, inputValues, valueLoopIdx);
+
+    Value result;
+    if (operation == "min") {
+        auto cmp = builder.create<mlir::CmpFOp>(loc, mlir::CmpFPredicate::OLT, val, thunk);
+        result = builder.create<mlir::SelectOp>(loc, cmp, val, thunk);
+    };
+
+    builder.create<memref::StoreOp>(loc, result, outputValues, valueLoopIdx);
+
+    // end value loop
+    builder.setInsertionPointAfter(valueLoop);
+
     // Add return op
-    builder.create<ReturnOp>(builder.getUnknownLoc());
+    builder.create<ReturnOp>(loc, output);
 }

--- a/mlir_graphblas/src/lowering-test/lowering.h
+++ b/mlir_graphblas/src/lowering-test/lowering.h
@@ -16,9 +16,10 @@ void addTransposeFunc(mlir::ModuleOp mod, bool swap_sizes);
 // util.cpp
 mlir::RankedTensorType getCSRTensorType(mlir::MLIRContext *context, mlir::FloatType valueType);
 mlir::CallOp callEmptyLike(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc, mlir::Value tensor);
+mlir::CallOp callDupTensor(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc, mlir::Value tensor);
+
 mlir::CallOp callResizeDim(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc,
                            mlir::Value tensor, mlir::Value d, mlir::Value size);
-
 mlir::CallOp callResizePointers(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc,
                                 mlir::Value tensor, mlir::Value d, mlir::Value size);
 mlir::CallOp callResizeIndex(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc,

--- a/mlir_graphblas/src/lowering-test/util.cpp
+++ b/mlir_graphblas/src/lowering-test/util.cpp
@@ -55,6 +55,15 @@ mlir::CallOp callEmptyLike(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::
     return result;
 }
 
+mlir::CallOp callDupTensor(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc, mlir::Value tensor) {
+    auto tensorType = tensor.getType();
+
+    auto func = getFunc(mod, loc, "dup_tensor", tensorType, tensorType);
+    auto result = builder.create<mlir::CallOp>(loc, func, tensorType, tensor);
+
+    return result;
+}
+
 mlir::CallOp callResizeDim(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc,
                            mlir::Value tensor, mlir::Value d, mlir::Value size)
 {


### PR DESCRIPTION
Simplify the existing implementation of matrix_apply by only iterating over the values and applying the function rather than iterating over rows and columns.