### PR TITLE
Make graphblas.matrix_reduce_to_scalar lower into inlined code

### DIFF
--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASPasses.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASPasses.cpp
@@ -38,7 +38,7 @@ public:
   LogicalResult matchAndRewrite(graphblas::TransposeOp op, PatternRewriter &rewriter) const {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
-    
+
     Value inputTensor = op.input();
     Type valueType = inputTensor.getType().dyn_cast<RankedTensorType>().getElementType();
     Type int64Type = rewriter.getIntegerType(64);
@@ -321,106 +321,71 @@ class LowerMatrixReduceToScalarRewrite : public OpRewritePattern<graphblas::Matr
 public:
   using OpRewritePattern<graphblas::MatrixReduceToScalarOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(graphblas::MatrixReduceToScalarOp op, PatternRewriter &rewriter) const {
-    MLIRContext *context = op->getContext();
-    ModuleOp module = op->getParentOfType<ModuleOp>();
+    Value input = op.input();
+    StringRef aggregator = op.aggregator();
     Location loc = rewriter.getUnknownLoc();
 
     RankedTensorType operandType = op.input().getType().dyn_cast<RankedTensorType>();
-    ArrayRef<int64_t> operandShape = operandType.getShape();
     Type valueType = operandType.getElementType();
     Type int64Type = rewriter.getIntegerType(64); // TODO should we get this from the sparse encoding?
     Type indexType = rewriter.getIndexType();
-    RankedTensorType csrTensorType = getCSRTensorType(context, operandShape, valueType);
-    
-    // TODO should this name also account for the dimensions of the input? Or should we fail upon certain dimensions/rank?
-    std::string funcName = "matrix_reduce_to_scalar_";
-    llvm::raw_string_ostream stream(funcName);
-    std::string aggregator = op.aggregator().str();
-    stream <<  aggregator << "_elem_";
-    valueType.print(stream);
-    stream.flush();
-    
-    FuncOp func = module.lookupSymbol<FuncOp>(funcName);
-    if (!func) {
-      OpBuilder moduleBuilder(module.getBodyRegion());
-      
-      FunctionType funcType = FunctionType::get(context, {csrTensorType}, valueType);
-      moduleBuilder.create<FuncOp>(op->getLoc(), funcName, funcType).setPrivate();
-      func = module.lookupSymbol<FuncOp>(funcName);
-      Block &entry_block = *func.addEntryBlock();
-      moduleBuilder.setInsertionPointToStart(&entry_block);
-      BlockArgument input = entry_block.getArgument(0);
-      
-      // Initial constants
-      llvm::Optional<ConstantOp> c0Accumulator = llvm::TypeSwitch<Type, llvm::Optional<ConstantOp>>(valueType)
-        .Case<IntegerType>([&](IntegerType type) {
-                             return moduleBuilder.create<ConstantIntOp>(loc, 0, type.getWidth());
-                           })
-        .Case<FloatType>([&](FloatType type) {
-                           return moduleBuilder.create<ConstantFloatOp>(loc, APFloat(type.getFloatSemantics()), type);
-                         })
-        .Default([&](Type type) { return llvm::None; });
-      if (!c0Accumulator.hasValue()) {
-        return failure(); // TODO test this case
-      }
-      ConstantIndexOp c0 = moduleBuilder.create<ConstantIndexOp>(loc, 0);
-      ConstantIndexOp c1 = moduleBuilder.create<ConstantIndexOp>(loc, 1);
-      
-      // Get sparse tensor info
-      MemRefType memref1DI64Type = MemRefType::get({-1}, int64Type);
-      MemRefType memref1DValueType = MemRefType::get({-1}, valueType);
 
-      memref::DimOp nrows = moduleBuilder.create<memref::DimOp>(loc, input, c0.getResult());
-      sparse_tensor::ToPointersOp inputPtrs = moduleBuilder.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, input, c1);
-      sparse_tensor::ToValuesOp inputValues = moduleBuilder.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, input);
-      memref::LoadOp nnz64 = moduleBuilder.create<memref::LoadOp>(loc, inputPtrs, nrows.getResult());
-      IndexCastOp nnz = moduleBuilder.create<IndexCastOp>(loc, nnz64, indexType);
-
-      // begin loop
-      scf::ParallelOp valueLoop = moduleBuilder.create<scf::ParallelOp>(loc, c0.getResult(), nnz.getResult(), c1.getResult(), c0Accumulator.getValue().getResult());
-      ValueRange valueLoopIdx = valueLoop.getInductionVars();
-
-      moduleBuilder.setInsertionPointToStart(valueLoop.getBody());
-      memref::LoadOp y = moduleBuilder.create<memref::LoadOp>(loc, inputValues, valueLoopIdx);
-
-      scf::ReduceOp reducer = moduleBuilder.create<scf::ReduceOp>(loc, y);
-      BlockArgument lhs = reducer.getRegion().getArgument(0);
-      BlockArgument rhs = reducer.getRegion().getArgument(1);
-
-      moduleBuilder.setInsertionPointToStart(&reducer.getRegion().front());
-
-      llvm::Optional<Value> z;
-      if (aggregator == "sum") {
-         z = llvm::TypeSwitch<Type, llvm::Optional<Value>>(valueType)
-          .Case<IntegerType>([&](IntegerType type) { return moduleBuilder.create<AddIOp>(loc, lhs, rhs).getResult(); })
-          .Case<FloatType>([&](FloatType type) { return moduleBuilder.create<AddFOp>(loc, lhs, rhs).getResult(); })
-          .Default([&](Type type) { return llvm::None; });
-        if (!z.hasValue()) {
-          return failure();
-        }
-      } else {
-        return failure(); // TODO test this
-      }
-      moduleBuilder.create<scf::ReduceReturnOp>(loc, z.getValue());
-
-      moduleBuilder.setInsertionPointAfter(reducer);
-
-      // end loop
-      moduleBuilder.setInsertionPointAfter(valueLoop);
-
-      // Add return op
-      moduleBuilder.create<ReturnOp>(loc, valueLoop.getResult(0));
+    // Initial constants
+    llvm::Optional<ConstantOp> c0Accumulator = llvm::TypeSwitch<Type, llvm::Optional<ConstantOp>>(valueType)
+      .Case<IntegerType>([&](IntegerType type) {
+			   return rewriter.create<ConstantIntOp>(loc, 0, type.getWidth());
+			 })
+      .Case<FloatType>([&](FloatType type) {
+			 return rewriter.create<ConstantFloatOp>(loc, APFloat(type.getFloatSemantics()), type);
+		       })
+      .Default([&](Type type) { return llvm::None; });
+    if (!c0Accumulator.hasValue()) {
+      return failure(); // TODO test this case
     }
-    FlatSymbolRefAttr funcSymbol = SymbolRefAttr::get(context, funcName);
-    
-    Value inputTensor = op.input();
-    CallOp callOp = rewriter.create<CallOp>(loc,
-                                            funcSymbol,
-                                            valueType,
-                                            llvm::ArrayRef<Value>({inputTensor})
-                                            );    
-    rewriter.replaceOp(op, callOp->getResults());
-    
+    ConstantIndexOp c0 = rewriter.create<ConstantIndexOp>(loc, 0);
+    ConstantIndexOp c1 = rewriter.create<ConstantIndexOp>(loc, 1);
+
+    // Get sparse tensor info
+    MemRefType memref1DI64Type = MemRefType::get({-1}, int64Type);
+    MemRefType memref1DValueType = MemRefType::get({-1}, valueType);
+
+    memref::DimOp nrows = rewriter.create<memref::DimOp>(loc, input, c0.getResult());
+    sparse_tensor::ToPointersOp inputPtrs = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, input, c1);
+    sparse_tensor::ToValuesOp inputValues = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, input);
+    memref::LoadOp nnz64 = rewriter.create<memref::LoadOp>(loc, inputPtrs, nrows.getResult());
+    IndexCastOp nnz = rewriter.create<IndexCastOp>(loc, nnz64, indexType);
+
+    // begin loop
+    scf::ParallelOp valueLoop = rewriter.create<scf::ParallelOp>(loc, c0.getResult(), nnz.getResult(), c1.getResult(), c0Accumulator.getValue().getResult());
+    ValueRange valueLoopIdx = valueLoop.getInductionVars();
+
+    rewriter.setInsertionPointToStart(valueLoop.getBody());
+    memref::LoadOp y = rewriter.create<memref::LoadOp>(loc, inputValues, valueLoopIdx);
+
+    scf::ReduceOp reducer = rewriter.create<scf::ReduceOp>(loc, y);
+    BlockArgument lhs = reducer.getRegion().getArgument(0);
+    BlockArgument rhs = reducer.getRegion().getArgument(1);
+
+    rewriter.setInsertionPointToStart(&reducer.getRegion().front());
+
+    llvm::Optional<Value> z;
+    if (aggregator == "sum") {
+      z = llvm::TypeSwitch<Type, llvm::Optional<Value>>(valueType)
+	.Case<IntegerType>([&](IntegerType type) { return rewriter.create<AddIOp>(loc, lhs, rhs).getResult(); })
+	.Case<FloatType>([&](FloatType type) { return rewriter.create<AddFOp>(loc, lhs, rhs).getResult(); })
+	.Default([&](Type type) { return llvm::None; });
+      if (!z.hasValue()) {
+	return failure();
+      }
+    } else {
+      return failure(); // TODO test this
+    }
+    rewriter.create<scf::ReduceReturnOp>(loc, z.getValue());
+
+    rewriter.setInsertionPointAfter(reducer);
+
+    rewriter.replaceOp(op, valueLoop.getResult(0));
+
     return success();
   };
 };
@@ -490,10 +455,10 @@ public:
     // TODO sanity check that the sparse encoding is sane
     // TODO handle the mask
     // TODO there should be a "return failure();" somewhere
-    
+
     MLIRContext *context = op->getContext();
     ModuleOp module = op->getParentOfType<ModuleOp>();
-    
+
     Type valueType = rewriter.getI64Type();
     ArrayRef<int64_t> shape = {-1, -1};
     RankedTensorType csrTensorType = getCSRTensorType(context, shape, valueType);
@@ -506,19 +471,19 @@ public:
       moduleBuilder.create<FuncOp>(op->getLoc(), funcName, funcType).setPrivate();
     }
     FlatSymbolRefAttr funcSymbol = SymbolRefAttr::get(context, funcName);
-    
+
     Value a = op.a();
     Value b = op.b();
     Location loc = rewriter.getUnknownLoc();
-    
+
     CallOp callOp = rewriter.create<CallOp>(loc,
                                             funcSymbol,
                                             csrTensorType,
                                             llvm::ArrayRef<Value>({a, b})
                                             );
-    
+
     rewriter.replaceOp(op, callOp->getResults());
-    
+
     return success();
   };
 };

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_matrix_multiply.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_matrix_multiply.mlir
@@ -84,7 +84,7 @@ module {
 }>
 
 module {
-    func @matrix_multiply_wrapper(%argA: tensor<2x3xi64, #CSR64>, %argB: tensor<3x2xi64, #CSC64>) -> tensor<2x2xi64> {
+    func @matrix_multiply_wrapper(%argA: tensor<2x3xi64, #CSR64>, %argB: tensor<3x2xi64, #CSC64>) -> tensor<2x2xi64, #CSR64> {
         %answer = graphblas.matrix_multiply %argA, %argB { semiring = "BAD_SEMIRING" } : (tensor<2x3xi64, #CSR64>, tensor<3x2xi64, #CSC64>) to tensor<2x2xi64, #CSR64> // expected-error {{"BAD_SEMIRING" is not a supported semiring.}}
         return %answer : tensor<2x2xi64, #CSR64>
     }

--- a/mlir_graphblas/src/test/GraphBLAS/lower_matrix_reduce_to_scalar.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_matrix_reduce_to_scalar.mlir
@@ -1,82 +1,38 @@
 // RUN: graphblas-opt %s | graphblas-opt --graphblas-lower | FileCheck %s
 
-// COM: graphblas.matrix_reduce_to_scalar currently lowers into a function call of an automatically generated private function.
-// COM: These tests do not test the contents of these automatically generated private functions.
-// COM: Testing for these automatically generated private functions should happen elsewhere where we verify their behavior as well.
-
 #CSR64 = #sparse_tensor.encoding<{
   dimLevelType = [ "dense", "compressed" ],
   dimOrdering = affine_map<(i,j) -> (i,j)>,
   pointerBitWidth = 64,
   indexBitWidth = 64
 }>
- 
+
 module {
-    // CHECK: func private @[[HELPER_FUNCTION:.*]](%[[ARG0:.*]]: [[CSR_TYPE:tensor<.*->.*>]]) -> [[RETURN_TYPE:.*]] {
-    // CHECK: func @[[WRAPPER_FUNC_NAME:.*]](%[[ARG0:.*]]: [[CSR_TYPE]]) -> [[RETURN_TYPE]] {
-        // CHECK-NEXT: %[[ANSWER:.*]] = call @[[HELPER_FUNCTION]](%[[ARG0]]) : ([[CSR_TYPE]]) -> [[RETURN_TYPE]]
-        // CHECK-NEXT: return %[[ANSWER]] : [[RETURN_TYPE]]
+    // CHECK-LABEL:   func @matrix_reduce_to_scalar_f64(
+    // CHECK-SAME:                                      %[[VAL_0:.*]]: tensor<?x?xf64, [[CSR:.*->.*]]>) -> f64 {
+    // CHECK:           %[[VAL_1:.*]] = constant 0.000000e+00 : f64
+    // CHECK:           %[[VAL_2:.*]] = constant 0 : index
+    // CHECK:           %[[VAL_3:.*]] = constant 1 : index
+    // CHECK:           %[[VAL_4:.*]] = memref.dim %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, [[CSR]]>
+    // CHECK:           %[[VAL_5:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, [[CSR]]> to memref<?xi64>
+    // CHECK:           %[[VAL_6:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, [[CSR]]> to memref<?xf64>
+    // CHECK:           %[[VAL_7:.*]] = memref.load %[[VAL_5]]{{\[}}%[[VAL_4]]] : memref<?xi64>
+    // CHECK:           %[[VAL_8:.*]] = index_cast %[[VAL_7]] : i64 to index
+    // CHECK:           %[[VAL_9:.*]] = scf.parallel (%[[VAL_10:.*]]) = (%[[VAL_2]]) to (%[[VAL_8]]) step (%[[VAL_3]]) init (%[[VAL_1]]) -> f64 {
+    // CHECK:             %[[VAL_11:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_10]]] : memref<?xf64>
+    // CHECK:             scf.reduce(%[[VAL_11]])  : f64 {
+    // CHECK:             ^bb0(%[[VAL_12:.*]]: f64, %[[VAL_13:.*]]: f64):
+    // CHECK:               %[[VAL_14:.*]] = addf %[[VAL_12]], %[[VAL_13]] : f64
+    // CHECK:               scf.reduce.return %[[VAL_14]] : f64
+    // CHECK:             }
+    // CHECK:             scf.yield
+    // CHECK:           }
+    // CHECK:           return %[[VAL_15:.*]] : f64
+    // CHECK:         }
     func @matrix_reduce_to_scalar_f64(%sparse_tensor: tensor<?x?xf64, #CSR64>) -> f64 {
         %answer = graphblas.matrix_reduce_to_scalar %sparse_tensor { aggregator = "sum" } : tensor<?x?xf64, #CSR64> to f64
         return %answer : f64
     }
 }
- 
-module {
-    // CHECK: func private @[[HELPER_FUNCTION_I1:.*]](%[[ARG0:.*]]: [[TENSOR_TYPE_I1:tensor<.*->.*>]]) -> [[I1_TYPE:.*]] {
-    // CHECK: func private @[[HELPER_FUNCTION_I4:.*]](%[[ARG0:.*]]: [[TENSOR_TYPE_I4:tensor<.*->.*>]]) -> [[I4_TYPE:.*]] {
-    // CHECK: func private @[[HELPER_FUNCTION_I8:.*]](%[[ARG0:.*]]: [[TENSOR_TYPE_I8:tensor<.*->.*>]]) -> [[I8_TYPE:.*]] {
-    // CHECK: func private @[[HELPER_FUNCTION_I16:.*]](%[[ARG0:.*]]: [[TENSOR_TYPE_I16:tensor<.*->.*>]]) -> [[I16_TYPE:.*]] {
-    // CHECK: func private @[[HELPER_FUNCTION_I32:.*]](%[[ARG0:.*]]: [[TENSOR_TYPE_I32:tensor<.*->.*>]]) -> [[I32_TYPE:.*]] {
-    // CHECK: func private @[[HELPER_FUNCTION_I64:.*]](%[[ARG0:.*]]: [[TENSOR_TYPE_I64:tensor<.*->.*>]]) -> [[I64_TYPE:.*]] {
-    // CHECK: func private @[[HELPER_FUNCTION_F16:.*]](%[[ARG0:.*]]: [[TENSOR_TYPE_F16:tensor<.*->.*>]]) -> [[F16_TYPE:.*]] {
-    // CHECK: func private @[[HELPER_FUNCTION_BF16:.*]](%[[ARG0:.*]]: [[TENSOR_TYPE_BF16:tensor<.*->.*>]]) -> [[BF16_TYPE:.*]] {
-    // CHECK: func private @[[HELPER_FUNCTION_F32:.*]](%[[ARG0:.*]]: [[TENSOR_TYPE_F32:tensor<.*->.*>]]) -> [[F32_TYPE:.*]] {
-    // CHECK: func private @[[HELPER_FUNCTION_F64:.*]](%[[ARG0:.*]]: [[TENSOR_TYPE_F64:tensor<.*->.*>]]) -> [[F64_TYPE:.*]] {
-    // CHECK: func private @[[HELPER_FUNCTION_F80:.*]](%[[ARG0:.*]]: [[TENSOR_TYPE_F80:tensor<.*->.*>]]) -> [[F80_TYPE:.*]] {
-    // CHECK: func private @[[HELPER_FUNCTION_F128:.*]](%[[ARG0:.*]]: [[TENSOR_TYPE_F128:tensor<.*->.*>]]) -> [[F128_TYPE:.*]] {
-    
-    // CHECK: func @[[MAIN_FUNC_NAME:.*]](%[[ARG_I1:.*]]: [[TENSOR_TYPE_I1]], %[[ARG_I4:.*]]: [[TENSOR_TYPE_I4]], %[[ARG_I8:.*]]: [[TENSOR_TYPE_I8]], %[[ARG_I16:.*]]: [[TENSOR_TYPE_I16]], %[[ARG_I32:.*]]: [[TENSOR_TYPE_I32]], %[[ARG_I64:.*]]: [[TENSOR_TYPE_I64]], %[[ARG_F16:.*]]: [[TENSOR_TYPE_F16]], %[[ARG_BF16:.*]]: [[TENSOR_TYPE_BF16]], %[[ARG_F32:.*]]: [[TENSOR_TYPE_F32]], %[[ARG_F64:.*]]: [[TENSOR_TYPE_F64]], %[[ARG_F80:.*]]: [[TENSOR_TYPE_F80]], %[[ARG_F128:.*]]: [[TENSOR_TYPE_F128]]) -> ([[I1_TYPE]], [[I4_TYPE]], [[I8_TYPE]], [[I16_TYPE]], [[I32_TYPE]], [[I64_TYPE]], [[F16_TYPE]], [[BF16_TYPE]], [[F32_TYPE]], [[F64_TYPE]], [[F80_TYPE]], [[F128_TYPE]]) {
-        // CHECK-NEXT: %[[ANSWER_I1:.*]] = call @[[HELPER_FUNCTION_I1]](%[[ARG_I1]]) : ([[TENSOR_TYPE_I1]]) -> [[I1_TYPE]]
-        // CHECK-NEXT: %[[ANSWER_I4:.*]] = call @[[HELPER_FUNCTION_I4]](%[[ARG_I4]]) : ([[TENSOR_TYPE_I4]]) -> [[I4_TYPE]]
-        // CHECK-NEXT: %[[ANSWER_I8:.*]] = call @[[HELPER_FUNCTION_I8]](%[[ARG_I8]]) : ([[TENSOR_TYPE_I8]]) -> [[I8_TYPE]]
-        // CHECK-NEXT: %[[ANSWER_I16:.*]] = call @[[HELPER_FUNCTION_I16]](%[[ARG_I16]]) : ([[TENSOR_TYPE_I16]]) -> [[I16_TYPE]]
-        // CHECK-NEXT: %[[ANSWER_I32:.*]] = call @[[HELPER_FUNCTION_I32]](%[[ARG_I32]]) : ([[TENSOR_TYPE_I32]]) -> [[I32_TYPE]]
-        // CHECK-NEXT: %[[ANSWER_I64:.*]] = call @[[HELPER_FUNCTION_I64]](%[[ARG_I64]]) : ([[TENSOR_TYPE_I64]]) -> [[I64_TYPE]]
-        // CHECK-NEXT: %[[ANSWER_F16:.*]] = call @[[HELPER_FUNCTION_F16]](%[[ARG_F16]]) : ([[TENSOR_TYPE_F16]]) -> [[F16_TYPE]]
-        // CHECK-NEXT: %[[ANSWER_BF16:.*]] = call @[[HELPER_FUNCTION_BF16]](%[[ARG_BF16]]) : ([[TENSOR_TYPE_BF16]]) -> [[BF16_TYPE]]
-        // CHECK-NEXT: %[[ANSWER_F32:.*]] = call @[[HELPER_FUNCTION_F32]](%[[ARG_F32]]) : ([[TENSOR_TYPE_F32]]) -> [[F32_TYPE]]
-        // CHECK-NEXT: %[[ANSWER_F64:.*]] = call @[[HELPER_FUNCTION_F64]](%[[ARG_F64]]) : ([[TENSOR_TYPE_F64]]) -> [[F64_TYPE]]
-        // CHECK-NEXT: %[[ANSWER_F80:.*]] = call @[[HELPER_FUNCTION_F80]](%[[ARG_F80]]) : ([[TENSOR_TYPE_F80]]) -> [[F80_TYPE]]
-        // CHECK-NEXT: %[[ANSWER_F128:.*]] = call @[[HELPER_FUNCTION_F128]](%[[ARG_F128]]) : ([[TENSOR_TYPE_F128]]) -> [[F128_TYPE]]
-        // CHECK-NEXT: return %[[ANSWER_I1]], %[[ANSWER_I4]], %[[ANSWER_I8]], %[[ANSWER_I16]], %[[ANSWER_I32]], %[[ANSWER_I64]], %[[ANSWER_F16]], %[[ANSWER_BF16]], %[[ANSWER_F32]], %[[ANSWER_F64]], %[[ANSWER_F80]], %[[ANSWER_F128]] : [[I1_TYPE]], [[I4_TYPE]], [[I8_TYPE]], [[I16_TYPE]], [[I32_TYPE]], [[I64_TYPE]], [[F16_TYPE]], [[BF16_TYPE]], [[F32_TYPE]], [[F64_TYPE]], [[F80_TYPE]], [[F128_TYPE]]
-    // CHECK-NEXT: }
-    func @matrix_reduce_to_scalar_all_types(
-         %sparse_tensor_i1: tensor<?x?xi1, #CSR64>,
-         %sparse_tensor_i4: tensor<?x?xi4, #CSR64>,
-         %sparse_tensor_i8: tensor<?x?xi8, #CSR64>,
-         %sparse_tensor_i16: tensor<?x?xi16, #CSR64>,
-         %sparse_tensor_i32: tensor<?x?xi32, #CSR64>,
-         %sparse_tensor_i64: tensor<?x?xi64, #CSR64>,
-         %sparse_tensor_f16: tensor<?x?xf16, #CSR64>,
-         %sparse_tensor_bf16: tensor<?x?xbf16, #CSR64>,
-         %sparse_tensor_f32: tensor<?x?xf32, #CSR64>,
-         %sparse_tensor_f64: tensor<?x?xf64, #CSR64>,
-         %sparse_tensor_f80: tensor<?x?xf80, #CSR64>,
-         %sparse_tensor_f128: tensor<?x?xf128, #CSR64>
-    ) -> (i1, i4, i8, i16, i32, i64, f16, bf16, f32, f64, f80, f128) {
-         %answer_i1 = graphblas.matrix_reduce_to_scalar %sparse_tensor_i1 { aggregator = "sum" } : tensor<?x?xi1, #CSR64> to i1
-         %answer_i4 = graphblas.matrix_reduce_to_scalar %sparse_tensor_i4 { aggregator = "sum" } : tensor<?x?xi4, #CSR64> to i4
-         %answer_i8 = graphblas.matrix_reduce_to_scalar %sparse_tensor_i8 { aggregator = "sum" } : tensor<?x?xi8, #CSR64> to i8
-         %answer_i16 = graphblas.matrix_reduce_to_scalar %sparse_tensor_i16 { aggregator = "sum" } : tensor<?x?xi16, #CSR64> to i16
-         %answer_i32 = graphblas.matrix_reduce_to_scalar %sparse_tensor_i32 { aggregator = "sum" } : tensor<?x?xi32, #CSR64> to i32
-         %answer_i64 = graphblas.matrix_reduce_to_scalar %sparse_tensor_i64 { aggregator = "sum" } : tensor<?x?xi64, #CSR64> to i64
-         %answer_f16 = graphblas.matrix_reduce_to_scalar %sparse_tensor_f16 { aggregator = "sum" } : tensor<?x?xf16, #CSR64> to f16
-         %answer_bf16 = graphblas.matrix_reduce_to_scalar %sparse_tensor_bf16 { aggregator = "sum" } : tensor<?x?xbf16, #CSR64> to bf16
-         %answer_f32 = graphblas.matrix_reduce_to_scalar %sparse_tensor_f32 { aggregator = "sum" } : tensor<?x?xf32, #CSR64> to f32
-         %answer_f64 = graphblas.matrix_reduce_to_scalar %sparse_tensor_f64 { aggregator = "sum" } : tensor<?x?xf64, #CSR64> to f64
-         %answer_f80 = graphblas.matrix_reduce_to_scalar %sparse_tensor_f80 { aggregator = "sum" } : tensor<?x?xf80, #CSR64> to f80
-         %answer_f128 = graphblas.matrix_reduce_to_scalar %sparse_tensor_f128 { aggregator = "sum" } : tensor<?x?xf128, #CSR64> to f128
-         return %answer_i1, %answer_i4, %answer_i8, %answer_i16, %answer_i32, %answer_i64, %answer_f16, %answer_bf16, %answer_f32, %answer_f64, %answer_f80, %answer_f128 : i1, i4, i8, i16, i32, i64, f16, bf16, f32, f64, f80, f128
-    }
-}
+
+// COM: TODO write tests for all tensor element types


### PR DESCRIPTION
This PR makes `graphblas.matrix_reduce_to_scalar` lower into inlined code rather than a function call. 