### PR TITLE
matrix_select with multiple selectors

### DIFF
--- a/mlir_graphblas/functions.py
+++ b/mlir_graphblas/functions.py
@@ -200,7 +200,7 @@ class MatrixSelect(BaseFunction):
     mlir_template = jinja2.Template(
         """
       func {% if private_func %}private {% endif %}@{{ func_name }}(%input: tensor<?x?xf64, #CSR64>) -> tensor<?x?xf64, #CSR64> {
-        %output = graphblas.matrix_select %input { selector = "{{ selector }}" } : tensor<?x?xf64, #CSR64>
+        %output = graphblas.matrix_select %input { selectors = ["{{ selector }}"] } : tensor<?x?xf64, #CSR64> to tensor<?x?xf64, #CSR64>
         return %output : tensor<?x?xf64, #CSR64>
       }
     """

--- a/mlir_graphblas/ops.py
+++ b/mlir_graphblas/ops.py
@@ -247,7 +247,7 @@ class GraphBLAS_MatrixSelect(BaseOp):
         ret_val = irbuilder.new_var(input.type)
         return ret_val, (
             f"{ret_val.assign} = graphblas.matrix_select {input} "
-            f'{{ selector = "{selector}" }} : {input.type}'
+            f'{{ selectors = ["{selector}"] }} : {input.type} to {input.type}'
         )
 
 

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
@@ -38,21 +38,22 @@ def GraphBLAS_ConvertLayoutOp : GraphBLAS_Op<"convert_layout", [NoSideEffect]> {
 def GraphBLAS_MatrixSelectOp : GraphBLAS_Op<"matrix_select", [NoSideEffect, SameOperandsAndResultType]> {
     let summary = "matrix select operation";
     let description = [{
-        Returns a new sparse tensor with a subset of element from the given matrix.
-        The elements included in the resulting sparse tensor vary depending on the selector given (one of "triu", "tril", or "gt0").
+        Returns new sparse tensor(s) with a subset of element from the given matrix.
+        The elements included in the resulting sparse tensor vary depending on the selectors given (one of "triu", "tril", or "gt0").
+        Multiple selectors may be given, in which case multiple results will be returned
         The given sparse tensor must be a matrix, i.e. have rank 2.
         The given tensor must have a CSR sparsity or a CSC sparsity.
-        The resulting sparse tensor will have the same sparsity as the given sparse tensor.
+        The resulting sparse tensors will have the same sparsity as the given sparse tensor.
 
         Example:
-        ```%answer = graphblas.matrix_select %sparse_tensor { selector = "triu" } : tensor<100x100xf64, #CSR64>```
+        ```%answer = graphblas.matrix_select %sparse_tensor { selectors = ["triu"] } : tensor<100x100xf64, #CSR64> to tensor<100x100xf64, #CSR64>```
     }];
 
-    let arguments = (ins AnyTensor:$input, StrAttr:$selector);
-    let results = (outs AnyTensor:$output);
+    let arguments = (ins AnyTensor:$input, StrArrayAttr:$selectors);
+    let results = (outs Variadic<AnyTensor>:$outputs);
     
     let assemblyFormat = [{
-           $input attr-dict `:` type($input)
+           $input attr-dict `:` type($input) `to` type($outputs)
     }];
 }
 

--- a/mlir_graphblas/src/test/GraphBLAS/check_ops.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/check_ops.mlir
@@ -30,24 +30,24 @@ module {
 
     // CHECK: func @matrix_select_triu(%[[ARG0:.*]]: [[CSR_TYPE:tensor<.*->.*>]]) -> [[CSR_TYPE]] {
     func @matrix_select_triu(%sparse_tensor: tensor<100x100xf64, #CSR64>) -> tensor<100x100xf64, #CSR64> {
-        // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.matrix_select %[[ARG0]] {selector = "triu"} : [[CSR_TYPE]]
-        %answer = graphblas.matrix_select %sparse_tensor { selector = "triu" } : tensor<100x100xf64, #CSR64>
+        // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.matrix_select %[[ARG0]] {selectors = ["triu"]} : [[CSR_TYPE]]
+        %answer = graphblas.matrix_select %sparse_tensor { selectors = ["triu"] } : tensor<100x100xf64, #CSR64> to tensor<100x100xf64, #CSR64>
         // CHECK-NEXT: return %[[ANSWER]] : [[CSR_TYPE]]
         return %answer : tensor<100x100xf64, #CSR64>
     }
 
     // CHECK: func @matrix_select_tril(%[[ARG0:.*]]: [[CSR_TYPE:tensor<.*->.*>]]) -> [[CSR_TYPE]] {
     func @matrix_select_tril(%sparse_tensor: tensor<100x100xf64, #CSR64>) -> tensor<100x100xf64, #CSR64> {
-        // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.matrix_select %[[ARG0]] {selector = "tril"} : [[CSR_TYPE]]
-        %answer = graphblas.matrix_select %sparse_tensor { selector = "tril" } : tensor<100x100xf64, #CSR64>
+        // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.matrix_select %[[ARG0]] {selectors = ["tril"]} : [[CSR_TYPE]]
+        %answer = graphblas.matrix_select %sparse_tensor { selectors = ["tril"] } : tensor<100x100xf64, #CSR64> to tensor<100x100xf64, #CSR64>
         // CHECK-NEXT: return %[[ANSWER]] : [[CSR_TYPE]]
         return %answer : tensor<100x100xf64, #CSR64>
     }
 
     // CHECK: func @matrix_select_gt0(%[[ARG0:.*]]: [[CSR_TYPE:tensor<.*->.*>]]) -> [[CSR_TYPE]] {
     func @matrix_select_gt0(%sparse_tensor: tensor<100x100xf64, #CSR64>) -> tensor<100x100xf64, #CSR64> {
-        // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.matrix_select %[[ARG0]] {selector = "gt0"} : [[CSR_TYPE]]
-        %answer = graphblas.matrix_select %sparse_tensor { selector = "gt0" } : tensor<100x100xf64, #CSR64>
+        // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.matrix_select %[[ARG0]] {selectors = ["gt0"]} : [[CSR_TYPE]]
+        %answer = graphblas.matrix_select %sparse_tensor { selectors = ["gt0"] } : tensor<100x100xf64, #CSR64> to tensor<100x100xf64, #CSR64>
         // CHECK-NEXT: return %[[ANSWER]] : [[CSR_TYPE]]
         return %answer : tensor<100x100xf64, #CSR64>
     }

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_matrix_select.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_matrix_select.mlir
@@ -11,7 +11,7 @@
 
 module {
     func @matrix_select_wrapper(%sparse_tensor: tensor<2x3xbf16>) -> tensor<2x3xbf16> {
-        %answer = graphblas.matrix_select %sparse_tensor { selector = "min" } : tensor<2x3xbf16> // expected-error {{Return value must be a sparse tensor.}}
+        %answer = graphblas.matrix_select %sparse_tensor { selectors = ["min"] } : tensor<2x3xbf16> to tensor<2x3xbf16> // expected-error {{Return value must be a sparse tensor.}}
         return %answer : tensor<2x3xbf16>
     }
 }
@@ -27,7 +27,7 @@ module {
 
 module {
     func @matrix_select_wrapper(%sparse_tensor: tensor<2x3xi8, #CSR64>) -> tensor<2x3xi8, #CSR64> {
-        %answer = graphblas.matrix_select %sparse_tensor { selector = "BADSELECTOR" } : tensor<2x3xi8, #CSR64> // expected-error {{"BADSELECTOR" is not a supported selector.}}
+        %answer = graphblas.matrix_select %sparse_tensor { selectors = ["BADSELECTOR"] } : tensor<2x3xi8, #CSR64> to tensor<2x3xi8, #CSR64> // expected-error {{"BADSELECTOR" is not a supported selector.}}
         return %answer : tensor<2x3xi8, #CSR64>
     }
 }

--- a/mlir_graphblas/src/test/GraphBLAS/lower_select_gt0.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_select_gt0.mlir
@@ -32,12 +32,12 @@
 // CHECK:             %[[VAL_20:.*]] = index_cast %[[VAL_18]] : i64 to index
 // CHECK:             %[[VAL_21:.*]] = index_cast %[[VAL_19]] : i64 to index
 // CHECK:             scf.for %[[VAL_22:.*]] = %[[VAL_20]] to %[[VAL_21]] step %[[VAL_2]] {
+// CHECK:               %[[VAL_27:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_22]]] : memref<?xi64>
 // CHECK:               %[[VAL_23:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_22]]] : memref<?xf64>
 // CHECK:               %[[VAL_24:.*]] = cmpf ogt, %[[VAL_23]], %[[VAL_5]] : f64
 // CHECK:               scf.if %[[VAL_24]] {
 // CHECK:                 %[[VAL_25:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:                 %[[VAL_26:.*]] = index_cast %[[VAL_25]] : i64 to index
-// CHECK:                 %[[VAL_27:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_22]]] : memref<?xi64>
 // CHECK:                 memref.store %[[VAL_27]], %[[VAL_13]]{{\[}}%[[VAL_26]]] : memref<?xi64>
 // CHECK:                 memref.store %[[VAL_23]], %[[VAL_14]]{{\[}}%[[VAL_26]]] : memref<?xf64>
 // CHECK:                 %[[VAL_28:.*]] = addi %[[VAL_25]], %[[VAL_4]] : i64
@@ -53,6 +53,6 @@
 // CHECK:         }
 
 func @select_gt0(%sparse_tensor: tensor<?x?xf64, #CSR64>) -> tensor<?x?xf64, #CSR64> {
-    %answer = graphblas.matrix_select %sparse_tensor { selector = "gt0" } : tensor<?x?xf64, #CSR64>
+    %answer = graphblas.matrix_select %sparse_tensor { selectors = ["gt0"] } : tensor<?x?xf64, #CSR64> to tensor<?x?xf64, #CSR64>
     return %answer : tensor<?x?xf64, #CSR64>
 }

--- a/mlir_graphblas/src/test/GraphBLAS/lower_select_multi.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_select_multi.mlir
@@ -1,0 +1,18 @@
+// RUN: graphblas-opt %s | graphblas-opt --graphblas-lower | FileCheck %s
+
+#CSR64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "dense", "compressed" ],
+  dimOrdering = affine_map<(i,j) -> (i,j)>,
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+
+// CHECK:               %[[VAL_35:.*]] = cmpf ogt, %[[VAL_34:.*]], %[[VAL_5:.*]] : f64
+// CHECK:               %[[VAL_39:.*]] = cmpi ugt, %[[VAL_33:.*]], %[[VAL_22:.*]] : index
+// CHECK:               %[[VAL_43:.*]] = cmpi ult, %[[VAL_33:.*]], %[[VAL_22:.*]] : index
+// CHECK:           return %[[VAL_10:.*]], %[[VAL_14:.*]], %[[VAL_18:.*]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+func @select_multi(%sparse_tensor: tensor<?x?xf64, #CSR64>) -> (tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSR64>) {
+    %answer1, %answer2, %answer3 = graphblas.matrix_select %sparse_tensor { selectors = ["gt0", "triu", "tril"] } : tensor<?x?xf64, #CSR64> to tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSR64>
+    return %answer1, %answer2, %answer3 : tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSR64>
+}

--- a/mlir_graphblas/src/test/GraphBLAS/lower_select_tril.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_select_tril.mlir
@@ -33,12 +33,12 @@
 // CHECK:             scf.for %[[VAL_22:.*]] = %[[VAL_20]] to %[[VAL_21]] step %[[VAL_2]] {
 // CHECK:               %[[VAL_23:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_22]]] : memref<?xi64>
 // CHECK:               %[[VAL_24:.*]] = index_cast %[[VAL_23]] : i64 to index
+// CHECK:               %[[VAL_28:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_22]]] : memref<?xf64>
 // CHECK:               %[[VAL_25:.*]] = cmpi ult, %[[VAL_24]], %[[VAL_15]] : index
 // CHECK:               scf.if %[[VAL_25]] {
 // CHECK:                 %[[VAL_26:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:                 %[[VAL_27:.*]] = index_cast %[[VAL_26]] : i64 to index
 // CHECK:                 memref.store %[[VAL_23]], %[[VAL_13]]{{\[}}%[[VAL_27]]] : memref<?xi64>
-// CHECK:                 %[[VAL_28:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_22]]] : memref<?xf64>
 // CHECK:                 memref.store %[[VAL_28]], %[[VAL_14]]{{\[}}%[[VAL_27]]] : memref<?xf64>
 // CHECK:                 %[[VAL_29:.*]] = addi %[[VAL_26]], %[[VAL_4]] : i64
 // CHECK:                 memref.store %[[VAL_29]], %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
@@ -53,6 +53,6 @@
 // CHECK:         }
 
 func @select_tril(%sparse_tensor: tensor<?x?xf64, #CSR64>) -> tensor<?x?xf64, #CSR64> {
-    %answer = graphblas.matrix_select %sparse_tensor { selector = "tril" } : tensor<?x?xf64, #CSR64>
+    %answer = graphblas.matrix_select %sparse_tensor { selectors = ["tril"] } : tensor<?x?xf64, #CSR64> to tensor<?x?xf64, #CSR64>
     return %answer : tensor<?x?xf64, #CSR64>
 }

--- a/mlir_graphblas/src/test/GraphBLAS/lower_select_triu.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_select_triu.mlir
@@ -33,12 +33,12 @@
 // CHECK:             scf.for %[[VAL_22:.*]] = %[[VAL_20]] to %[[VAL_21]] step %[[VAL_2]] {
 // CHECK:               %[[VAL_23:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_22]]] : memref<?xi64>
 // CHECK:               %[[VAL_24:.*]] = index_cast %[[VAL_23]] : i64 to index
+// CHECK:               %[[VAL_28:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_22]]] : memref<?xf64>
 // CHECK:               %[[VAL_25:.*]] = cmpi ugt, %[[VAL_24]], %[[VAL_15]] : index
 // CHECK:               scf.if %[[VAL_25]] {
 // CHECK:                 %[[VAL_26:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:                 %[[VAL_27:.*]] = index_cast %[[VAL_26]] : i64 to index
 // CHECK:                 memref.store %[[VAL_23]], %[[VAL_13]]{{\[}}%[[VAL_27]]] : memref<?xi64>
-// CHECK:                 %[[VAL_28:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_22]]] : memref<?xf64>
 // CHECK:                 memref.store %[[VAL_28]], %[[VAL_14]]{{\[}}%[[VAL_27]]] : memref<?xf64>
 // CHECK:                 %[[VAL_29:.*]] = addi %[[VAL_26]], %[[VAL_4]] : i64
 // CHECK:                 memref.store %[[VAL_29]], %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
@@ -53,7 +53,7 @@
 // CHECK:         }
 
 func @select_triu(%sparse_tensor: tensor<?x?xf64, #CSR64>) -> tensor<?x?xf64, #CSR64> {
-    %answer = graphblas.matrix_select %sparse_tensor { selector = "triu" } : tensor<?x?xf64, #CSR64>
+    %answer = graphblas.matrix_select %sparse_tensor { selectors = ["triu"] } : tensor<?x?xf64, #CSR64> to tensor<?x?xf64, #CSR64>
     return %answer : tensor<?x?xf64, #CSR64>
 }
 


### PR DESCRIPTION
This PR changes the definition of the `matrix_select` op to take a `selectors` (note the plural) attribute list, which contains the strings expected by `matrix_select` already.  (`gt0`, `triu`, `tril`).  The op now returns 1 or more values depending on how long the list is.  The generated code will loop through the input array once, and populate the output arrays as needed.  In the case of a single selector, the generated code is nearly identical to before.  (one load operation is moved out of an if statement into the enclosing loop)

Marked WIP because this current implementation is pretty ugly, but passes tests.