### PR TITLE
Make functions.py use the graphblas dialect.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,14 @@
+import os
 import distutils.core
+import subprocess
 
 
 def pytest_configure(config):
     distutils.core.run_setup(
         "./setup.py", script_args=["build_ext", "--inplace"], stop_after="run"
     )
+
+    # Ensure graphblas-opt is built
+    subprocess.run(["python", os.path.join("mlir_graphblas", "src", "build.py")])
+
     return

--- a/continuous_integration/conda/meta.yaml
+++ b/continuous_integration/conda/meta.yaml
@@ -40,6 +40,7 @@ test:
     - coverage
 
   commands:
+    - python -c "import mlir_graphblas"
     - pytest --pyargs mlir_graphblas.tests
 
 about:

--- a/continuous_integration/environment.yml
+++ b/continuous_integration/environment.yml
@@ -22,3 +22,7 @@ dependencies:
   - pygments
   - cython
   - jinja2
+# temp restrictions until graphblas-opt is built in setup.py
+  - cmake>=3.13.4
+  - ninja
+  - lit

--- a/mlir_graphblas/SparseUtils.cpp
+++ b/mlir_graphblas/SparseUtils.cpp
@@ -754,6 +754,12 @@ void *ptr8_to_tensor(void *tensor) {
 void *tensor_to_ptr8(void *tensor) {
     return tensor;
 }
+void *cast_csr_to_csc(void *tensor) {
+    return tensor;
+}
+void *cast_csc_to_csr(void *tensor) {
+    return tensor;
+}
 void *empty_like(void *tensor) {
     return static_cast<SparseTensorStorageBase *>(tensor)->empty_like();
 }

--- a/mlir_graphblas/cli.py
+++ b/mlir_graphblas/cli.py
@@ -13,6 +13,19 @@ def logged_subprocess_run(*args, **kwargs):
     return subprocess.run(*args, **kwargs)
 
 
+try:
+    # when running in developer mode
+    from . import src
+
+    _SCRIPT_DIR = os.path.dirname(__file__)
+    _BUILD_DIR = os.path.join(_SCRIPT_DIR, "src", "build")
+    GRAPHBLAS_OPT_EXE = os.path.join(_BUILD_DIR, "bin", "graphblas-opt")
+except ImportError:
+    # ImportError assumes a normal install without a src directory, so graphblas-opt should
+    # be available in the /bin folder of the environment
+    GRAPHBLAS_OPT_EXE = "graphblas-opt"
+
+
 class MlirOptError(Exception):
     pass
 
@@ -24,7 +37,7 @@ class MlirOptCli:
         if executable is None:
             from . import config
 
-            executable = config.get("cli.executable", "mlir-opt")
+            executable = config.get("cli.executable", GRAPHBLAS_OPT_EXE)
         self._executable = executable
         if options is None:
             options = []

--- a/mlir_graphblas/mlir_builder.py
+++ b/mlir_graphblas/mlir_builder.py
@@ -8,6 +8,7 @@ An IR builder for MLIR.
 
 import jinja2
 import mlir
+import itertools
 from contextlib import contextmanager
 from collections import OrderedDict
 from .sparse_utils import MLIRSparseTensor
@@ -144,7 +145,7 @@ class MLIRFunctionBuilder(BaseFunction):
         self.input_vars = input_vars
         self.return_types = return_types
 
-        self.var_name_counter = 0
+        self.var_name_counter = itertools.count()
         self.function_body_statements: List[str] = []
 
         # function_name -> (function_mlir_definition, input_mlir_types, return_mlir_type)
@@ -194,6 +195,7 @@ class MLIRFunctionBuilder(BaseFunction):
         return
 
     def add_statement(self, statement: str) -> None:
+        """In an ideal world, no human would ever call this method."""
         for line in map(str.strip, statement.split("\n")):
             self.function_body_statements.append(
                 " " * self.default_indentation_size
@@ -203,8 +205,7 @@ class MLIRFunctionBuilder(BaseFunction):
         return
 
     def new_var(self, *var_types: str) -> MLIRVar:
-        var_name = f"var_{self.var_name_counter}"
-        self.var_name_counter += 1
+        var_name = f"var_{next(self.var_name_counter)}"
         return MLIRVar(var_name, *var_types)
 
     #########################

--- a/mlir_graphblas/sparse_utils.pyx
+++ b/mlir_graphblas/sparse_utils.pyx
@@ -187,6 +187,8 @@ cdef extern from "SparseUtils.cpp" nogil:
     void *dup_tensor(void *tensor)
     void *ptr8_to_tensor(void *tensor)
     void *tensor_to_ptr8(void *tensor)
+    void *cast_csr_to_csc(void *tensor)
+    void *cast_csc_to_csr(void *tensor)
     void *empty_like(void *tensor)
     void *empty(void *tensor, uint64_t ndims)
 

--- a/mlir_graphblas/src/graphblas-opt/graphblas-opt.cpp
+++ b/mlir_graphblas/src/graphblas-opt/graphblas-opt.cpp
@@ -26,13 +26,11 @@ int main(int argc, char **argv) {
 
   mlir::DialectRegistry registry;
   registry.insert<mlir::graphblas::GraphBLASDialect>();
-  registry.insert<mlir::StandardOpsDialect>();
-  registry.insert<mlir::sparse_tensor::SparseTensorDialect>();
   
   // Add the following to include *all* MLIR Core dialects, or selectively
   // include what you need like above. You only need to register dialects that
   // will be *parsed* by the tool, not the one generated
-  // registerAllDialects(registry);
+  registerAllDialects(registry);
 
   return failed(
       mlir::MlirOptMain(argc, argv, "GraphBLAS optimizer driver\n", registry));

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
@@ -8,9 +8,13 @@
 #include "llvm/ADT/APInt.h"
 
 
+bool typeIsCSR(mlir::Type inputType);
+bool typeIsCSC(mlir::Type inputType);
 mlir::RankedTensorType getCSRTensorType(mlir::MLIRContext *context, llvm::ArrayRef<int64_t> shape, mlir::Type valueType);
 mlir::RankedTensorType getCSCTensorType(mlir::MLIRContext *context, llvm::ArrayRef<int64_t> shape, mlir::Type valueType);
 
+mlir::Value convertToExternalCSR(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc, mlir::Value input);
+mlir::Value convertToExternalCSC(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc, mlir::Value input);
 mlir::Value callEmptyLike(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc, mlir::Value tensor);
 mlir::Value callDupTensor(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc, mlir::Value tensor);
 

--- a/mlir_graphblas/src/test/GraphBLAS/lower_convert_layout.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_convert_layout.mlir
@@ -13,7 +13,14 @@
   pointerBitWidth = 64,
   indexBitWidth = 64
 }>
- 
+
+// CHECK-LABEL:   func private @resize_values(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index)
+// CHECK:         func private @resize_index(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
+// CHECK:         func private @resize_pointers(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
+// CHECK:         func private @resize_dim(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
+// CHECK:         func private @cast_csr_to_csc(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:         func private @empty_like(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:         func private @cast_csc_to_csr(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 
 // CHECK-LABEL:   func @convert_layout(
 // CHECK-SAME:                         %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
@@ -85,8 +92,8 @@
 // CHECK:             memref.store %[[VAL_44]], %[[VAL_14]]{{\[}}%[[VAL_9]]] : memref<?xi64>
 // CHECK:           }
 // CHECK:           memref.store %[[VAL_42]], %[[VAL_14]]{{\[}}%[[VAL_9]]] : memref<?xi64>
-// CHECK:           %[[VAL_50:.*]] = tensor.cast %[[VAL_13]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           return %[[VAL_50]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_46:.*]] = call @cast_csr_to_csc(%[[VAL_13]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           return %[[VAL_46]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
 
 func @convert_layout(%sparse_tensor: tensor<?x?xf64, #CSR64>) -> tensor<?x?xf64, #CSC64> {

--- a/mlir_graphblas/tests/jit_engine_test_utils.py
+++ b/mlir_graphblas/tests/jit_engine_test_utils.py
@@ -3,6 +3,20 @@ from mlir_graphblas.sparse_utils import MLIRSparseTensor
 
 from typing import Sequence
 
+GRAPHBLAS_PASSES = [
+    "--graphblas-lower",
+    "--sparsification",
+    "--sparse-tensor-conversion",
+    "--linalg-bufferize",
+    "--func-bufferize",
+    "--tensor-bufferize",
+    "--tensor-constant-bufferize",
+    "--finalizing-bufferize",
+    "--convert-linalg-to-loops",
+    "--convert-scf-to-std",
+    "--convert-std-to-llvm",
+]
+
 STANDARD_PASSES = [
     "--sparsification",
     "--sparse-tensor-conversion",

--- a/mlir_graphblas/tests/test_algorithms.py
+++ b/mlir_graphblas/tests/test_algorithms.py
@@ -50,3 +50,5 @@ def test_triangle_count():
 
     num_triangles = mlalgo.triangle_count_combined(a)
     assert num_triangles == 5, num_triangles
+
+    return

--- a/mlir_graphblas/tests/test_mlir_builder.py
+++ b/mlir_graphblas/tests/test_mlir_builder.py
@@ -8,13 +8,13 @@ from mlir_graphblas import MlirJitEngine
 from mlir_graphblas.engine import parse_mlir_string
 from mlir_graphblas.sparse_utils import MLIRSparseTensor
 from mlir_graphblas.mlir_builder import MLIRVar, MLIRFunctionBuilder
-from mlir_graphblas.functions import Transpose
+from mlir_graphblas.functions import ConvertLayout
 from mlir_graphblas.algorithms import (
     triangle_count_combined,
     dense_neural_network_combined,
 )
 
-from .jit_engine_test_utils import sparsify_array
+from .jit_engine_test_utils import sparsify_array, GRAPHBLAS_PASSES
 
 from typing import List, Callable
 
@@ -29,7 +29,7 @@ def engine():
 
     jit_engine.add(
         """
-#trait_densify = {
+#trait_densify_csr = {
   indexing_maps = [
     affine_map<(i,j) -> (i,j)>,
     affine_map<(i,j) -> (i,j)>
@@ -37,17 +37,43 @@ def engine():
   iterator_types = ["parallel", "parallel"]
 }
 
-#sparseTensor = #sparse_tensor.encoding<{
+#CSR64 = #sparse_tensor.encoding<{
   dimLevelType = [ "dense", "compressed" ],
   dimOrdering = affine_map<(i,j) -> (i,j)>,
   pointerBitWidth = 64,
   indexBitWidth = 64
 }>
 
-func @densify(%argA: tensor<8x8xf64, #sparseTensor>) -> tensor<8x8xf64> {
+func @csr_densify8x8(%argA: tensor<8x8xf64, #CSR64>) -> tensor<8x8xf64> {
   %output_storage = constant dense<0.0> : tensor<8x8xf64>
-  %0 = linalg.generic #trait_densify
-    ins(%argA: tensor<8x8xf64, #sparseTensor>)
+  %0 = linalg.generic #trait_densify_csr
+    ins(%argA: tensor<8x8xf64, #CSR64>)
+    outs(%output_storage: tensor<8x8xf64>) {
+      ^bb(%A: f64, %x: f64):
+        linalg.yield %A : f64
+    } -> tensor<8x8xf64>
+  return %0 : tensor<8x8xf64>
+}
+
+#trait_densify_csc = {
+  indexing_maps = [
+    affine_map<(i,j) -> (j,i)>,
+    affine_map<(i,j) -> (i,j)>
+  ],
+  iterator_types = ["parallel", "parallel"]
+}
+
+#CSC64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "dense", "compressed" ],
+  dimOrdering = affine_map<(i,j) -> (j,i)>,
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+func @csc_densify8x8(%argA: tensor<8x8xf64, #CSC64>) -> tensor<8x8xf64> {
+  %output_storage = constant dense<0.0> : tensor<8x8xf64>
+  %0 = linalg.generic #trait_densify_csc
+    ins(%argA: tensor<8x8xf64, #CSC64>)
     outs(%output_storage: tensor<8x8xf64>) {
       ^bb(%A: f64, %x: f64):
         linalg.yield %A : f64
@@ -55,41 +81,31 @@ func @densify(%argA: tensor<8x8xf64, #sparseTensor>) -> tensor<8x8xf64> {
   return %0 : tensor<8x8xf64>
 }
 """,
-        [
-            "--sparsification",
-            "--sparse-tensor-conversion",
-            "--linalg-bufferize",
-            "--convert-scf-to-std",
-            "--func-bufferize",
-            "--tensor-bufferize",
-            "--tensor-constant-bufferize",
-            "--finalizing-bufferize",
-            "--convert-linalg-to-loops",
-            "--convert-scf-to-std",
-            "--convert-std-to-llvm",
-        ],
+        GRAPHBLAS_PASSES,
     )
     return jit_engine
 
 
-def test_ir_builder_transpose_wrapper(engine: MlirJitEngine):
+def test_ir_builder_convert_layout_wrapper(engine: MlirJitEngine):
     # Build Function
-    transpose_function = Transpose()
+    convert_layout_function = ConvertLayout()
 
     input_var = MLIRVar("input_tensor", "tensor<?x?xf64, #CSR64>")
 
     ir_builder = MLIRFunctionBuilder(
-        "transpose_wrapper",
+        "convert_layout_wrapper",
         input_vars=[input_var],
-        return_types=("tensor<?x?xf64, #CSR64>",),
+        return_types=("tensor<?x?xf64, #CSC64>",),
     )
-    transpose_result = ir_builder.call(transpose_function, input_var)
-    ir_builder.return_vars(transpose_result)
+    convert_layout_result = ir_builder.call(convert_layout_function, input_var)
+    ir_builder.return_vars(convert_layout_result)
 
     assert ir_builder.get_mlir()
 
     # Test Compiled Function
-    transpose_wrapper_callable = ir_builder.compile(engine=engine)
+    convert_layout_wrapper_callable = ir_builder.compile(
+        engine=engine, passes=GRAPHBLAS_PASSES
+    )
 
     indices = np.array(
         [
@@ -107,62 +123,59 @@ def test_ir_builder_transpose_wrapper(engine: MlirJitEngine):
     dense_input_tensor = np.zeros([8, 8], dtype=np.float64)
     dense_input_tensor[1, 2] = 1.2
     dense_input_tensor[4, 3] = 4.3
-    assert np.isclose(dense_input_tensor, engine.densify(input_tensor)).all()
+    assert np.isclose(dense_input_tensor, engine.csr_densify8x8(input_tensor)).all()
 
-    output_tensor = transpose_wrapper_callable(input_tensor)
+    output_tensor = convert_layout_wrapper_callable(input_tensor)
 
-    assert np.isclose(
-        dense_input_tensor, engine.densify(input_tensor)
-    ).all(), f"{input_tensor} values unexpectedly changed."
-    assert np.isclose(dense_input_tensor.T, engine.densify(output_tensor)).all()
+    assert np.isclose(dense_input_tensor, engine.csc_densify8x8(output_tensor)).all()
 
     return
 
 
-def test_ir_builder_triple_transpose(engine: MlirJitEngine):
+def test_ir_builder_triple_convert_layout(engine: MlirJitEngine):
     # Build Function
 
     input_var = MLIRVar("input_tensor", "tensor<?x?xf64, #CSR64>")
 
     ir_builder = MLIRFunctionBuilder(
-        "triple_transpose",
+        "triple_convert_layout",
         input_vars=(input_var,),
-        return_types=["tensor<?x?xf64, #CSR64>"],
+        return_types=["tensor<?x?xf64, #CSC64>"],
     )
-    # Use different instances of Tranpose to ideally get exactly one transpose helper in the final MLIR text
-    inter1 = ir_builder.call(Transpose(), input_var)
-    inter2 = ir_builder.call(Transpose(), inter1)
-    return_var = ir_builder.call(Transpose(), inter2)
+    # Use different instances of Tranpose to ideally get exactly one convert_layout helper in the final MLIR text
+    inter1 = ir_builder.call(ConvertLayout("csc"), input_var)
+    inter2 = ir_builder.call(ConvertLayout("csr"), inter1)
+    return_var = ir_builder.call(ConvertLayout("csc"), inter2)
     ir_builder.return_vars(return_var)
 
     mlir_text = ir_builder.get_mlir(make_private=False)
     ast = parse_mlir_string(mlir_text)
     # verify there are exactly two functions
-    private_func, public_func = [
-        node for node in ast.body if isinstance(node, mlir.astnodes.Function)
-    ]
-    assert private_func.name.value == "transpose"
-    assert private_func.visibility == "private"
-    assert public_func.name.value == "triple_transpose"
-    assert public_func.visibility == "public"
+    functions = [node for node in ast.body if isinstance(node, mlir.astnodes.Function)]
+    triple_convert_func = functions.pop(-1)
+    assert triple_convert_func.visibility == "public"
+    assert all(
+        func.name.value.startswith("convert_layout_cs") and func.visibility == "private"
+        for func in functions
+        if func.name.value == "triple_convert_layout"
+    )
 
-    # verify in_place_triple_transpose has three transpose calls
-    region = public_func.body
+    # verify in_place_triple_convert_layout has three convert_layout calls
+    region = triple_convert_func.body
     (block,) = region.body
     call_op_1, call_op_2, call_op_3, return_op = block.body
-    assert (
-        call_op_1.op.func.value
-        == call_op_2.op.func.value
-        == call_op_3.op.func.value
-        == "transpose"
-    )
+    assert call_op_1.op.func.value == "convert_layout_to_csc"
+    assert call_op_2.op.func.value == "convert_layout_to_csr"
+    assert call_op_3.op.func.value == "convert_layout_to_csc"
     (return_op_type,) = [
         t for t in mlir.dialects.standard.ops if t.__name__ == "ReturnOperation"
     ]
     assert isinstance(return_op.op, return_op_type)
 
     # Test Compiled Function
-    triple_transpose_callable = ir_builder.compile(engine=engine)
+    triple_convert_layout_callable = ir_builder.compile(
+        engine=engine, passes=GRAPHBLAS_PASSES
+    )
 
     indices = np.array(
         [
@@ -180,14 +193,11 @@ def test_ir_builder_triple_transpose(engine: MlirJitEngine):
     dense_input_tensor = np.zeros([8, 8], dtype=np.float64)
     dense_input_tensor[1, 2] = 1.2
     dense_input_tensor[4, 3] = 4.3
-    assert np.isclose(dense_input_tensor, engine.densify(input_tensor)).all()
+    assert np.isclose(dense_input_tensor, engine.csr_densify8x8(input_tensor)).all()
 
-    transposed_tensor = triple_transpose_callable(input_tensor)
+    output_tensor = triple_convert_layout_callable(input_tensor)
 
-    assert np.isclose(
-        dense_input_tensor, engine.densify(input_tensor)
-    ).all(), f"{input_tensor} values unexpectedly changed."
-    assert np.isclose(dense_input_tensor.T, engine.densify(transposed_tensor)).all()
+    assert np.isclose(dense_input_tensor, engine.csc_densify8x8(output_tensor)).all()
 
     return
 
@@ -496,7 +506,7 @@ def test_ir_builder_dnn(
             sparse_input_tensor,
             clamp_threshold,
         )
-        dense_result = engine.densify(sparse_result)
+        dense_result = engine.csr_densify8x8(sparse_result)
 
         with np.printoptions(suppress=True):
             assert np.isclose(


### PR DESCRIPTION
The changes include:
- Rename `mlir_graphblas.algorithms.Transpose` &#8594; `mlir_graphblas.algorithms.ConvertLayout`.
- Make `algorithms.py` use `graphblas-opt` instead of `mlir-opt`.
- Change the signature of `MlirJitEngine`'s constructor. Mostly make it take more parameters.
- Make `graphblas-opt` use the helper functions `cast_csr_to_csc` and `cast_csc_to_csr` since MLIR's `tensor.cast` doesn't (always) work with sparse tensors. This is a sort of work around. 