### PR TITLE
Remove unnecessary uses of MLIRFunctionBuilder.add_statement from tests.

### DIFF
--- a/mlir_graphblas/mlir_builder.py
+++ b/mlir_graphblas/mlir_builder.py
@@ -206,7 +206,7 @@ class MLIRFunctionBuilder(BaseFunction):
 
             for opclass in ops.values():
 
-                def op(opclass, *args, **kwargs):
+                def op(opclass, *args, **kwargs) -> Optional[MLIRVar]:
                     ret_val, mlir = opclass.call(self, *args, **kwargs)
                     self.add_statement(mlir)
                     return ret_val

--- a/mlir_graphblas/ops.py
+++ b/mlir_graphblas/ops.py
@@ -1,7 +1,7 @@
 """
 Various ops written in MLIR which implement dialects or other utilities
 """
-from typing import Tuple
+from typing import Tuple, Sequence, Optional, Union
 from .mlir_builder import MLIRFunctionBuilder, MLIRVar
 
 
@@ -29,10 +29,25 @@ class ConstantOp(BaseOp):
 
     @classmethod
     def call(cls, irbuilder, value, type):
-        if type in {"f128", "f64", "f32", "f16", "f8"}:
+        if type in {"bf16", "f16", "f32", "f64", "f80", "f128"}:
             value = float(value)
         ret_val = irbuilder.new_var(type)
         return ret_val, (f"{ret_val.assign} = constant {value} : {type}")
+
+
+class IndexCastOp(BaseOp):
+    name = "index_cast"
+
+    @classmethod
+    def call(cls, irbuilder, value: MLIRVar, result_type):
+        if not isinstance(value, MLIRVar):
+            raise TypeError(
+                f"{cls.name} expected an {MLIRVar.__qualname__}, but got {lhs}."
+            )
+        ret_val = irbuilder.new_var(result_type)
+        return ret_val, (
+            f"{ret_val.assign} = std.index_cast {value} : {value.type} to {result_type}"
+        )
 
 
 class AddIOp(BaseOp):
@@ -40,10 +55,141 @@ class AddIOp(BaseOp):
 
     @classmethod
     def call(cls, irbuilder, lhs, rhs):
+        if not isinstance(lhs, MLIRVar):
+            raise TypeError(
+                f"{cls.name} expected an {MLIRVar.__qualname__}, but got {lhs}."
+            )
+        if not isinstance(rhs, MLIRVar):
+            raise TypeError(
+                f"{cls.name} expected an {MLIRVar.__qualname__}, but got {rhs}."
+            )
         if lhs.type != rhs.type:
             raise TypeError(f"Type mismatch: {lhs.type} != {rhs.type}")
         ret_val = irbuilder.new_var(lhs.type)
         return ret_val, (f"{ret_val.assign} = addi {lhs}, {rhs} : {lhs.type}")
+
+
+class MulIOp(BaseOp):
+    name = "muli"
+
+    @classmethod
+    def call(cls, irbuilder, lhs, rhs):
+        if not isinstance(lhs, MLIRVar):
+            raise TypeError(
+                f"{cls.name} expected an {MLIRVar.__qualname__}, but got {lhs}."
+            )
+        if not isinstance(rhs, MLIRVar):
+            raise TypeError(
+                f"{cls.name} expected an {MLIRVar.__qualname__}, but got {rhs}."
+            )
+        if lhs.type != rhs.type:
+            raise TypeError(f"Type mismatch: {lhs.type} != {rhs.type}")
+        ret_val = irbuilder.new_var(lhs.type)
+        return ret_val, (f"{ret_val.assign} = muli {lhs}, {rhs} : {lhs.type}")
+
+
+class AddFOp(BaseOp):
+    name = "addf"
+
+    @classmethod
+    def call(cls, irbuilder, lhs, rhs):
+        if not isinstance(lhs, MLIRVar):
+            raise TypeError(
+                f"{cls.name} expected an {MLIRVar.__qualname__}, but got {lhs}."
+            )
+        if not isinstance(rhs, MLIRVar):
+            raise TypeError(
+                f"{cls.name} expected an {MLIRVar.__qualname__}, but got {rhs}."
+            )
+        if lhs.type != rhs.type:
+            raise TypeError(f"Type mismatch: {lhs.type} != {rhs.type}")
+        ret_val = irbuilder.new_var(lhs.type)
+        return ret_val, (f"{ret_val.assign} = addf {lhs}, {rhs} : {lhs.type}")
+
+
+class MulFOp(BaseOp):
+    name = "mulf"
+
+    @classmethod
+    def call(cls, irbuilder, lhs, rhs):
+        if not isinstance(lhs, MLIRVar):
+            raise TypeError(
+                f"{cls.name} expected an {MLIRVar.__qualname__}, but got {lhs}."
+            )
+        if not isinstance(rhs, MLIRVar):
+            raise TypeError(
+                f"{cls.name} expected an {MLIRVar.__qualname__}, but got {rhs}."
+            )
+        if lhs.type != rhs.type:
+            raise TypeError(f"Type mismatch: {lhs.type} != {rhs.type}")
+        ret_val = irbuilder.new_var(lhs.type)
+        return ret_val, (f"{ret_val.assign} = mulf {lhs}, {rhs} : {lhs.type}")
+
+
+###########################################
+# memref ops
+###########################################
+
+
+class MemrefAllocOp(BaseOp):
+    dialect = "memref"
+    name = "alloc"
+
+    @classmethod
+    def call(cls, irbuilder, shape: Optional[Sequence[Optional[int]]], type: str):
+        """
+        If shape is None, then the memref is unranked.
+        If shape is a sequence, NoneType elements indicate an arbitrarily shaped dimension.
+        """
+        shape = (
+            ["*"]
+            if shape is None
+            else ["?" if dim is None else str(dim) for dim in shape]
+        )
+        shape_and_dtype = "x".join(shape + [type])
+        memref_type = f"memref<{shape_and_dtype}>"
+        ret_val = irbuilder.new_var(memref_type)
+        return ret_val, (f"{ret_val.assign} = memref.alloc() : {memref_type}")
+
+
+class MemrefStoreOp(BaseOp):
+    dialect = "memref"
+    name = "store"
+
+    @classmethod
+    def call(
+        cls,
+        irbuilder,
+        value,
+        destination: MLIRVar,
+        indices: Sequence[Union[MLIRVar, int]],
+    ):
+        indices_string = ", ".join(map(str, indices))
+        return None, (
+            f"memref.store {value}, {destination}[{indices_string}] : {destination.type}"
+        )
+
+
+class MemrefLoadOp(BaseOp):
+    dialect = "memref"
+    name = "load"
+
+    @classmethod
+    def call(
+        cls, irbuilder, input_memref: MLIRVar, indices: Sequence[Union[MLIRVar, int]]
+    ):
+        indices_string = ", ".join(map(str, indices))
+        # TODO can we do this parsing in PyMLIR?
+        _, ret_type = input_memref.type.split("memref<")
+        ret_type = ret_type[:-1]  # before this, it endsx with ">"
+        ret_type = ret_type.split(",")[
+            0
+        ].strip()  # Grab the dimensions+dtype string, e.g. ?x?xf32
+        ret_type = ret_type.split("x")[-1]
+        ret_val = irbuilder.new_var(ret_type)
+        return ret_val, (
+            f"{ret_val.assign} = memref.load {input_memref}[{indices_string}] : {input_memref.type}"
+        )
 
 
 ###########################################

--- a/mlir_graphblas/tests/test_mlir_builder.py
+++ b/mlir_graphblas/tests/test_mlir_builder.py
@@ -258,27 +258,16 @@ def test_ir_builder_for_loop_simple(engine: MlirJitEngine):
         "times_three", input_vars=[input_var], return_types=["f64"]
     )
     zero_f64 = ir_builder.constant(0.0, "f64")
-    ir_builder.add_statement(
-        f"""
-%sum_memref = memref.alloc() : memref<f64>
-memref.store {zero_f64}, %sum_memref[] : memref<f64>
-"""
-    )
+    sum_memref = ir_builder.memref.alloc([], "f64")
+    ir_builder.memref.store(zero_f64, sum_memref, [])
+
     with ir_builder.for_loop(0, 3) as for_vars:
-        ir_builder.add_statement(
-            f"""
-%current_sum = memref.load %sum_memref[] : memref<f64>
-%updated_sum = addf {input_var}, %current_sum : f64
-memref.store %updated_sum, %sum_memref[] : memref<f64>
-"""
-        )
+        current_sum = ir_builder.memref.load(sum_memref, [])
+        updated_sum = ir_builder.addf(input_var, current_sum)
+        ir_builder.memref.store(updated_sum, sum_memref, [])
     assert for_vars.returned_variable is None
-    result_var = MLIRVar("sum", "f64")
-    ir_builder.add_statement(
-        f"""
-{result_var.assign} = memref.load %sum_memref[] : memref<f64>
-"""
-    )
+
+    result_var = ir_builder.memref.load(sum_memref, [])
     ir_builder.return_vars(result_var)
 
     assert ir_builder.get_mlir()
@@ -304,12 +293,8 @@ def test_ir_builder_for_loop_float_iter(engine: MlirJitEngine):
     ir_builder = MLIRFunctionBuilder(
         "plus_6x7_8", input_vars=[input_var], return_types=["f64"]
     )
-    ir_builder.add_statement(
-        f"""
-%sum_memref = memref.alloc() : memref<f64>
-memref.store {input_var}, %sum_memref[] : memref<f64>
-"""
-    )
+    sum_memref = ir_builder.memref.alloc([], "f64")
+    ir_builder.memref.store(input_var, sum_memref, [])
 
     float_lower_var = ir_builder.constant(lower_float, "f64")
     float_iter_var = MLIRVar("float_iter", "f64")
@@ -318,22 +303,13 @@ memref.store {input_var}, %sum_memref[] : memref<f64>
         lower_i, upper_i, delta_i, iter_vars=[(float_iter_var, float_lower_var)]
     ) as for_vars:
         assert [float_iter_var] == for_vars.iter_vars
-        incremented_float_var = MLIRVar("incremented_float", "f64")
-        ir_builder.add_statement(
-            f"""
-%current_sum = memref.load %sum_memref[] : memref<f64>
-%updated_sum = addf {float_iter_var}, %current_sum : f64
-memref.store %updated_sum, %sum_memref[] : memref<f64>
-{incremented_float_var.assign} = addf {float_iter_var}, {float_delta_var} : f64
-"""
-        )
+        current_sum = ir_builder.memref.load(sum_memref, [])
+        updated_sum = ir_builder.addf(float_iter_var, current_sum)
+        ir_builder.memref.store(updated_sum, sum_memref, [])
+        incremented_float_var = ir_builder.addf(float_iter_var, float_delta_var)
         for_vars.yield_vars(incremented_float_var)
-    result_var = MLIRVar("sum", "f64")
-    ir_builder.add_statement(
-        f"""
-{result_var.assign} = memref.load %sum_memref[] : memref<f64>
-"""
-    )
+
+    result_var = ir_builder.memref.load(sum_memref, [])
     ir_builder.return_vars(result_var)
 
     assert ir_builder.get_mlir()
@@ -370,12 +346,9 @@ def test_ir_builder_for_loop_user_specified_vars(engine: MlirJitEngine):
     ir_builder = MLIRFunctionBuilder(
         "add_user_specified_vars", input_vars=[input_var], return_types=["i64"]
     )
-    ir_builder.add_statement(
-        f"""
-%sum_memref = memref.alloc() : memref<i64>
-memref.store {input_var}, %sum_memref[] : memref<i64>
-"""
-    )
+    sum_memref = ir_builder.memref.alloc([], "i64")
+    ir_builder.memref.store(input_var, sum_memref, [])
+
     lower_index_var = ir_builder.constant(lower_index, "index")
     upper_index_var = ir_builder.constant(upper_index, "index")
     delta_index_var = ir_builder.constant(delta_index, "index")
@@ -393,30 +366,26 @@ memref.store {input_var}, %sum_memref[] : memref<i64>
         assert upper_index_var == for_vars.upper_var_index
         assert delta_index_var == for_vars.step_var_index
         assert [iter_i64_var] == for_vars.iter_vars
-        incremented_iter_i64_var = MLIRVar("incremented_iter_i64", "i64")
-        ir_builder.add_statement(
-            f"""
-%current_sum = memref.load %sum_memref[] : memref<i64>
-%prod_of_index_vars_0 = muli {for_vars.lower_var_index}, {for_vars.upper_var_index} : index
-%prod_of_index_vars_1 = muli %prod_of_index_vars_0, {for_vars.step_var_index} : index
-%prod_of_index_vars = std.index_cast %prod_of_index_vars_1 : index to i64
-%prod_of_i64_vars = muli {lower_i64_var}, {delta_i64_var} : i64
-%iter_index_i64 = std.index_cast {for_vars.iter_var_index} : index to i64
-%prod_of_iter_vars = muli %iter_index_i64, {iter_i64_var} : i64
-%updated_sum_0 = addi %current_sum, %prod_of_index_vars : i64
-%updated_sum_1 = addi %updated_sum_0, %prod_of_i64_vars : i64
-%updated_sum = addi %updated_sum_1, %prod_of_iter_vars : i64
-memref.store %updated_sum, %sum_memref[] : memref<i64>
-{incremented_iter_i64_var.assign} = addi {iter_i64_var}, {delta_i64_var} : i64
-"""
+        current_sum = ir_builder.memref.load(sum_memref, [])
+        prod_of_index_vars_0 = ir_builder.muli(
+            for_vars.lower_var_index, for_vars.upper_var_index
         )
+        prod_of_index_vars_1 = ir_builder.muli(
+            prod_of_index_vars_0, for_vars.step_var_index
+        )
+        prod_of_index_vars = ir_builder.index_cast(prod_of_index_vars_1, "i64")
+        prod_of_i64_vars = ir_builder.muli(lower_i64_var, delta_i64_var)
+        iter_index_i64 = ir_builder.index_cast(for_vars.iter_var_index, "i64")
+        prod_of_iter_vars = ir_builder.muli(iter_index_i64, iter_i64_var)
+        updated_sum_0 = ir_builder.addi(current_sum, prod_of_index_vars)
+        updated_sum_1 = ir_builder.addi(updated_sum_0, prod_of_i64_vars)
+        updated_sum = ir_builder.addi(updated_sum_1, prod_of_iter_vars)
+        ir_builder.memref.store(updated_sum, sum_memref, [])
+
+        incremented_iter_i64_var = ir_builder.addi(iter_i64_var, delta_i64_var)
         for_vars.yield_vars(incremented_iter_i64_var)
-    result_var = MLIRVar("sum", "i64")
-    ir_builder.add_statement(
-        f"""
-{result_var.assign} = memref.load %sum_memref[] : memref<i64>
-"""
-    )
+
+    result_var = ir_builder.memref.load(sum_memref, [])
     ir_builder.return_vars(result_var)
 
     assert (

--- a/mlir_graphblas/tests/test_mlir_builder_bad_inputs.py
+++ b/mlir_graphblas/tests/test_mlir_builder_bad_inputs.py
@@ -50,6 +50,18 @@ def test_ir_builder_bad_input_multi_value_mlir_variable():
             f"{assigned_to_i8_var.assign} = addi {c1_i8_var}, {for_vars.returned_variable} : i8"
         )
 
+    with pytest.raises(
+        TypeError,
+        match="Cannot access MLIRTuple .+ directly. Use index notation to access an element.",
+    ):
+        ir_builder.addi(c1_i8_var, for_vars.returned_variable)
+
+    with pytest.raises(
+        TypeError,
+        match="Cannot access MLIRTuple .+ directly. Use index notation to access an element.",
+    ):
+        ir_builder.addi(for_vars.returned_variable, c1_i8_var)
+
     # Raise when using multiple valued variable indexed via out-of-bound int index as operand
     with pytest.raises(IndexError):
         for_vars.returned_variable[999]


### PR DESCRIPTION
This also adds several ops to the IR builder. 