### PR TITLE
Types for IRBuilder

### DIFF
--- a/mlir_graphblas/mlir_builder.py
+++ b/mlir_graphblas/mlir_builder.py
@@ -249,7 +249,7 @@ class MLIRFunctionBuilder(BaseFunction):
 
         signature = ", ".join(f"{var}: {var.type}" for var in self.inputs)
 
-        # TODO: add top-level aliases based on self.aliases
+        # TODO: add top-level aliases based on self.aliases (instead of hardcoding CSR64 and CSC64)
         return needed_function_definitions + self.function_wrapper_text.render(
             private_func=make_private,
             func_name=self.func_name,

--- a/mlir_graphblas/tests/test_mlir_builder.py
+++ b/mlir_graphblas/tests/test_mlir_builder.py
@@ -266,7 +266,7 @@ def test_ir_builder_for_loop_simple(engine: MlirJitEngine, aliases: AliasMap):
     )
     (input_var,) = ir_builder.inputs
     zero_f64 = ir_builder.constant(0.0, "f64")
-    sum_memref = ir_builder.memref.alloc([], "f64")
+    sum_memref = ir_builder.memref.alloc("memref<f64>")
     ir_builder.memref.store(zero_f64, sum_memref, [])
 
     with ir_builder.for_loop(0, 3) as for_vars:
@@ -300,7 +300,7 @@ def test_ir_builder_for_loop_float_iter(engine: MlirJitEngine, aliases: AliasMap
         "plus_6x7_8", input_types=["f64"], return_types=["f64"], aliases=aliases
     )
     (input_var,) = ir_builder.inputs
-    sum_memref = ir_builder.memref.alloc([], "f64")
+    sum_memref = ir_builder.memref.alloc("memref<f64>")
     ir_builder.memref.store(input_var, sum_memref, [])
 
     float_lower_var = ir_builder.constant(lower_float, "f64")
@@ -352,7 +352,7 @@ def test_ir_builder_for_loop_user_specified_vars(engine: MlirJitEngine):
         "add_user_specified_vars", input_types=["i64"], return_types=["i64"]
     )
     (input_var,) = ir_builder.inputs
-    sum_memref = ir_builder.memref.alloc([], "i64")
+    sum_memref = ir_builder.memref.alloc("memref<i64>")
     ir_builder.memref.store(input_var, sum_memref, [])
 
     lower_index_var = ir_builder.constant(lower_index, "index")

--- a/mlir_graphblas/tests/test_mlir_builder.py
+++ b/mlir_graphblas/tests/test_mlir_builder.py
@@ -7,7 +7,8 @@ import numpy as np
 from mlir_graphblas import MlirJitEngine
 from mlir_graphblas.engine import parse_mlir_string
 from mlir_graphblas.sparse_utils import MLIRSparseTensor
-from mlir_graphblas.mlir_builder import MLIRVar, MLIRFunctionBuilder
+from mlir_graphblas.mlir_builder import MLIRFunctionBuilder
+from mlir_graphblas.types import AliasMap, SparseEncodingType
 from mlir_graphblas.functions import ConvertLayout
 from mlir_graphblas.algorithms import (
     triangle_count_combined,
@@ -86,17 +87,27 @@ func @csc_densify8x8(%argA: tensor<8x8xf64, #CSC64>) -> tensor<8x8xf64> {
     return jit_engine
 
 
-def test_ir_builder_convert_layout_wrapper(engine: MlirJitEngine):
+@pytest.fixture(scope="module")
+def aliases() -> AliasMap:
+    csr64 = SparseEncodingType(["dense", "compressed"], [0, 1], 64, 64)
+    csc64 = SparseEncodingType(["dense", "compressed"], [1, 0], 64, 64)
+    aliases = AliasMap()
+    aliases["CSR64"] = csr64
+    aliases["CSC64"] = csc64
+    return aliases
+
+
+def test_ir_builder_convert_layout_wrapper(engine: MlirJitEngine, aliases: AliasMap):
     # Build Function
     convert_layout_function = ConvertLayout()
 
-    input_var = MLIRVar("input_tensor", "tensor<?x?xf64, #CSR64>")
-
     ir_builder = MLIRFunctionBuilder(
         "convert_layout_wrapper",
-        input_vars=[input_var],
+        input_types=["tensor<?x?xf64, #CSR64>"],
         return_types=("tensor<?x?xf64, #CSC64>",),
+        aliases=aliases,
     )
+    (input_var,) = ir_builder.inputs
     convert_layout_result = ir_builder.call(convert_layout_function, input_var)
     ir_builder.return_vars(convert_layout_result)
 
@@ -129,19 +140,17 @@ def test_ir_builder_convert_layout_wrapper(engine: MlirJitEngine):
 
     assert np.isclose(dense_input_tensor, engine.csc_densify8x8(output_tensor)).all()
 
-    return
 
-
-def test_ir_builder_triple_convert_layout(engine: MlirJitEngine):
+def test_ir_builder_triple_convert_layout(engine: MlirJitEngine, aliases: AliasMap):
     # Build Function
-
-    input_var = MLIRVar("input_tensor", "tensor<?x?xf64, #CSR64>")
 
     ir_builder = MLIRFunctionBuilder(
         "triple_convert_layout",
-        input_vars=(input_var,),
+        input_types=["tensor<?x?xf64, #CSR64>"],
         return_types=["tensor<?x?xf64, #CSC64>"],
+        aliases=aliases,
     )
+    (input_var,) = ir_builder.inputs
     # Use different instances of Tranpose to ideally get exactly one convert_layout helper in the final MLIR text
     inter1 = ir_builder.call(ConvertLayout("csc"), input_var)
     inter2 = ir_builder.call(ConvertLayout("csr"), inter1)
@@ -202,7 +211,7 @@ def test_ir_builder_triple_convert_layout(engine: MlirJitEngine):
     return
 
 
-def test_ir_builder_triangle_count(engine: MlirJitEngine):
+def test_ir_builder_triangle_count():
     # 0 - 1    5 - 6
     # | X |    | /
     # 3 - 4 -- 2 - 7
@@ -249,14 +258,13 @@ def test_ir_builder_triangle_count(engine: MlirJitEngine):
     return
 
 
-def test_ir_builder_for_loop_simple(engine: MlirJitEngine):
+def test_ir_builder_for_loop_simple(engine: MlirJitEngine, aliases: AliasMap):
     # Build Function
 
-    input_var = MLIRVar("input_value", "f64")
-
     ir_builder = MLIRFunctionBuilder(
-        "times_three", input_vars=[input_var], return_types=["f64"]
+        "times_three", input_types=["f64"], return_types=["f64"], aliases=aliases
     )
+    (input_var,) = ir_builder.inputs
     zero_f64 = ir_builder.constant(0.0, "f64")
     ir_builder.add_statement(
         f"""
@@ -273,7 +281,7 @@ memref.store %updated_sum, %sum_memref[] : memref<f64>
 """
         )
     assert for_vars.returned_variable is None
-    result_var = MLIRVar("sum", "f64")
+    result_var = ir_builder.new_var("f64")
     ir_builder.add_statement(
         f"""
 {result_var.assign} = memref.load %sum_memref[] : memref<f64>
@@ -290,7 +298,7 @@ memref.store %updated_sum, %sum_memref[] : memref<f64>
     return
 
 
-def test_ir_builder_for_loop_float_iter(engine: MlirJitEngine):
+def test_ir_builder_for_loop_float_iter(engine: MlirJitEngine, aliases: AliasMap):
     # Build Function
 
     lower_i = 0
@@ -299,11 +307,10 @@ def test_ir_builder_for_loop_float_iter(engine: MlirJitEngine):
     lower_float = 0.0
     delta_float = 7.8
 
-    input_var = MLIRVar("input_value", "f64")
-
     ir_builder = MLIRFunctionBuilder(
-        "plus_6x7_8", input_vars=[input_var], return_types=["f64"]
+        "plus_6x7_8", input_types=["f64"], return_types=["f64"], aliases=aliases
     )
+    (input_var,) = ir_builder.inputs
     ir_builder.add_statement(
         f"""
 %sum_memref = memref.alloc() : memref<f64>
@@ -312,13 +319,13 @@ memref.store {input_var}, %sum_memref[] : memref<f64>
     )
 
     float_lower_var = ir_builder.constant(lower_float, "f64")
-    float_iter_var = MLIRVar("float_iter", "f64")
+    float_iter_var = ir_builder.new_var("f64")
     float_delta_var = ir_builder.constant(delta_float, "f64")
     with ir_builder.for_loop(
         lower_i, upper_i, delta_i, iter_vars=[(float_iter_var, float_lower_var)]
     ) as for_vars:
         assert [float_iter_var] == for_vars.iter_vars
-        incremented_float_var = MLIRVar("incremented_float", "f64")
+        incremented_float_var = ir_builder.new_var("f64")
         ir_builder.add_statement(
             f"""
 %current_sum = memref.load %sum_memref[] : memref<f64>
@@ -328,7 +335,7 @@ memref.store %updated_sum, %sum_memref[] : memref<f64>
 """
         )
         for_vars.yield_vars(incremented_float_var)
-    result_var = MLIRVar("sum", "f64")
+    result_var = ir_builder.new_var("f64")
     ir_builder.add_statement(
         f"""
 {result_var.assign} = memref.load %sum_memref[] : memref<f64>
@@ -349,8 +356,6 @@ memref.store %updated_sum, %sum_memref[] : memref<f64>
 def test_ir_builder_for_loop_user_specified_vars(engine: MlirJitEngine):
     # Build Function
 
-    input_var = MLIRVar("input_value", "i64")
-
     lower_index = 3
     upper_index = 9
     delta_index = 2
@@ -368,8 +373,9 @@ def test_ir_builder_for_loop_user_specified_vars(engine: MlirJitEngine):
 
     # Build IR
     ir_builder = MLIRFunctionBuilder(
-        "add_user_specified_vars", input_vars=[input_var], return_types=["i64"]
+        "add_user_specified_vars", input_types=["i64"], return_types=["i64"]
     )
+    (input_var,) = ir_builder.inputs
     ir_builder.add_statement(
         f"""
 %sum_memref = memref.alloc() : memref<i64>
@@ -381,7 +387,7 @@ memref.store {input_var}, %sum_memref[] : memref<i64>
     delta_index_var = ir_builder.constant(delta_index, "index")
     lower_i64_var = ir_builder.constant(lower_i64, "i64")
     delta_i64_var = ir_builder.constant(delta_i64, "i64")
-    iter_i64_var = MLIRVar("iter_i64", "i64")
+    iter_i64_var = ir_builder.new_var("i64")
 
     with ir_builder.for_loop(
         lower_index_var,
@@ -393,7 +399,7 @@ memref.store {input_var}, %sum_memref[] : memref<i64>
         assert upper_index_var == for_vars.upper_var_index
         assert delta_index_var == for_vars.step_var_index
         assert [iter_i64_var] == for_vars.iter_vars
-        incremented_iter_i64_var = MLIRVar("incremented_iter_i64", "i64")
+        incremented_iter_i64_var = ir_builder.new_var("i64")
         ir_builder.add_statement(
             f"""
 %current_sum = memref.load %sum_memref[] : memref<i64>
@@ -411,7 +417,7 @@ memref.store %updated_sum, %sum_memref[] : memref<i64>
 """
         )
         for_vars.yield_vars(incremented_iter_i64_var)
-    result_var = MLIRVar("sum", "i64")
+    result_var = ir_builder.new_var("i64")
     ir_builder.add_statement(
         f"""
 {result_var.assign} = memref.load %sum_memref[] : memref<i64>

--- a/mlir_graphblas/tests/test_mlir_builder_bad_inputs.py
+++ b/mlir_graphblas/tests/test_mlir_builder_bad_inputs.py
@@ -9,11 +9,11 @@ def engine():
 
 
 def test_ir_builder_bad_input_multi_value_mlir_variable():
-    ir_builder = MLIRFunctionBuilder("some_func", input_vars=[], return_types=("i8",))
+    ir_builder = MLIRFunctionBuilder("some_func", input_types=[], return_types=("i8",))
 
-    iter_i8_var = MLIRVar("iter_i8", "i8")
+    iter_i8_var = ir_builder.new_var("i8")
     lower_i8_var = ir_builder.constant(1, "i8")
-    iter_i64_var = MLIRVar("iter_64", "i64")
+    iter_i64_var = ir_builder.new_var("i64")
     lower_i64_var = ir_builder.constant(1, "i64")
     with ir_builder.for_loop(
         0, 1, 1, iter_vars=[(iter_i8_var, lower_i8_var), (iter_i64_var, lower_i64_var)]
@@ -40,7 +40,7 @@ def test_ir_builder_bad_input_multi_value_mlir_variable():
         ir_builder.return_vars(for_vars.returned_variable)
 
     # Raise when using multiple valued variable as operand
-    assigned_to_i8_var = MLIRVar("assigned_to_i8", "i8")
+    assigned_to_i8_var = ir_builder.new_var("i8")
     c1_i8_var = ir_builder.constant(1, "i8")
     with pytest.raises(
         TypeError,
@@ -67,7 +67,7 @@ def test_ir_builder_bad_input_multi_value_mlir_variable():
     # Raise when returning value incompatible with return type.
     c1_i64_var = ir_builder.constant(1, "i64")
     with pytest.raises(
-        TypeError, match="Return type of MLIRVar<name=.+, type=i64> does not match i8"
+        TypeError, match="Return type of MLIRVar\(name=.+, type=i64\) does not match i8"
     ):
         ir_builder.return_vars(c1_i64_var)
 

--- a/mlir_graphblas/types.py
+++ b/mlir_graphblas/types.py
@@ -1,0 +1,181 @@
+import re
+
+
+class AliasMap(dict):
+    def __setitem__(self, name, type):
+        type = Type.find(type, aliases=self)
+        super().__setitem__(name, type)
+
+
+class Type:
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self})"
+
+    def __eq__(self, other):
+        if not isinstance(other, Type):
+            return NotImplemented
+        return self.__class__ is other.__class__ and str(self) == str(other)
+
+    @classmethod
+    def find(cls, text: str, aliases: AliasMap = None):
+        if isinstance(text, Type):
+            return text
+        if aliases is not None and text[:1] == "#":
+            if alias := aliases.get(text[1:]):
+                return alias
+
+        for klass in (
+            IndexType,
+            FloatType,
+            IntType,
+            TensorType,
+            SparseEncodingType,
+            LlvmPtrType,
+        ):
+            result = klass.parse(text, aliases=aliases)
+            if result is not None:
+                return result
+
+        raise TypeError(f"Unknown type: {text}")
+
+
+class IndexType(Type):
+    def __init__(self):
+        pass
+
+    def __str__(self):
+        return "index"
+
+    @classmethod
+    def parse(cls, text: str, aliases: AliasMap = None):
+        if text == "index":
+            return IndexType()
+
+
+class FloatType(Type):
+    _patt = re.compile(r"^f(\d+)$")
+
+    def __init__(self, num: int):
+        self.num = num
+
+    def __str__(self):
+        return f"f{self.num}"
+
+    @classmethod
+    def parse(cls, text: str, aliases: AliasMap = None):
+        if m := cls._patt.match(text):
+            return FloatType(int(m.group(1)))
+
+
+class IntType(Type):
+    _patt = re.compile(r"^i(\d+)$")
+
+    def __init__(self, num: int):
+        self.num = num
+
+    def __str__(self):
+        return f"i{self.num}"
+
+    @classmethod
+    def parse(cls, text: str, aliases: AliasMap = None):
+        if m := cls._patt.match(text):
+            return IntType(int(m.group(1)))
+
+
+class TensorType(Type):
+    _patt = re.compile(r"^tensor<\?x\?x(.+), (#.+)>$")
+
+    def __init__(self, value_type: Type, encoding: "SparseEncodingType"):
+        if not isinstance(value_type, Type):
+            raise TypeError(f"value_type must be a Type, not {type(value_type)}")
+        if not isinstance(encoding, SparseEncodingType):
+            raise TypeError(
+                f"encoding must be a SparseEncodingType, not {type(encoding)}"
+            )
+        self.value_type = value_type
+        self.encoding = encoding
+
+    def __str__(self):
+        return f"tensor<?x?x{self.value_type}, {self.encoding}>"
+
+    @classmethod
+    def parse(cls, text: str, aliases: AliasMap = None):
+        if m := cls._patt.match(text):
+            value_type = Type.find(m.group(1), aliases=aliases)
+            encoding = Type.find(m.group(2), aliases=aliases)
+            return TensorType(value_type, encoding)
+
+
+class SparseEncodingType(Type):
+    _patt = re.compile(
+        r"^#sparse_tensor.encoding<\{"
+        r"\s*,?\s*(?:dimLevelType\s*=\s*\[(?P<levels>.+)\])?"
+        r"\s*,?\s*(?:dimOrdering\s*=\s*affine_map<(?P<ordering>.+)>)?"
+        r"\s*,?\s*(?:pointerBitWidth\s*=\s*(?P<pointer>\d+))?"
+        r"\s*,?\s*(?:indexBitWidth\s*=\s*(?P<index>\d+))?"
+        r"\s*,?\s*\}>$"
+    )
+
+    def __init__(self, levels, ordering=None, pointer_bit_width=64, index_bit_width=64):
+        if levels is None:
+            if ordering is not None:
+                raise TypeError("Cannot provide ordering without levels")
+        self.levels = levels
+        self.ordering = ordering
+        self.pointer_bit_width = pointer_bit_width
+        self.index_bit_width = index_bit_width
+
+    @property
+    def rank(self):
+        if self.levels is None and self.ordering is None:
+            return -1
+        return len(self.levels)
+
+    def __str__(self):
+        internals = []
+        if self.levels is not None:
+            lvl_str = ", ".join(f'"{lvl}"' for lvl in self.levels)
+            internals.append(f"dimLevelType = [ {lvl_str} ]")
+            if self.ordering is not None:
+                lhs = [f"d{i}" for i in range(len(self.levels))]
+                rhs = [lhs[idx] for idx in self.ordering]
+                internals.append(
+                    f"dimOrdering = affine_map<({', '.join(lhs)}) -> ({', '.join(rhs)})>"
+                )
+        internals.append(f"pointerBitWidth = {self.pointer_bit_width}")
+        internals.append(f"indexBitWidth = {self.index_bit_width}")
+        return f"#sparse_tensor.encoding<{{ {', '.join(internals)} }}>"
+
+    @classmethod
+    def parse(cls, text: str, aliases: AliasMap = None):
+        if m := cls._patt.match(text):
+            if levels := m["levels"]:
+                levels = [lvl.strip().strip("\"'") for lvl in levels.split(",")]
+            if ordering := m["ordering"]:
+                lhs, rhs = ordering.split("->")
+                lhs = [x.strip() for x in lhs.strip().strip("()").split(",")]
+                rhs = [x.strip() for x in rhs.strip().strip("()").split(",")]
+                ordering = [lhs.index(x) for x in rhs]
+            pointer_bit_width = int(m["pointer"])
+            index_bit_width = int(m["index"])
+            return SparseEncodingType(
+                levels, ordering, pointer_bit_width, index_bit_width
+            )
+
+
+class LlvmPtrType(Type):
+    _patt = re.compile(r"^!llvm\.ptr<\s*(.+)\s*>$")
+
+    def __init__(self, internal_type: Type):
+        if not isinstance(internal_type, Type):
+            raise TypeError(f"internal_type must be a Type, not {type(internal_type)}")
+        self.internal_type = internal_type
+
+    def __str__(self):
+        return f"!llvm.ptr<{self.internal_type}>"
+
+    @classmethod
+    def parse(cls, text: str, aliases: AliasMap = None):
+        if m := cls._patt.match(text):
+            internal_type = Type.find(m.group(1), aliases=aliases)
+            return LlvmPtrType(internal_type)


### PR DESCRIPTION
* `MLIRVar`s now require a proper `Type` rather than a string.
* Aliases can be defined and will resolve within types

I am very happy with how this turned out. It greatly simplifies many things and allows us to inspect and more easily compare types.

The use of aliases made it necessary to pass in input types to the builder rather than MLIRVars. Otherwise it put a burden on the caller to understand the ins-and-outs of Types and alias resolution.

The pattern now is to:
1. Create the IR builder, passing a list of input types and return types
2. Grab the newly created inputs using `input1, input2, input3 = irbuilder.inputs`. These will be proper MLIRVars.