### PR TITLE
CS-generic Sparse Encoding

### DIFF
--- a/mlir_graphblas/SparseUtils.cpp
+++ b/mlir_graphblas/SparseUtils.cpp
@@ -754,10 +754,16 @@ void *ptr8_to_tensor(void *tensor) {
 void *tensor_to_ptr8(void *tensor) {
     return tensor;
 }
-void *cast_csr_to_csc(void *tensor) {
+void *cast_csr_to_csx(void *tensor) {
     return tensor;
 }
-void *cast_csc_to_csr(void *tensor) {
+void *cast_csc_to_csx(void *tensor) {
+    return tensor;
+}
+void *cast_csx_to_csc(void *tensor) {
+    return tensor;
+}
+void *cast_csx_to_csr(void *tensor) {
     return tensor;
 }
 void *empty_like(void *tensor) {

--- a/mlir_graphblas/functions.py
+++ b/mlir_graphblas/functions.py
@@ -58,19 +58,21 @@ class BaseFunction:
   indexBitWidth = 64
 }>
 
+#CSX64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "dense", "compressed" ],
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
 module  {
-    func private @cast_csr_to_csc(tensor<?x?xf64, #CSR64>) -> tensor<?x?xf64, #CSC64>
+    func private @cast_csr_to_csx(tensor<?x?xf64, #CSR64>) -> tensor<?x?xf64, #CSX64>
+    func private @cast_csc_to_csx(tensor<?x?xf64, #CSC64>) -> tensor<?x?xf64, #CSX64>
+    func private @cast_csx_to_csr(tensor<?x?xf64, #CSX64>) -> tensor<?x?xf64, #CSR64>
+    func private @cast_csx_to_csc(tensor<?x?xf64, #CSX64>) -> tensor<?x?xf64, #CSC64>
     
-    func private @empty(tensor<?x?xf64, #CSR64>, index) -> tensor<?x?xf64, #CSR64>
-    func private @dup_tensor(tensor<?x?xf64, #CSR64>) -> tensor<?x?xf64, #CSR64>
-    func private @ptr8_to_tensor(!llvm.ptr<i8>) -> tensor<?x?xf64, #CSR64>
-    func private @tensor_to_ptr8(tensor<?x?xf64, #CSR64>) -> !llvm.ptr<i8>
-
-    func private @resize_pointers(tensor<?x?xf64, #CSR64>, index, index) -> ()
-    func private @resize_index(tensor<?x?xf64, #CSR64>, index, index) -> ()
-    func private @resize_values(tensor<?x?xf64, #CSR64>, index) -> ()
-    func private @resize_dim(tensor<?x?xf64, #CSR64>, index, index) -> ()
-
+    func private @ptr8_to_tensor(!llvm.ptr<i8>) -> tensor<?x?xf64, #CSX64>
+    func private @tensor_to_ptr8(tensor<?x?xf64, #CSX64>) -> !llvm.ptr<i8>
+    
     {{ body }}
 
 }

--- a/mlir_graphblas/sparse_utils.pyx
+++ b/mlir_graphblas/sparse_utils.pyx
@@ -187,8 +187,10 @@ cdef extern from "SparseUtils.cpp" nogil:
     void *dup_tensor(void *tensor)
     void *ptr8_to_tensor(void *tensor)
     void *tensor_to_ptr8(void *tensor)
-    void *cast_csr_to_csc(void *tensor)
-    void *cast_csc_to_csr(void *tensor)
+    void *cast_csr_to_csx(void *tensor)
+    void *cast_csc_to_csx(void *tensor)
+    void *cast_csx_to_csr(void *tensor)
+    void *cast_csx_to_csc(void *tensor)
     void *empty_like(void *tensor)
     void *empty(void *tensor, uint64_t ndims)
 

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASUtils.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASUtils.cpp
@@ -9,34 +9,102 @@ using namespace std;
 using namespace mlir;
 using namespace mlir::sparse_tensor;
 
-bool typeIsCSR(Type inputType) {
+bool typeIsCSX(Type inputType) {
   sparse_tensor::SparseTensorEncodingAttr inputSparseEncoding =
     sparse_tensor::getSparseTensorEncoding(inputType);
-  if (inputSparseEncoding) {
-    AffineMap inputDimOrdering = inputSparseEncoding.getDimOrdering();
-    if (inputDimOrdering.getNumDims() == 2) {
-      unsigned inputDimOrdering0 = inputDimOrdering.getDimPosition(0);
-      unsigned inputDimOrdering1 = inputDimOrdering.getDimPosition(1);
-      bool inputTypeIsCSR = (inputDimOrdering0 == 0 &&  inputDimOrdering1 == 1);
-      return inputTypeIsCSR;
-    }
+
+  if (!inputSparseEncoding)
+    return false;
+  
+  AffineMap inputDimOrdering = inputSparseEncoding.getDimOrdering();
+  if (inputDimOrdering) 
+    return false;
+  
+  llvm::ArrayRef<SparseTensorEncodingAttr::DimLevelType> dlt = inputSparseEncoding.getDimLevelType();
+  if (dlt.size() != 2)
+    return false;
+  
+  return true;
+}
+
+bool typeIsCSR(Type inputType) {
+
+  sparse_tensor::SparseTensorEncodingAttr inputSparseEncoding =
+    sparse_tensor::getSparseTensorEncoding(inputType);
+  
+  if (!inputSparseEncoding)
+    return false;
+  
+  AffineMap inputDimOrdering = inputSparseEncoding.getDimOrdering();
+  if (!inputDimOrdering) // if inputDimOrdering.map != nullptr ; i.e. if the dimOrdering exists
+    return false;
+  if (inputDimOrdering.getNumDims() != 2) {
+    return false;
+  } else {
+    unsigned inputDimOrdering0 = inputDimOrdering.getDimPosition(0);
+    unsigned inputDimOrdering1 = inputDimOrdering.getDimPosition(1);
+    if (inputDimOrdering0 != 0 || inputDimOrdering1 != 1)
+      return false;
   }
-  return false;
+  llvm::ArrayRef<SparseTensorEncodingAttr::DimLevelType> dlt = inputSparseEncoding.getDimLevelType();
+  if (dlt.size() != 2) {
+    return false;
+  } else {
+    if (dlt[0] != sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Dense
+	|| dlt[1] != sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Compressed)
+      return false;
+  }
+
+  return true;
 }
 
 bool typeIsCSC(Type inputType) {
   sparse_tensor::SparseTensorEncodingAttr inputSparseEncoding =
     sparse_tensor::getSparseTensorEncoding(inputType);
-  if (inputSparseEncoding) {
-    AffineMap inputDimOrdering = inputSparseEncoding.getDimOrdering();
-    if (inputDimOrdering.getNumDims() == 2) {
-      unsigned inputDimOrdering0 = inputDimOrdering.getDimPosition(0);
-      unsigned inputDimOrdering1 = inputDimOrdering.getDimPosition(1);
-      bool inputTypeIsCSC = (inputDimOrdering0 == 1 &&  inputDimOrdering1 == 0);
-      return inputTypeIsCSC;
-    }
+  
+  if (!inputSparseEncoding)
+    return false;
+  
+  AffineMap inputDimOrdering = inputSparseEncoding.getDimOrdering();
+  if (!inputDimOrdering) // if inputDimOrdering.map != nullptr ; i.e. if the dimOrdering exists
+    return false;
+  if (inputDimOrdering.getNumDims() != 2) {
+    return false;
+  } else {
+    unsigned inputDimOrdering0 = inputDimOrdering.getDimPosition(0);
+    unsigned inputDimOrdering1 = inputDimOrdering.getDimPosition(1);
+    if (inputDimOrdering0 != 1 || inputDimOrdering1 != 0)
+      return false;
   }
-  return false;
+  
+  llvm::ArrayRef<SparseTensorEncodingAttr::DimLevelType> dlt = inputSparseEncoding.getDimLevelType();
+  if (dlt.size() != 2) {
+    return false;
+  } else {
+    if (dlt[0] != sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Dense
+	|| dlt[1] != sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Compressed)
+      return false;
+  }
+  
+  return true;
+}
+
+// make CSX tensor type
+RankedTensorType getCSXTensorType(MLIRContext *context, ArrayRef<int64_t> shape, Type valueType)
+{
+    SmallVector<sparse_tensor::SparseTensorEncodingAttr::DimLevelType, 2> dlt;
+    dlt.push_back(sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Dense);
+    dlt.push_back(sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Compressed);
+    unsigned ptr = 64;
+    unsigned ind = 64;
+    AffineMap map = {};
+    
+    RankedTensorType csrTensor = RankedTensorType::get(
+        shape,
+        valueType,
+        sparse_tensor::SparseTensorEncodingAttr::get(context, dlt, map, ptr, ind));
+    
+    return csrTensor;
 }
 
 // make CSR tensor type
@@ -93,6 +161,31 @@ static FlatSymbolRefAttr getFunc(ModuleOp &mod, Location &loc, StringRef name, T
     return SymbolRefAttr::get(context, name);
 }
 
+Value convertToExternalCSX(OpBuilder &builder, ModuleOp &mod, Location loc, Value input)
+{
+  MLIRContext *context = mod.getContext();
+  RankedTensorType inputType = input.getType().dyn_cast<RankedTensorType>();
+  if (typeIsCSX(inputType))
+    return input;
+  
+  RankedTensorType csxType = getCSXTensorType(context, {-1, -1}, builder.getF64Type()); 
+  FlatSymbolRefAttr castFuncSymbol;
+  if (typeIsCSC(inputType))
+    castFuncSymbol = getFunc(mod, loc, "cast_csc_to_csx", csxType, inputType);
+  else if (typeIsCSR(inputType))
+    castFuncSymbol = getFunc(mod, loc, "cast_csr_to_csx", csxType, inputType);
+  else 
+    assert(false && "Unexpected tensor type.");
+  CallOp castCallOp = builder.create<CallOp>(loc,
+					     castFuncSymbol,
+					     csxType,
+					     llvm::ArrayRef<Value>({input})
+					     );
+
+  Value result = castCallOp->getResult(0);
+  return result;
+}
+
 Value convertToExternalCSR(OpBuilder &builder, ModuleOp &mod, Location loc, Value input)
 {
   // Cast the tensor to the CSR type that our external functions expect
@@ -100,13 +193,17 @@ Value convertToExternalCSR(OpBuilder &builder, ModuleOp &mod, Location loc, Valu
   // this is OK.
   MLIRContext *context = mod.getContext();
   RankedTensorType inputType = input.getType().dyn_cast<RankedTensorType>();
-  if (typeIsCSR(inputType)) {
+  if (typeIsCSR(inputType))
     return input;
+
+  if (typeIsCSC(inputType)) {
+    input = convertToExternalCSX(builder, mod, loc, input);
+    inputType = input.getType().dyn_cast<RankedTensorType>();
   }
   
   // all external calls are currently for unknown size float64 tensors
-  RankedTensorType csrType = getCSRTensorType(context, {-1, -1}, builder.getF64Type());
-  FlatSymbolRefAttr castFuncSymbol = getFunc(mod, loc, "cast_csc_to_csr", csrType, inputType);
+  RankedTensorType csrType = getCSRTensorType(context, {-1, -1}, builder.getF64Type()); 
+  FlatSymbolRefAttr castFuncSymbol = getFunc(mod, loc, "cast_csx_to_csr", csrType, inputType);
   CallOp castCallOp = builder.create<CallOp>(loc,
 					     castFuncSymbol,
 					     csrType,
@@ -121,16 +218,19 @@ Value convertToExternalCSC(OpBuilder &builder, ModuleOp &mod, Location loc, Valu
 {
   MLIRContext *context = mod.getContext();
   RankedTensorType inputType = input.getType().dyn_cast<RankedTensorType>();
-  if (typeIsCSC(inputType)) {
+  if (typeIsCSC(inputType))
     return input;
+
+  if (typeIsCSR(inputType)) {
+    input = convertToExternalCSX(builder, mod, loc, input);
+    inputType = input.getType().dyn_cast<RankedTensorType>();
   }
   
-  // all external calls are currently for unknown size float64 tensors
-  RankedTensorType csrType = getCSCTensorType(context, {-1, -1}, builder.getF64Type());
-  FlatSymbolRefAttr castFuncSymbol = getFunc(mod, loc, "cast_csr_to_csc", csrType, inputType);
+  RankedTensorType cscType = getCSCTensorType(context, {-1, -1}, builder.getF64Type()); 
+  FlatSymbolRefAttr castFuncSymbol = getFunc(mod, loc, "cast_csx_to_csc", cscType, inputType);
   CallOp castCallOp = builder.create<CallOp>(loc,
 					     castFuncSymbol,
-					     csrType,
+					     cscType,
 					     llvm::ArrayRef<Value>({input})
 					     );
 
@@ -139,63 +239,48 @@ Value convertToExternalCSC(OpBuilder &builder, ModuleOp &mod, Location loc, Valu
 }
 
 mlir::Value callEmptyLike(OpBuilder &builder, ModuleOp &mod, Location loc, Value tensor) {
-    Type tensorType = tensor.getType();
-    Value csrTensor = convertToExternalCSR(builder, mod, loc, tensor);
-    Type csrTensorType = csrTensor.getType();
+    Value csxTensor = convertToExternalCSX(builder, mod, loc, tensor);
+    Type csxTensorType = csxTensor.getType();
 
-    FlatSymbolRefAttr func = getFunc(mod, loc, "empty_like", csrTensorType, csrTensorType);
-    mlir::CallOp result = builder.create<mlir::CallOp>(loc, func, csrTensorType, csrTensor);
-    if (typeIsCSR(tensorType)) {
-      Value castResult = convertToExternalCSR(builder, mod, loc, result.getResult(0));
-      return castResult;
-    } else if (typeIsCSC(tensorType)) {
-      Value castResult = convertToExternalCSC(builder, mod, loc, result.getResult(0));
-      return castResult;
-    } else {
-      assert(false && "Unexpected tensor type.");
-    }
+    FlatSymbolRefAttr func = getFunc(mod, loc, "empty_like", csxTensorType, csxTensorType);
+    mlir::CallOp callOpResult = builder.create<mlir::CallOp>(loc, func, csxTensorType, csxTensor);
+    Value result = callOpResult->getResult(0);
+    return result;
 }
 
 mlir::Value callDupTensor(OpBuilder &builder, ModuleOp &mod, Location loc, Value tensor) {
-  Type tensorType = tensor.getType();
-  Value csrTensor = convertToExternalCSR(builder, mod, loc, tensor);
-  Type csrTensorType = csrTensor.getType();
+  Value csxTensor = convertToExternalCSX(builder, mod, loc, tensor);
+  Type csxTensorType = csxTensor.getType();
 
-  FlatSymbolRefAttr func = getFunc(mod, loc, "dup_tensor", csrTensorType, csrTensorType);
-  mlir::CallOp result = builder.create<mlir::CallOp>(loc, func, csrTensorType, csrTensor);
-  if (typeIsCSR(tensorType)) {
-    Value castResult = convertToExternalCSR(builder, mod, loc, result.getResult(0));
-    return castResult;
-  } else if (typeIsCSC(tensorType)) {
-    Value castResult = convertToExternalCSC(builder, mod, loc, result.getResult(0));
-    return castResult;
-  } else {
-    assert(false && "Unexpected tensor type.");
-  }
+  FlatSymbolRefAttr func = getFunc(mod, loc, "dup_tensor", csxTensorType, csxTensorType);
+    mlir::CallOp callOpResult = builder.create<mlir::CallOp>(loc, func, csxTensorType, csxTensor);
+    Value result = callOpResult->getResult(0);
+    return result;
+  
 }
 
 mlir::CallOp callResizeDim(OpBuilder &builder, ModuleOp &mod, Location loc,
                            Value tensor, Value d, Value size)
 {
-    Value csrTensor = convertToExternalCSR(builder, mod, loc, tensor);
-    Type tensorType = csrTensor.getType();
+  Value csxTensor = convertToExternalCSX(builder, mod, loc, tensor);
+  Type csxTensorType = csxTensor.getType();
 
-    Type indexType = builder.getIndexType();
-    FlatSymbolRefAttr func = getFunc(mod, loc, "resize_dim", TypeRange(), {tensorType, indexType, indexType});
-    mlir::CallOp result = builder.create<mlir::CallOp>(loc, func, TypeRange(), ArrayRef<Value>({csrTensor, d, size}));
+  Type indexType = builder.getIndexType();
+  FlatSymbolRefAttr func = getFunc(mod, loc, "resize_dim", TypeRange(), {csxTensorType, indexType, indexType});
+  mlir::CallOp result = builder.create<mlir::CallOp>(loc, func, TypeRange(), ArrayRef<Value>({csxTensor, d, size}));
 
-    return result;
+  return result;
 }
 
 mlir::CallOp callResizePointers(OpBuilder &builder, ModuleOp &mod, Location loc,
                                 Value tensor, Value d, Value size)
 {
-    Value csrTensor = convertToExternalCSR(builder, mod, loc, tensor);
-    Type tensorType = csrTensor.getType();
+    Value csxTensor = convertToExternalCSX(builder, mod, loc, tensor);
+    Type tensorType = csxTensor.getType();
 
     Type indexType = builder.getIndexType();
     FlatSymbolRefAttr func = getFunc(mod, loc, "resize_pointers", TypeRange(), {tensorType, indexType, indexType});
-    mlir::CallOp result = builder.create<mlir::CallOp>(loc, func, TypeRange(), ArrayRef<Value>({csrTensor, d, size}));
+    mlir::CallOp result = builder.create<mlir::CallOp>(loc, func, TypeRange(), ArrayRef<Value>({csxTensor, d, size}));
 
     return result;
 }
@@ -203,12 +288,12 @@ mlir::CallOp callResizePointers(OpBuilder &builder, ModuleOp &mod, Location loc,
 mlir::CallOp callResizeIndex(OpBuilder &builder, ModuleOp &mod, Location loc,
                              Value tensor, Value d, Value size)
 {
-    Value csrTensor = convertToExternalCSR(builder, mod, loc, tensor);
-    Type tensorType = csrTensor.getType();
+    Value csxTensor = convertToExternalCSX(builder, mod, loc, tensor);
+    Type tensorType = csxTensor.getType();
 
     Type indexType = builder.getIndexType();
     FlatSymbolRefAttr func = getFunc(mod, loc, "resize_index", TypeRange(), {tensorType, indexType, indexType});
-    mlir::CallOp result = builder.create<mlir::CallOp>(loc, func, TypeRange(), ArrayRef<Value>({csrTensor, d, size}));
+    mlir::CallOp result = builder.create<mlir::CallOp>(loc, func, TypeRange(), ArrayRef<Value>({csxTensor, d, size}));
 
     return result;
 }
@@ -216,12 +301,12 @@ mlir::CallOp callResizeIndex(OpBuilder &builder, ModuleOp &mod, Location loc,
 mlir::CallOp callResizeValues(OpBuilder &builder, ModuleOp &mod, Location loc,
                               Value tensor, Value size)
 {
-    Value csrTensor = convertToExternalCSR(builder, mod, loc, tensor);
-    Type tensorType = csrTensor.getType();
+    Value csxTensor = convertToExternalCSX(builder, mod, loc, tensor);
+    Type tensorType = csxTensor.getType();
 
     Type indexType = builder.getIndexType();
     FlatSymbolRefAttr func = getFunc(mod, loc, "resize_values", TypeRange(), {tensorType, indexType});
-    mlir::CallOp result = builder.create<mlir::CallOp>(loc, func, TypeRange(), ArrayRef<Value>({csrTensor, size}));
+    mlir::CallOp result = builder.create<mlir::CallOp>(loc, func, TypeRange(), ArrayRef<Value>({csxTensor, size}));
 
     return result;
 }

--- a/mlir_graphblas/src/test/GraphBLAS/lower_apply.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_apply.mlir
@@ -7,26 +7,32 @@
   indexBitWidth = 64
 }>
 
+// CHECK-LABEL:   func private @cast_csx_to_csr(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:         func private @dup_tensor(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:         func private @cast_csr_to_csx(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+
 // CHECK-LABEL:   func @apply_min(
 // CHECK-SAME:                    %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                    %[[VAL_1:.*]]: f64) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:           %[[VAL_2:.*]] = constant 0 : index
 // CHECK:           %[[VAL_3:.*]] = constant 1 : index
-// CHECK:           %[[VAL_4:.*]] = call @dup_tensor(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_5:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_6:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_7:.*]] = sparse_tensor.values %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_8:.*]] = memref.dim %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_9:.*]] = memref.load %[[VAL_5]]{{\[}}%[[VAL_8]]] : memref<?xi64>
-// CHECK:           %[[VAL_10:.*]] = index_cast %[[VAL_9]] : i64 to index
-// CHECK:           scf.parallel (%[[VAL_11:.*]]) = (%[[VAL_2]]) to (%[[VAL_10]]) step (%[[VAL_3]]) {
-// CHECK:             %[[VAL_12:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_11]]] : memref<?xf64>
-// CHECK:             %[[VAL_13:.*]] = cmpf olt, %[[VAL_12]], %[[VAL_1]] : f64
-// CHECK:             %[[VAL_14:.*]] = select %[[VAL_13]], %[[VAL_12]], %[[VAL_1]] : f64
-// CHECK:             memref.store %[[VAL_14]], %[[VAL_7]]{{\[}}%[[VAL_11]]] : memref<?xf64>
+// CHECK:           %[[VAL_4:.*]] = call @cast_csr_to_csx(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_5:.*]] = call @dup_tensor(%[[VAL_4]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_6:.*]] = call @cast_csx_to_csr(%[[VAL_5]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_7:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_8:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_9:.*]] = sparse_tensor.values %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_10:.*]] = memref.dim %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_11:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_10]]] : memref<?xi64>
+// CHECK:           %[[VAL_12:.*]] = index_cast %[[VAL_11]] : i64 to index
+// CHECK:           scf.parallel (%[[VAL_13:.*]]) = (%[[VAL_2]]) to (%[[VAL_12]]) step (%[[VAL_3]]) {
+// CHECK:             %[[VAL_14:.*]] = memref.load %[[VAL_8]]{{\[}}%[[VAL_13]]] : memref<?xf64>
+// CHECK:             %[[VAL_15:.*]] = cmpf olt, %[[VAL_14]], %[[VAL_1]] : f64
+// CHECK:             %[[VAL_16:.*]] = select %[[VAL_15]], %[[VAL_14]], %[[VAL_1]] : f64
+// CHECK:             memref.store %[[VAL_16]], %[[VAL_9]]{{\[}}%[[VAL_13]]] : memref<?xf64>
 // CHECK:             scf.yield
 // CHECK:           }
-// CHECK:           return %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           return %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
 
 func @apply_min(%sparse_tensor: tensor<?x?xf64, #CSR64>, %thunk: f64) -> tensor<?x?xf64, #CSR64> {

--- a/mlir_graphblas/src/test/GraphBLAS/lower_convert_layout.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_convert_layout.mlir
@@ -14,13 +14,15 @@
   indexBitWidth = 64
 }>
 
-// CHECK-LABEL:   func private @resize_values(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index)
-// CHECK:         func private @resize_index(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK:         func private @resize_pointers(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK:         func private @resize_dim(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK:         func private @cast_csr_to_csc(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:         func private @empty_like(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:         func private @cast_csc_to_csr(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK-LABEL:   func private @cast_csx_to_csc(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:         func private @cast_csr_to_csx(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:         func private @cast_csx_to_csr(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:         func private @resize_values(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index)
+// CHECK:         func private @resize_index(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
+// CHECK:         func private @resize_pointers(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
+// CHECK:         func private @resize_dim(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
+// CHECK:         func private @empty_like(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:         func private @cast_csc_to_csx(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
 
 // CHECK-LABEL:   func @convert_layout(
 // CHECK-SAME:                         %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
@@ -36,64 +38,65 @@
 // CHECK:           %[[VAL_10:.*]] = addi %[[VAL_9]], %[[VAL_2]] : index
 // CHECK:           %[[VAL_11:.*]] = memref.load %[[VAL_5]]{{\[}}%[[VAL_8]]] : memref<?xi64>
 // CHECK:           %[[VAL_12:.*]] = index_cast %[[VAL_11]] : i64 to index
-// CHECK:           %[[VAL_13:.*]] = call @empty_like(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @resize_dim(%[[VAL_13]], %[[VAL_1]], %[[VAL_8]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @resize_dim(%[[VAL_13]], %[[VAL_2]], %[[VAL_9]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @resize_pointers(%[[VAL_13]], %[[VAL_2]], %[[VAL_10]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @resize_index(%[[VAL_13]], %[[VAL_2]], %[[VAL_12]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @resize_values(%[[VAL_13]], %[[VAL_12]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
-// CHECK:           %[[VAL_14:.*]] = sparse_tensor.pointers %[[VAL_13]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_15:.*]] = sparse_tensor.indices %[[VAL_13]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_16:.*]] = sparse_tensor.values %[[VAL_13]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           scf.for %[[VAL_17:.*]] = %[[VAL_1]] to %[[VAL_9]] step %[[VAL_2]] {
-// CHECK:             memref.store %[[VAL_3]], %[[VAL_14]]{{\[}}%[[VAL_17]]] : memref<?xi64>
+// CHECK:           %[[VAL_13:.*]] = call @cast_csr_to_csx(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_14:.*]] = call @empty_like(%[[VAL_13]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           call @resize_dim(%[[VAL_14]], %[[VAL_1]], %[[VAL_8]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK:           call @resize_dim(%[[VAL_14]], %[[VAL_2]], %[[VAL_9]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK:           call @resize_pointers(%[[VAL_14]], %[[VAL_2]], %[[VAL_10]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK:           call @resize_index(%[[VAL_14]], %[[VAL_2]], %[[VAL_12]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK:           call @resize_values(%[[VAL_14]], %[[VAL_12]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
+// CHECK:           %[[VAL_15:.*]] = call @cast_csx_to_csc(%[[VAL_14]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_16:.*]] = sparse_tensor.pointers %[[VAL_15]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_17:.*]] = sparse_tensor.indices %[[VAL_15]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_18:.*]] = sparse_tensor.values %[[VAL_15]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           scf.for %[[VAL_19:.*]] = %[[VAL_1]] to %[[VAL_9]] step %[[VAL_2]] {
+// CHECK:             memref.store %[[VAL_3]], %[[VAL_16]]{{\[}}%[[VAL_19]]] : memref<?xi64>
 // CHECK:           }
-// CHECK:           scf.for %[[VAL_18:.*]] = %[[VAL_1]] to %[[VAL_12]] step %[[VAL_2]] {
-// CHECK:             %[[VAL_19:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_18]]] : memref<?xi64>
-// CHECK:             %[[VAL_20:.*]] = index_cast %[[VAL_19]] : i64 to index
-// CHECK:             %[[VAL_21:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_20]]] : memref<?xi64>
-// CHECK:             %[[VAL_22:.*]] = addi %[[VAL_21]], %[[VAL_4]] : i64
-// CHECK:             memref.store %[[VAL_22]], %[[VAL_14]]{{\[}}%[[VAL_20]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_20:.*]] = %[[VAL_1]] to %[[VAL_12]] step %[[VAL_2]] {
+// CHECK:             %[[VAL_21:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_20]]] : memref<?xi64>
+// CHECK:             %[[VAL_22:.*]] = index_cast %[[VAL_21]] : i64 to index
+// CHECK:             %[[VAL_23:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_22]]] : memref<?xi64>
+// CHECK:             %[[VAL_24:.*]] = addi %[[VAL_23]], %[[VAL_4]] : i64
+// CHECK:             memref.store %[[VAL_24]], %[[VAL_16]]{{\[}}%[[VAL_22]]] : memref<?xi64>
 // CHECK:           }
-// CHECK:           memref.store %[[VAL_3]], %[[VAL_14]]{{\[}}%[[VAL_9]]] : memref<?xi64>
-// CHECK:           scf.for %[[VAL_23:.*]] = %[[VAL_1]] to %[[VAL_9]] step %[[VAL_2]] {
-// CHECK:             %[[VAL_24:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_23]]] : memref<?xi64>
-// CHECK:             %[[VAL_25:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_9]]] : memref<?xi64>
-// CHECK:             memref.store %[[VAL_25]], %[[VAL_14]]{{\[}}%[[VAL_23]]] : memref<?xi64>
-// CHECK:             %[[VAL_26:.*]] = addi %[[VAL_25]], %[[VAL_24]] : i64
-// CHECK:             memref.store %[[VAL_26]], %[[VAL_14]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:           memref.store %[[VAL_3]], %[[VAL_16]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_25:.*]] = %[[VAL_1]] to %[[VAL_9]] step %[[VAL_2]] {
+// CHECK:             %[[VAL_26:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_25]]] : memref<?xi64>
+// CHECK:             %[[VAL_27:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_27]], %[[VAL_16]]{{\[}}%[[VAL_25]]] : memref<?xi64>
+// CHECK:             %[[VAL_28:.*]] = addi %[[VAL_27]], %[[VAL_26]] : i64
+// CHECK:             memref.store %[[VAL_28]], %[[VAL_16]]{{\[}}%[[VAL_9]]] : memref<?xi64>
 // CHECK:           }
-// CHECK:           scf.for %[[VAL_27:.*]] = %[[VAL_1]] to %[[VAL_8]] step %[[VAL_2]] {
-// CHECK:             %[[VAL_28:.*]] = index_cast %[[VAL_27]] : index to i64
-// CHECK:             %[[VAL_29:.*]] = memref.load %[[VAL_5]]{{\[}}%[[VAL_27]]] : memref<?xi64>
-// CHECK:             %[[VAL_30:.*]] = index_cast %[[VAL_29]] : i64 to index
-// CHECK:             %[[VAL_31:.*]] = addi %[[VAL_27]], %[[VAL_2]] : index
-// CHECK:             %[[VAL_32:.*]] = memref.load %[[VAL_5]]{{\[}}%[[VAL_31]]] : memref<?xi64>
-// CHECK:             %[[VAL_33:.*]] = index_cast %[[VAL_32]] : i64 to index
-// CHECK:             scf.for %[[VAL_34:.*]] = %[[VAL_30]] to %[[VAL_33]] step %[[VAL_2]] {
-// CHECK:               %[[VAL_35:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_34]]] : memref<?xi64>
-// CHECK:               %[[VAL_36:.*]] = index_cast %[[VAL_35]] : i64 to index
-// CHECK:               %[[VAL_37:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_36]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_29:.*]] = %[[VAL_1]] to %[[VAL_8]] step %[[VAL_2]] {
+// CHECK:             %[[VAL_30:.*]] = index_cast %[[VAL_29]] : index to i64
+// CHECK:             %[[VAL_31:.*]] = memref.load %[[VAL_5]]{{\[}}%[[VAL_29]]] : memref<?xi64>
+// CHECK:             %[[VAL_32:.*]] = index_cast %[[VAL_31]] : i64 to index
+// CHECK:             %[[VAL_33:.*]] = addi %[[VAL_29]], %[[VAL_2]] : index
+// CHECK:             %[[VAL_34:.*]] = memref.load %[[VAL_5]]{{\[}}%[[VAL_33]]] : memref<?xi64>
+// CHECK:             %[[VAL_35:.*]] = index_cast %[[VAL_34]] : i64 to index
+// CHECK:             scf.for %[[VAL_36:.*]] = %[[VAL_32]] to %[[VAL_35]] step %[[VAL_2]] {
+// CHECK:               %[[VAL_37:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_36]]] : memref<?xi64>
 // CHECK:               %[[VAL_38:.*]] = index_cast %[[VAL_37]] : i64 to index
-// CHECK:               memref.store %[[VAL_28]], %[[VAL_15]]{{\[}}%[[VAL_38]]] : memref<?xi64>
-// CHECK:               %[[VAL_39:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_34]]] : memref<?xf64>
-// CHECK:               memref.store %[[VAL_39]], %[[VAL_16]]{{\[}}%[[VAL_38]]] : memref<?xf64>
-// CHECK:               %[[VAL_40:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_36]]] : memref<?xi64>
-// CHECK:               %[[VAL_41:.*]] = addi %[[VAL_40]], %[[VAL_4]] : i64
-// CHECK:               memref.store %[[VAL_41]], %[[VAL_14]]{{\[}}%[[VAL_36]]] : memref<?xi64>
+// CHECK:               %[[VAL_39:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_38]]] : memref<?xi64>
+// CHECK:               %[[VAL_40:.*]] = index_cast %[[VAL_39]] : i64 to index
+// CHECK:               memref.store %[[VAL_30]], %[[VAL_17]]{{\[}}%[[VAL_40]]] : memref<?xi64>
+// CHECK:               %[[VAL_41:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_36]]] : memref<?xf64>
+// CHECK:               memref.store %[[VAL_41]], %[[VAL_18]]{{\[}}%[[VAL_40]]] : memref<?xf64>
+// CHECK:               %[[VAL_42:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_38]]] : memref<?xi64>
+// CHECK:               %[[VAL_43:.*]] = addi %[[VAL_42]], %[[VAL_4]] : i64
+// CHECK:               memref.store %[[VAL_43]], %[[VAL_16]]{{\[}}%[[VAL_38]]] : memref<?xi64>
 // CHECK:             }
 // CHECK:           }
-// CHECK:           %[[VAL_42:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_9]]] : memref<?xi64>
-// CHECK:           memref.store %[[VAL_3]], %[[VAL_14]]{{\[}}%[[VAL_9]]] : memref<?xi64>
-// CHECK:           scf.for %[[VAL_43:.*]] = %[[VAL_1]] to %[[VAL_9]] step %[[VAL_2]] {
-// CHECK:             %[[VAL_44:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_43]]] : memref<?xi64>
-// CHECK:             %[[VAL_45:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_9]]] : memref<?xi64>
-// CHECK:             memref.store %[[VAL_45]], %[[VAL_14]]{{\[}}%[[VAL_43]]] : memref<?xi64>
-// CHECK:             memref.store %[[VAL_44]], %[[VAL_14]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:           %[[VAL_44:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:           memref.store %[[VAL_3]], %[[VAL_16]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_45:.*]] = %[[VAL_1]] to %[[VAL_9]] step %[[VAL_2]] {
+// CHECK:             %[[VAL_46:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_45]]] : memref<?xi64>
+// CHECK:             %[[VAL_47:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_47]], %[[VAL_16]]{{\[}}%[[VAL_45]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_46]], %[[VAL_16]]{{\[}}%[[VAL_9]]] : memref<?xi64>
 // CHECK:           }
-// CHECK:           memref.store %[[VAL_42]], %[[VAL_14]]{{\[}}%[[VAL_9]]] : memref<?xi64>
-// CHECK:           %[[VAL_46:.*]] = call @cast_csr_to_csc(%[[VAL_13]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           return %[[VAL_46]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           memref.store %[[VAL_44]], %[[VAL_16]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:           return %[[VAL_15]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
 
 func @convert_layout(%sparse_tensor: tensor<?x?xf64, #CSR64>) -> tensor<?x?xf64, #CSC64> {

--- a/mlir_graphblas/src/test/GraphBLAS/lower_matrix_multiply.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_matrix_multiply.mlir
@@ -14,10 +14,17 @@
   indexBitWidth = 64
 }>
 
+// CHECK-LABEL:   func private @resize_values(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index)
+// CHECK:         func private @resize_index(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
+// CHECK:         func private @cast_csx_to_csr(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:         func private @resize_pointers(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
+// CHECK:         func private @resize_dim(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
+// CHECK:         func private @empty_like(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:         func private @cast_csr_to_csx(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+
 // CHECK-LABEL:   func @matrix_multiply_plus_times(
-// CHECK-SAME:        %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
-// CHECK-SAME:        %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK-SAME:    ) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK-SAME:                                     %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
+// CHECK-SAME:                                     %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:           %[[VAL_2:.*]] = constant 0 : index
 // CHECK:           %[[VAL_3:.*]] = constant 1 : index
 // CHECK:           %[[VAL_4:.*]] = constant 0 : i64
@@ -35,145 +42,148 @@
 // CHECK:           %[[VAL_16:.*]] = memref.dim %[[VAL_1]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_17:.*]] = memref.dim %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_18:.*]] = addi %[[VAL_15]], %[[VAL_3]] : index
-// CHECK:           %[[VAL_19:.*]] = call @empty_like(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @resize_dim(%[[VAL_19]], %[[VAL_2]], %[[VAL_15]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @resize_dim(%[[VAL_19]], %[[VAL_3]], %[[VAL_16]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @resize_pointers(%[[VAL_19]], %[[VAL_3]], %[[VAL_18]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           %[[VAL_20:.*]] = sparse_tensor.pointers %[[VAL_19]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           scf.parallel (%[[VAL_21:.*]]) = (%[[VAL_2]]) to (%[[VAL_15]]) step (%[[VAL_3]]) {
-// CHECK:             %[[VAL_22:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_21]]] : memref<?xi64>
-// CHECK:             %[[VAL_23:.*]] = addi %[[VAL_21]], %[[VAL_3]] : index
+// CHECK:           %[[VAL_19:.*]] = call @cast_csr_to_csx(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_20:.*]] = call @empty_like(%[[VAL_19]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           call @resize_dim(%[[VAL_20]], %[[VAL_2]], %[[VAL_15]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK:           call @resize_dim(%[[VAL_20]], %[[VAL_3]], %[[VAL_16]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK:           call @resize_pointers(%[[VAL_20]], %[[VAL_3]], %[[VAL_18]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK:           %[[VAL_21:.*]] = call @cast_csx_to_csr(%[[VAL_20]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_22:.*]] = sparse_tensor.pointers %[[VAL_21]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           scf.parallel (%[[VAL_23:.*]]) = (%[[VAL_2]]) to (%[[VAL_15]]) step (%[[VAL_3]]) {
 // CHECK:             %[[VAL_24:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_23]]] : memref<?xi64>
-// CHECK:             %[[VAL_25:.*]] = cmpi eq, %[[VAL_22]], %[[VAL_24]] : i64
-// CHECK:             %[[VAL_26:.*]] = scf.if %[[VAL_25]] -> (i64) {
+// CHECK:             %[[VAL_25:.*]] = addi %[[VAL_23]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_26:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_25]]] : memref<?xi64>
+// CHECK:             %[[VAL_27:.*]] = cmpi eq, %[[VAL_24]], %[[VAL_26]] : i64
+// CHECK:             %[[VAL_28:.*]] = scf.if %[[VAL_27]] -> (i64) {
 // CHECK:               scf.yield %[[VAL_4]] : i64
 // CHECK:             } else {
-// CHECK:               %[[VAL_27:.*]] = index_cast %[[VAL_22]] : i64 to index
-// CHECK:               %[[VAL_28:.*]] = index_cast %[[VAL_24]] : i64 to index
-// CHECK:               %[[VAL_29:.*]] = memref.alloc(%[[VAL_17]]) : memref<?xi1>
-// CHECK:               linalg.fill(%[[VAL_29]], %[[VAL_8]]) : memref<?xi1>, i1
-// CHECK:               scf.parallel (%[[VAL_30:.*]]) = (%[[VAL_27]]) to (%[[VAL_28]]) step (%[[VAL_3]]) {
-// CHECK:                 %[[VAL_31:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_30]]] : memref<?xi64>
-// CHECK:                 %[[VAL_32:.*]] = index_cast %[[VAL_31]] : i64 to index
-// CHECK:                 memref.store %[[VAL_7]], %[[VAL_29]]{{\[}}%[[VAL_32]]] : memref<?xi1>
+// CHECK:               %[[VAL_29:.*]] = index_cast %[[VAL_24]] : i64 to index
+// CHECK:               %[[VAL_30:.*]] = index_cast %[[VAL_26]] : i64 to index
+// CHECK:               %[[VAL_31:.*]] = memref.alloc(%[[VAL_17]]) : memref<?xi1>
+// CHECK:               linalg.fill(%[[VAL_31]], %[[VAL_8]]) : memref<?xi1>, i1
+// CHECK:               scf.parallel (%[[VAL_32:.*]]) = (%[[VAL_29]]) to (%[[VAL_30]]) step (%[[VAL_3]]) {
+// CHECK:                 %[[VAL_33:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_32]]] : memref<?xi64>
+// CHECK:                 %[[VAL_34:.*]] = index_cast %[[VAL_33]] : i64 to index
+// CHECK:                 memref.store %[[VAL_7]], %[[VAL_31]]{{\[}}%[[VAL_34]]] : memref<?xi1>
 // CHECK:                 scf.yield
 // CHECK:               }
-// CHECK:               %[[VAL_33:.*]] = scf.parallel (%[[VAL_34:.*]]) = (%[[VAL_2]]) to (%[[VAL_16]]) step (%[[VAL_3]]) init (%[[VAL_4]]) -> i64 {
-// CHECK:                 %[[VAL_35:.*]] = addi %[[VAL_34]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_36:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_34]]] : memref<?xi64>
-// CHECK:                 %[[VAL_37:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_35]]] : memref<?xi64>
-// CHECK:                 %[[VAL_38:.*]] = cmpi eq, %[[VAL_36]], %[[VAL_37]] : i64
-// CHECK:                 %[[VAL_39:.*]] = scf.if %[[VAL_38]] -> (i64) {
+// CHECK:               %[[VAL_35:.*]] = scf.parallel (%[[VAL_36:.*]]) = (%[[VAL_2]]) to (%[[VAL_16]]) step (%[[VAL_3]]) init (%[[VAL_4]]) -> i64 {
+// CHECK:                 %[[VAL_37:.*]] = addi %[[VAL_36]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_38:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_36]]] : memref<?xi64>
+// CHECK:                 %[[VAL_39:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_37]]] : memref<?xi64>
+// CHECK:                 %[[VAL_40:.*]] = cmpi eq, %[[VAL_38]], %[[VAL_39]] : i64
+// CHECK:                 %[[VAL_41:.*]] = scf.if %[[VAL_40]] -> (i64) {
 // CHECK:                   scf.yield %[[VAL_4]] : i64
 // CHECK:                 } else {
-// CHECK:                   %[[VAL_40:.*]] = scf.while (%[[VAL_41:.*]] = %[[VAL_36]]) : (i64) -> i64 {
-// CHECK:                     %[[VAL_42:.*]] = cmpi uge, %[[VAL_41]], %[[VAL_37]] : i64
-// CHECK:                     %[[VAL_43:.*]]:2 = scf.if %[[VAL_42]] -> (i1, i64) {
+// CHECK:                   %[[VAL_42:.*]] = scf.while (%[[VAL_43:.*]] = %[[VAL_38]]) : (i64) -> i64 {
+// CHECK:                     %[[VAL_44:.*]] = cmpi uge, %[[VAL_43]], %[[VAL_39]] : i64
+// CHECK:                     %[[VAL_45:.*]]:2 = scf.if %[[VAL_44]] -> (i1, i64) {
 // CHECK:                       scf.yield %[[VAL_8]], %[[VAL_4]] : i1, i64
 // CHECK:                     } else {
-// CHECK:                       %[[VAL_44:.*]] = index_cast %[[VAL_41]] : i64 to index
-// CHECK:                       %[[VAL_45:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_44]]] : memref<?xi64>
-// CHECK:                       %[[VAL_46:.*]] = index_cast %[[VAL_45]] : i64 to index
-// CHECK:                       %[[VAL_47:.*]] = memref.load %[[VAL_29]]{{\[}}%[[VAL_46]]] : memref<?xi1>
-// CHECK:                       %[[VAL_48:.*]] = select %[[VAL_47]], %[[VAL_8]], %[[VAL_7]] : i1
-// CHECK:                       %[[VAL_49:.*]] = select %[[VAL_47]], %[[VAL_5]], %[[VAL_41]] : i64
-// CHECK:                       scf.yield %[[VAL_48]], %[[VAL_49]] : i1, i64
+// CHECK:                       %[[VAL_46:.*]] = index_cast %[[VAL_43]] : i64 to index
+// CHECK:                       %[[VAL_47:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_46]]] : memref<?xi64>
+// CHECK:                       %[[VAL_48:.*]] = index_cast %[[VAL_47]] : i64 to index
+// CHECK:                       %[[VAL_49:.*]] = memref.load %[[VAL_31]]{{\[}}%[[VAL_48]]] : memref<?xi1>
+// CHECK:                       %[[VAL_50:.*]] = select %[[VAL_49]], %[[VAL_8]], %[[VAL_7]] : i1
+// CHECK:                       %[[VAL_51:.*]] = select %[[VAL_49]], %[[VAL_5]], %[[VAL_43]] : i64
+// CHECK:                       scf.yield %[[VAL_50]], %[[VAL_51]] : i1, i64
 // CHECK:                     }
-// CHECK:                     scf.condition(%[[VAL_50:.*]]#0) %[[VAL_50]]#1 : i64
+// CHECK:                     scf.condition(%[[VAL_52:.*]]#0) %[[VAL_52]]#1 : i64
 // CHECK:                   } do {
-// CHECK:                   ^bb0(%[[VAL_51:.*]]: i64):
-// CHECK:                     %[[VAL_52:.*]] = addi %[[VAL_51]], %[[VAL_5]] : i64
-// CHECK:                     scf.yield %[[VAL_52]] : i64
+// CHECK:                   ^bb0(%[[VAL_53:.*]]: i64):
+// CHECK:                     %[[VAL_54:.*]] = addi %[[VAL_53]], %[[VAL_5]] : i64
+// CHECK:                     scf.yield %[[VAL_54]] : i64
 // CHECK:                   }
-// CHECK:                   scf.yield %[[VAL_53:.*]] : i64
+// CHECK:                   scf.yield %[[VAL_55:.*]] : i64
 // CHECK:                 }
-// CHECK:                 scf.reduce(%[[VAL_54:.*]])  : i64 {
-// CHECK:                 ^bb0(%[[VAL_55:.*]]: i64, %[[VAL_56:.*]]: i64):
-// CHECK:                   %[[VAL_57:.*]] = addi %[[VAL_55]], %[[VAL_56]] : i64
-// CHECK:                   scf.reduce.return %[[VAL_57]] : i64
+// CHECK:                 scf.reduce(%[[VAL_56:.*]])  : i64 {
+// CHECK:                 ^bb0(%[[VAL_57:.*]]: i64, %[[VAL_58:.*]]: i64):
+// CHECK:                   %[[VAL_59:.*]] = addi %[[VAL_57]], %[[VAL_58]] : i64
+// CHECK:                   scf.reduce.return %[[VAL_59]] : i64
 // CHECK:                 }
 // CHECK:                 scf.yield
 // CHECK:               }
-// CHECK:               scf.yield %[[VAL_58:.*]] : i64
+// CHECK:               scf.yield %[[VAL_60:.*]] : i64
 // CHECK:             }
-// CHECK:             memref.store %[[VAL_59:.*]], %[[VAL_20]]{{\[}}%[[VAL_21]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_61:.*]], %[[VAL_22]]{{\[}}%[[VAL_23]]] : memref<?xi64>
 // CHECK:             scf.yield
 // CHECK:           }
-// CHECK:           scf.for %[[VAL_60:.*]] = %[[VAL_2]] to %[[VAL_15]] step %[[VAL_3]] {
-// CHECK:             %[[VAL_61:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_60]]] : memref<?xi64>
-// CHECK:             %[[VAL_62:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_15]]] : memref<?xi64>
-// CHECK:             memref.store %[[VAL_62]], %[[VAL_20]]{{\[}}%[[VAL_60]]] : memref<?xi64>
-// CHECK:             %[[VAL_63:.*]] = addi %[[VAL_62]], %[[VAL_61]] : i64
-// CHECK:             memref.store %[[VAL_63]], %[[VAL_20]]{{\[}}%[[VAL_15]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_62:.*]] = %[[VAL_2]] to %[[VAL_15]] step %[[VAL_3]] {
+// CHECK:             %[[VAL_63:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_62]]] : memref<?xi64>
+// CHECK:             %[[VAL_64:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_15]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_64]], %[[VAL_22]]{{\[}}%[[VAL_62]]] : memref<?xi64>
+// CHECK:             %[[VAL_65:.*]] = addi %[[VAL_64]], %[[VAL_63]] : i64
+// CHECK:             memref.store %[[VAL_65]], %[[VAL_22]]{{\[}}%[[VAL_15]]] : memref<?xi64>
 // CHECK:           }
-// CHECK:           %[[VAL_64:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_15]]] : memref<?xi64>
-// CHECK:           %[[VAL_65:.*]] = index_cast %[[VAL_64]] : i64 to index
-// CHECK:           call @resize_index(%[[VAL_19]], %[[VAL_3]], %[[VAL_65]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @resize_values(%[[VAL_19]], %[[VAL_65]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
-// CHECK:           %[[VAL_66:.*]] = sparse_tensor.indices %[[VAL_19]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_67:.*]] = sparse_tensor.values %[[VAL_19]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           scf.parallel (%[[VAL_68:.*]]) = (%[[VAL_2]]) to (%[[VAL_15]]) step (%[[VAL_3]]) {
-// CHECK:             %[[VAL_69:.*]] = addi %[[VAL_68]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_70:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_68]]] : memref<?xi64>
-// CHECK:             %[[VAL_71:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_69]]] : memref<?xi64>
-// CHECK:             %[[VAL_72:.*]] = cmpi ne, %[[VAL_70]], %[[VAL_71]] : i64
-// CHECK:             scf.if %[[VAL_72]] {
-// CHECK:               %[[VAL_73:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_68]]] : memref<?xi64>
-// CHECK:               %[[VAL_74:.*]] = index_cast %[[VAL_73]] : i64 to index
-// CHECK:               %[[VAL_75:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_68]]] : memref<?xi64>
-// CHECK:               %[[VAL_76:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_69]]] : memref<?xi64>
-// CHECK:               %[[VAL_77:.*]] = index_cast %[[VAL_75]] : i64 to index
-// CHECK:               %[[VAL_78:.*]] = index_cast %[[VAL_76]] : i64 to index
-// CHECK:               %[[VAL_79:.*]] = memref.alloc(%[[VAL_17]]) : memref<?xf64>
-// CHECK:               %[[VAL_80:.*]] = memref.alloc(%[[VAL_17]]) : memref<?xi1>
-// CHECK:               linalg.fill(%[[VAL_80]], %[[VAL_8]]) : memref<?xi1>, i1
-// CHECK:               scf.parallel (%[[VAL_81:.*]]) = (%[[VAL_77]]) to (%[[VAL_78]]) step (%[[VAL_3]]) {
-// CHECK:                 %[[VAL_82:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_81]]] : memref<?xi64>
-// CHECK:                 %[[VAL_83:.*]] = index_cast %[[VAL_82]] : i64 to index
-// CHECK:                 memref.store %[[VAL_7]], %[[VAL_80]]{{\[}}%[[VAL_83]]] : memref<?xi1>
-// CHECK:                 %[[VAL_84:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_81]]] : memref<?xf64>
-// CHECK:                 memref.store %[[VAL_84]], %[[VAL_79]]{{\[}}%[[VAL_83]]] : memref<?xf64>
+// CHECK:           %[[VAL_66:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_15]]] : memref<?xi64>
+// CHECK:           %[[VAL_67:.*]] = index_cast %[[VAL_66]] : i64 to index
+// CHECK:           %[[VAL_68:.*]] = call @cast_csr_to_csx(%[[VAL_21]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           call @resize_index(%[[VAL_68]], %[[VAL_3]], %[[VAL_67]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK:           %[[VAL_69:.*]] = call @cast_csr_to_csx(%[[VAL_21]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           call @resize_values(%[[VAL_69]], %[[VAL_67]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
+// CHECK:           %[[VAL_70:.*]] = sparse_tensor.indices %[[VAL_21]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_71:.*]] = sparse_tensor.values %[[VAL_21]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           scf.parallel (%[[VAL_72:.*]]) = (%[[VAL_2]]) to (%[[VAL_15]]) step (%[[VAL_3]]) {
+// CHECK:             %[[VAL_73:.*]] = addi %[[VAL_72]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_74:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_72]]] : memref<?xi64>
+// CHECK:             %[[VAL_75:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_73]]] : memref<?xi64>
+// CHECK:             %[[VAL_76:.*]] = cmpi ne, %[[VAL_74]], %[[VAL_75]] : i64
+// CHECK:             scf.if %[[VAL_76]] {
+// CHECK:               %[[VAL_77:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_72]]] : memref<?xi64>
+// CHECK:               %[[VAL_78:.*]] = index_cast %[[VAL_77]] : i64 to index
+// CHECK:               %[[VAL_79:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_72]]] : memref<?xi64>
+// CHECK:               %[[VAL_80:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_73]]] : memref<?xi64>
+// CHECK:               %[[VAL_81:.*]] = index_cast %[[VAL_79]] : i64 to index
+// CHECK:               %[[VAL_82:.*]] = index_cast %[[VAL_80]] : i64 to index
+// CHECK:               %[[VAL_83:.*]] = memref.alloc(%[[VAL_17]]) : memref<?xf64>
+// CHECK:               %[[VAL_84:.*]] = memref.alloc(%[[VAL_17]]) : memref<?xi1>
+// CHECK:               linalg.fill(%[[VAL_84]], %[[VAL_8]]) : memref<?xi1>, i1
+// CHECK:               scf.parallel (%[[VAL_85:.*]]) = (%[[VAL_81]]) to (%[[VAL_82]]) step (%[[VAL_3]]) {
+// CHECK:                 %[[VAL_86:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_85]]] : memref<?xi64>
+// CHECK:                 %[[VAL_87:.*]] = index_cast %[[VAL_86]] : i64 to index
+// CHECK:                 memref.store %[[VAL_7]], %[[VAL_84]]{{\[}}%[[VAL_87]]] : memref<?xi1>
+// CHECK:                 %[[VAL_88:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_85]]] : memref<?xf64>
+// CHECK:                 memref.store %[[VAL_88]], %[[VAL_83]]{{\[}}%[[VAL_87]]] : memref<?xf64>
 // CHECK:                 scf.yield
 // CHECK:               }
-// CHECK:               %[[VAL_85:.*]] = scf.for %[[VAL_86:.*]] = %[[VAL_2]] to %[[VAL_16]] step %[[VAL_3]] iter_args(%[[VAL_87:.*]] = %[[VAL_2]]) -> (index) {
-// CHECK:                 %[[VAL_88:.*]] = index_cast %[[VAL_86]] : index to i64
-// CHECK:                 %[[VAL_89:.*]] = addi %[[VAL_86]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_90:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_86]]] : memref<?xi64>
-// CHECK:                 %[[VAL_91:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_89]]] : memref<?xi64>
-// CHECK:                 %[[VAL_92:.*]] = index_cast %[[VAL_90]] : i64 to index
-// CHECK:                 %[[VAL_93:.*]] = index_cast %[[VAL_91]] : i64 to index
-// CHECK:                 %[[VAL_94:.*]]:2 = scf.for %[[VAL_95:.*]] = %[[VAL_92]] to %[[VAL_93]] step %[[VAL_3]] iter_args(%[[VAL_96:.*]] = %[[VAL_6]], %[[VAL_97:.*]] = %[[VAL_8]]) -> (f64, i1) {
-// CHECK:                   %[[VAL_98:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_95]]] : memref<?xi64>
-// CHECK:                   %[[VAL_99:.*]] = index_cast %[[VAL_98]] : i64 to index
-// CHECK:                   %[[VAL_100:.*]] = memref.load %[[VAL_80]]{{\[}}%[[VAL_99]]] : memref<?xi1>
-// CHECK:                   %[[VAL_101:.*]]:2 = scf.if %[[VAL_100]] -> (f64, i1) {
-// CHECK:                     %[[VAL_102:.*]] = memref.load %[[VAL_79]]{{\[}}%[[VAL_99]]] : memref<?xf64>
-// CHECK:                     %[[VAL_103:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_95]]] : memref<?xf64>
-// CHECK:                     %[[VAL_104:.*]] = mulf %[[VAL_102]], %[[VAL_103]] : f64
-// CHECK:                     %[[VAL_105:.*]] = addf %[[VAL_96]], %[[VAL_104]] : f64
-// CHECK:                     scf.yield %[[VAL_105]], %[[VAL_7]] : f64, i1
+// CHECK:               %[[VAL_89:.*]] = scf.for %[[VAL_90:.*]] = %[[VAL_2]] to %[[VAL_16]] step %[[VAL_3]] iter_args(%[[VAL_91:.*]] = %[[VAL_2]]) -> (index) {
+// CHECK:                 %[[VAL_92:.*]] = index_cast %[[VAL_90]] : index to i64
+// CHECK:                 %[[VAL_93:.*]] = addi %[[VAL_90]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_94:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_90]]] : memref<?xi64>
+// CHECK:                 %[[VAL_95:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_93]]] : memref<?xi64>
+// CHECK:                 %[[VAL_96:.*]] = index_cast %[[VAL_94]] : i64 to index
+// CHECK:                 %[[VAL_97:.*]] = index_cast %[[VAL_95]] : i64 to index
+// CHECK:                 %[[VAL_98:.*]]:2 = scf.for %[[VAL_99:.*]] = %[[VAL_96]] to %[[VAL_97]] step %[[VAL_3]] iter_args(%[[VAL_100:.*]] = %[[VAL_6]], %[[VAL_101:.*]] = %[[VAL_8]]) -> (f64, i1) {
+// CHECK:                   %[[VAL_102:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_99]]] : memref<?xi64>
+// CHECK:                   %[[VAL_103:.*]] = index_cast %[[VAL_102]] : i64 to index
+// CHECK:                   %[[VAL_104:.*]] = memref.load %[[VAL_84]]{{\[}}%[[VAL_103]]] : memref<?xi1>
+// CHECK:                   %[[VAL_105:.*]]:2 = scf.if %[[VAL_104]] -> (f64, i1) {
+// CHECK:                     %[[VAL_106:.*]] = memref.load %[[VAL_83]]{{\[}}%[[VAL_103]]] : memref<?xf64>
+// CHECK:                     %[[VAL_107:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_99]]] : memref<?xf64>
+// CHECK:                     %[[VAL_108:.*]] = mulf %[[VAL_106]], %[[VAL_107]] : f64
+// CHECK:                     %[[VAL_109:.*]] = addf %[[VAL_100]], %[[VAL_108]] : f64
+// CHECK:                     scf.yield %[[VAL_109]], %[[VAL_7]] : f64, i1
 // CHECK:                   } else {
-// CHECK:                     scf.yield %[[VAL_96]], %[[VAL_97]] : f64, i1
+// CHECK:                     scf.yield %[[VAL_100]], %[[VAL_101]] : f64, i1
 // CHECK:                   }
-// CHECK:                   scf.yield %[[VAL_106:.*]]#0, %[[VAL_106]]#1 : f64, i1
+// CHECK:                   scf.yield %[[VAL_110:.*]]#0, %[[VAL_110]]#1 : f64, i1
 // CHECK:                 }
-// CHECK:                 %[[VAL_107:.*]] = scf.if %[[VAL_108:.*]]#1 -> (index) {
-// CHECK:                   %[[VAL_109:.*]] = addi %[[VAL_74]], %[[VAL_87]] : index
-// CHECK:                   memref.store %[[VAL_88]], %[[VAL_66]]{{\[}}%[[VAL_109]]] : memref<?xi64>
-// CHECK:                   memref.store %[[VAL_108]]#0, %[[VAL_67]]{{\[}}%[[VAL_109]]] : memref<?xf64>
-// CHECK:                   %[[VAL_110:.*]] = addi %[[VAL_87]], %[[VAL_3]] : index
-// CHECK:                   scf.yield %[[VAL_110]] : index
+// CHECK:                 %[[VAL_111:.*]] = scf.if %[[VAL_112:.*]]#1 -> (index) {
+// CHECK:                   %[[VAL_113:.*]] = addi %[[VAL_78]], %[[VAL_91]] : index
+// CHECK:                   memref.store %[[VAL_92]], %[[VAL_70]]{{\[}}%[[VAL_113]]] : memref<?xi64>
+// CHECK:                   memref.store %[[VAL_112]]#0, %[[VAL_71]]{{\[}}%[[VAL_113]]] : memref<?xf64>
+// CHECK:                   %[[VAL_114:.*]] = addi %[[VAL_91]], %[[VAL_3]] : index
+// CHECK:                   scf.yield %[[VAL_114]] : index
 // CHECK:                 } else {
-// CHECK:                   scf.yield %[[VAL_87]] : index
+// CHECK:                   scf.yield %[[VAL_91]] : index
 // CHECK:                 }
-// CHECK:                 scf.yield %[[VAL_111:.*]] : index
+// CHECK:                 scf.yield %[[VAL_115:.*]] : index
 // CHECK:               }
 // CHECK:             }
 // CHECK:             scf.yield
 // CHECK:           }
-// CHECK:           return %[[VAL_19]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           return %[[VAL_21]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
-
 
 func @matrix_multiply_plus_times(%a: tensor<?x?xf64, #CSR64>, %b: tensor<?x?xf64, #CSC64>) -> tensor<?x?xf64, #CSR64> {
     %answer = graphblas.matrix_multiply %a, %b { semiring = "plus_times" } : (tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSC64>) to tensor<?x?xf64, #CSR64>

--- a/mlir_graphblas/src/test/GraphBLAS/lower_matrix_multiply_mask.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_matrix_multiply_mask.mlir
@@ -14,12 +14,18 @@
   indexBitWidth = 64
 }>
 
+// CHECK-LABEL:   func private @resize_values(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index)
+// CHECK:         func private @resize_index(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
+// CHECK:         func private @cast_csx_to_csr(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:         func private @resize_pointers(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
+// CHECK:         func private @resize_dim(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
+// CHECK:         func private @empty_like(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:         func private @cast_csr_to_csx(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
 
 // CHECK-LABEL:   func @matrix_multiply_mask_plus_pair(
-// CHECK-SAME:        %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
-// CHECK-SAME:        %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
-// CHECK-SAME:        %[[VAL_2:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK-SAME:    ) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK-SAME:                                         %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
+// CHECK-SAME:                                         %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
+// CHECK-SAME:                                         %[[VAL_2:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:           %[[VAL_3:.*]] = constant 0 : index
 // CHECK:           %[[VAL_4:.*]] = constant 1 : index
 // CHECK:           %[[VAL_5:.*]] = constant 0 : i64
@@ -39,153 +45,156 @@
 // CHECK:           %[[VAL_19:.*]] = addi %[[VAL_16]], %[[VAL_4]] : index
 // CHECK:           %[[VAL_20:.*]] = sparse_tensor.pointers %[[VAL_2]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_21:.*]] = sparse_tensor.indices %[[VAL_2]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_22:.*]] = call @empty_like(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @resize_dim(%[[VAL_22]], %[[VAL_3]], %[[VAL_16]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @resize_dim(%[[VAL_22]], %[[VAL_4]], %[[VAL_17]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @resize_pointers(%[[VAL_22]], %[[VAL_4]], %[[VAL_19]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           %[[VAL_23:.*]] = sparse_tensor.pointers %[[VAL_22]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           scf.parallel (%[[VAL_24:.*]]) = (%[[VAL_3]]) to (%[[VAL_16]]) step (%[[VAL_4]]) {
-// CHECK:             %[[VAL_25:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_24]]] : memref<?xi64>
-// CHECK:             %[[VAL_26:.*]] = addi %[[VAL_24]], %[[VAL_4]] : index
+// CHECK:           %[[VAL_22:.*]] = call @cast_csr_to_csx(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_23:.*]] = call @empty_like(%[[VAL_22]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           call @resize_dim(%[[VAL_23]], %[[VAL_3]], %[[VAL_16]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK:           call @resize_dim(%[[VAL_23]], %[[VAL_4]], %[[VAL_17]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK:           call @resize_pointers(%[[VAL_23]], %[[VAL_4]], %[[VAL_19]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK:           %[[VAL_24:.*]] = call @cast_csx_to_csr(%[[VAL_23]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_25:.*]] = sparse_tensor.pointers %[[VAL_24]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           scf.parallel (%[[VAL_26:.*]]) = (%[[VAL_3]]) to (%[[VAL_16]]) step (%[[VAL_4]]) {
 // CHECK:             %[[VAL_27:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_26]]] : memref<?xi64>
-// CHECK:             %[[VAL_28:.*]] = cmpi eq, %[[VAL_25]], %[[VAL_27]] : i64
-// CHECK:             %[[VAL_29:.*]] = scf.if %[[VAL_28]] -> (i64) {
+// CHECK:             %[[VAL_28:.*]] = addi %[[VAL_26]], %[[VAL_4]] : index
+// CHECK:             %[[VAL_29:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_28]]] : memref<?xi64>
+// CHECK:             %[[VAL_30:.*]] = cmpi eq, %[[VAL_27]], %[[VAL_29]] : i64
+// CHECK:             %[[VAL_31:.*]] = scf.if %[[VAL_30]] -> (i64) {
 // CHECK:               scf.yield %[[VAL_5]] : i64
 // CHECK:             } else {
-// CHECK:               %[[VAL_30:.*]] = index_cast %[[VAL_25]] : i64 to index
-// CHECK:               %[[VAL_31:.*]] = index_cast %[[VAL_27]] : i64 to index
-// CHECK:               %[[VAL_32:.*]] = memref.alloc(%[[VAL_18]]) : memref<?xi1>
-// CHECK:               linalg.fill(%[[VAL_32]], %[[VAL_10]]) : memref<?xi1>, i1
-// CHECK:               scf.parallel (%[[VAL_33:.*]]) = (%[[VAL_30]]) to (%[[VAL_31]]) step (%[[VAL_4]]) {
-// CHECK:                 %[[VAL_34:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_33]]] : memref<?xi64>
-// CHECK:                 %[[VAL_35:.*]] = index_cast %[[VAL_34]] : i64 to index
-// CHECK:                 memref.store %[[VAL_9]], %[[VAL_32]]{{\[}}%[[VAL_35]]] : memref<?xi1>
+// CHECK:               %[[VAL_32:.*]] = index_cast %[[VAL_27]] : i64 to index
+// CHECK:               %[[VAL_33:.*]] = index_cast %[[VAL_29]] : i64 to index
+// CHECK:               %[[VAL_34:.*]] = memref.alloc(%[[VAL_18]]) : memref<?xi1>
+// CHECK:               linalg.fill(%[[VAL_34]], %[[VAL_10]]) : memref<?xi1>, i1
+// CHECK:               scf.parallel (%[[VAL_35:.*]]) = (%[[VAL_32]]) to (%[[VAL_33]]) step (%[[VAL_4]]) {
+// CHECK:                 %[[VAL_36:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_35]]] : memref<?xi64>
+// CHECK:                 %[[VAL_37:.*]] = index_cast %[[VAL_36]] : i64 to index
+// CHECK:                 memref.store %[[VAL_9]], %[[VAL_34]]{{\[}}%[[VAL_37]]] : memref<?xi1>
 // CHECK:                 scf.yield
 // CHECK:               }
-// CHECK:               %[[VAL_36:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_24]]] : memref<?xi64>
-// CHECK:               %[[VAL_37:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_26]]] : memref<?xi64>
-// CHECK:               %[[VAL_38:.*]] = index_cast %[[VAL_36]] : i64 to index
-// CHECK:               %[[VAL_39:.*]] = index_cast %[[VAL_37]] : i64 to index
-// CHECK:               %[[VAL_40:.*]] = scf.parallel (%[[VAL_41:.*]]) = (%[[VAL_38]]) to (%[[VAL_39]]) step (%[[VAL_4]]) init (%[[VAL_5]]) -> i64 {
-// CHECK:                 %[[VAL_42:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_41]]] : memref<?xi64>
-// CHECK:                 %[[VAL_43:.*]] = index_cast %[[VAL_42]] : i64 to index
-// CHECK:                 %[[VAL_44:.*]] = addi %[[VAL_43]], %[[VAL_4]] : index
-// CHECK:                 %[[VAL_45:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_43]]] : memref<?xi64>
-// CHECK:                 %[[VAL_46:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_44]]] : memref<?xi64>
-// CHECK:                 %[[VAL_47:.*]] = cmpi eq, %[[VAL_45]], %[[VAL_46]] : i64
-// CHECK:                 %[[VAL_48:.*]] = scf.if %[[VAL_47]] -> (i64) {
+// CHECK:               %[[VAL_38:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_26]]] : memref<?xi64>
+// CHECK:               %[[VAL_39:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_28]]] : memref<?xi64>
+// CHECK:               %[[VAL_40:.*]] = index_cast %[[VAL_38]] : i64 to index
+// CHECK:               %[[VAL_41:.*]] = index_cast %[[VAL_39]] : i64 to index
+// CHECK:               %[[VAL_42:.*]] = scf.parallel (%[[VAL_43:.*]]) = (%[[VAL_40]]) to (%[[VAL_41]]) step (%[[VAL_4]]) init (%[[VAL_5]]) -> i64 {
+// CHECK:                 %[[VAL_44:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_43]]] : memref<?xi64>
+// CHECK:                 %[[VAL_45:.*]] = index_cast %[[VAL_44]] : i64 to index
+// CHECK:                 %[[VAL_46:.*]] = addi %[[VAL_45]], %[[VAL_4]] : index
+// CHECK:                 %[[VAL_47:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_45]]] : memref<?xi64>
+// CHECK:                 %[[VAL_48:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_46]]] : memref<?xi64>
+// CHECK:                 %[[VAL_49:.*]] = cmpi eq, %[[VAL_47]], %[[VAL_48]] : i64
+// CHECK:                 %[[VAL_50:.*]] = scf.if %[[VAL_49]] -> (i64) {
 // CHECK:                   scf.yield %[[VAL_5]] : i64
 // CHECK:                 } else {
-// CHECK:                   %[[VAL_49:.*]] = scf.while (%[[VAL_50:.*]] = %[[VAL_45]]) : (i64) -> i64 {
-// CHECK:                     %[[VAL_51:.*]] = cmpi uge, %[[VAL_50]], %[[VAL_46]] : i64
-// CHECK:                     %[[VAL_52:.*]]:2 = scf.if %[[VAL_51]] -> (i1, i64) {
+// CHECK:                   %[[VAL_51:.*]] = scf.while (%[[VAL_52:.*]] = %[[VAL_47]]) : (i64) -> i64 {
+// CHECK:                     %[[VAL_53:.*]] = cmpi uge, %[[VAL_52]], %[[VAL_48]] : i64
+// CHECK:                     %[[VAL_54:.*]]:2 = scf.if %[[VAL_53]] -> (i1, i64) {
 // CHECK:                       scf.yield %[[VAL_10]], %[[VAL_5]] : i1, i64
 // CHECK:                     } else {
-// CHECK:                       %[[VAL_53:.*]] = index_cast %[[VAL_50]] : i64 to index
-// CHECK:                       %[[VAL_54:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_53]]] : memref<?xi64>
-// CHECK:                       %[[VAL_55:.*]] = index_cast %[[VAL_54]] : i64 to index
-// CHECK:                       %[[VAL_56:.*]] = memref.load %[[VAL_32]]{{\[}}%[[VAL_55]]] : memref<?xi1>
-// CHECK:                       %[[VAL_57:.*]] = select %[[VAL_56]], %[[VAL_10]], %[[VAL_9]] : i1
-// CHECK:                       %[[VAL_58:.*]] = select %[[VAL_56]], %[[VAL_6]], %[[VAL_50]] : i64
-// CHECK:                       scf.yield %[[VAL_57]], %[[VAL_58]] : i1, i64
+// CHECK:                       %[[VAL_55:.*]] = index_cast %[[VAL_52]] : i64 to index
+// CHECK:                       %[[VAL_56:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_55]]] : memref<?xi64>
+// CHECK:                       %[[VAL_57:.*]] = index_cast %[[VAL_56]] : i64 to index
+// CHECK:                       %[[VAL_58:.*]] = memref.load %[[VAL_34]]{{\[}}%[[VAL_57]]] : memref<?xi1>
+// CHECK:                       %[[VAL_59:.*]] = select %[[VAL_58]], %[[VAL_10]], %[[VAL_9]] : i1
+// CHECK:                       %[[VAL_60:.*]] = select %[[VAL_58]], %[[VAL_6]], %[[VAL_52]] : i64
+// CHECK:                       scf.yield %[[VAL_59]], %[[VAL_60]] : i1, i64
 // CHECK:                     }
-// CHECK:                     scf.condition(%[[VAL_59:.*]]#0) %[[VAL_59]]#1 : i64
+// CHECK:                     scf.condition(%[[VAL_61:.*]]#0) %[[VAL_61]]#1 : i64
 // CHECK:                   } do {
-// CHECK:                   ^bb0(%[[VAL_60:.*]]: i64):
-// CHECK:                     %[[VAL_61:.*]] = addi %[[VAL_60]], %[[VAL_6]] : i64
-// CHECK:                     scf.yield %[[VAL_61]] : i64
+// CHECK:                   ^bb0(%[[VAL_62:.*]]: i64):
+// CHECK:                     %[[VAL_63:.*]] = addi %[[VAL_62]], %[[VAL_6]] : i64
+// CHECK:                     scf.yield %[[VAL_63]] : i64
 // CHECK:                   }
-// CHECK:                   scf.yield %[[VAL_62:.*]] : i64
+// CHECK:                   scf.yield %[[VAL_64:.*]] : i64
 // CHECK:                 }
-// CHECK:                 scf.reduce(%[[VAL_63:.*]])  : i64 {
-// CHECK:                 ^bb0(%[[VAL_64:.*]]: i64, %[[VAL_65:.*]]: i64):
-// CHECK:                   %[[VAL_66:.*]] = addi %[[VAL_64]], %[[VAL_65]] : i64
-// CHECK:                   scf.reduce.return %[[VAL_66]] : i64
+// CHECK:                 scf.reduce(%[[VAL_65:.*]])  : i64 {
+// CHECK:                 ^bb0(%[[VAL_66:.*]]: i64, %[[VAL_67:.*]]: i64):
+// CHECK:                   %[[VAL_68:.*]] = addi %[[VAL_66]], %[[VAL_67]] : i64
+// CHECK:                   scf.reduce.return %[[VAL_68]] : i64
 // CHECK:                 }
 // CHECK:                 scf.yield
 // CHECK:               }
-// CHECK:               scf.yield %[[VAL_67:.*]] : i64
+// CHECK:               scf.yield %[[VAL_69:.*]] : i64
 // CHECK:             }
-// CHECK:             memref.store %[[VAL_68:.*]], %[[VAL_23]]{{\[}}%[[VAL_24]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_70:.*]], %[[VAL_25]]{{\[}}%[[VAL_26]]] : memref<?xi64>
 // CHECK:             scf.yield
 // CHECK:           }
-// CHECK:           scf.for %[[VAL_69:.*]] = %[[VAL_3]] to %[[VAL_16]] step %[[VAL_4]] {
-// CHECK:             %[[VAL_70:.*]] = memref.load %[[VAL_23]]{{\[}}%[[VAL_69]]] : memref<?xi64>
-// CHECK:             %[[VAL_71:.*]] = memref.load %[[VAL_23]]{{\[}}%[[VAL_16]]] : memref<?xi64>
-// CHECK:             memref.store %[[VAL_71]], %[[VAL_23]]{{\[}}%[[VAL_69]]] : memref<?xi64>
-// CHECK:             %[[VAL_72:.*]] = addi %[[VAL_71]], %[[VAL_70]] : i64
-// CHECK:             memref.store %[[VAL_72]], %[[VAL_23]]{{\[}}%[[VAL_16]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_71:.*]] = %[[VAL_3]] to %[[VAL_16]] step %[[VAL_4]] {
+// CHECK:             %[[VAL_72:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_71]]] : memref<?xi64>
+// CHECK:             %[[VAL_73:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_16]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_73]], %[[VAL_25]]{{\[}}%[[VAL_71]]] : memref<?xi64>
+// CHECK:             %[[VAL_74:.*]] = addi %[[VAL_73]], %[[VAL_72]] : i64
+// CHECK:             memref.store %[[VAL_74]], %[[VAL_25]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:           }
-// CHECK:           %[[VAL_73:.*]] = memref.load %[[VAL_23]]{{\[}}%[[VAL_16]]] : memref<?xi64>
-// CHECK:           %[[VAL_74:.*]] = index_cast %[[VAL_73]] : i64 to index
-// CHECK:           call @resize_index(%[[VAL_22]], %[[VAL_4]], %[[VAL_74]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @resize_values(%[[VAL_22]], %[[VAL_74]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
-// CHECK:           %[[VAL_75:.*]] = sparse_tensor.indices %[[VAL_22]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_76:.*]] = sparse_tensor.values %[[VAL_22]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           scf.parallel (%[[VAL_77:.*]]) = (%[[VAL_3]]) to (%[[VAL_16]]) step (%[[VAL_4]]) {
-// CHECK:             %[[VAL_78:.*]] = addi %[[VAL_77]], %[[VAL_4]] : index
-// CHECK:             %[[VAL_79:.*]] = memref.load %[[VAL_23]]{{\[}}%[[VAL_77]]] : memref<?xi64>
-// CHECK:             %[[VAL_80:.*]] = memref.load %[[VAL_23]]{{\[}}%[[VAL_78]]] : memref<?xi64>
-// CHECK:             %[[VAL_81:.*]] = cmpi ne, %[[VAL_79]], %[[VAL_80]] : i64
-// CHECK:             scf.if %[[VAL_81]] {
-// CHECK:               %[[VAL_82:.*]] = memref.load %[[VAL_23]]{{\[}}%[[VAL_77]]] : memref<?xi64>
-// CHECK:               %[[VAL_83:.*]] = index_cast %[[VAL_82]] : i64 to index
-// CHECK:               %[[VAL_84:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_77]]] : memref<?xi64>
-// CHECK:               %[[VAL_85:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_78]]] : memref<?xi64>
-// CHECK:               %[[VAL_86:.*]] = index_cast %[[VAL_84]] : i64 to index
-// CHECK:               %[[VAL_87:.*]] = index_cast %[[VAL_85]] : i64 to index
-// CHECK:               %[[VAL_88:.*]] = memref.alloc(%[[VAL_18]]) : memref<?xf64>
-// CHECK:               %[[VAL_89:.*]] = memref.alloc(%[[VAL_18]]) : memref<?xi1>
-// CHECK:               linalg.fill(%[[VAL_89]], %[[VAL_10]]) : memref<?xi1>, i1
-// CHECK:               scf.parallel (%[[VAL_90:.*]]) = (%[[VAL_86]]) to (%[[VAL_87]]) step (%[[VAL_4]]) {
-// CHECK:                 %[[VAL_91:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_90]]] : memref<?xi64>
-// CHECK:                 %[[VAL_92:.*]] = index_cast %[[VAL_91]] : i64 to index
-// CHECK:                 memref.store %[[VAL_9]], %[[VAL_89]]{{\[}}%[[VAL_92]]] : memref<?xi1>
-// CHECK:                 %[[VAL_93:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_90]]] : memref<?xf64>
-// CHECK:                 memref.store %[[VAL_93]], %[[VAL_88]]{{\[}}%[[VAL_92]]] : memref<?xf64>
+// CHECK:           %[[VAL_75:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_16]]] : memref<?xi64>
+// CHECK:           %[[VAL_76:.*]] = index_cast %[[VAL_75]] : i64 to index
+// CHECK:           %[[VAL_77:.*]] = call @cast_csr_to_csx(%[[VAL_24]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           call @resize_index(%[[VAL_77]], %[[VAL_4]], %[[VAL_76]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK:           %[[VAL_78:.*]] = call @cast_csr_to_csx(%[[VAL_24]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           call @resize_values(%[[VAL_78]], %[[VAL_76]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
+// CHECK:           %[[VAL_79:.*]] = sparse_tensor.indices %[[VAL_24]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_80:.*]] = sparse_tensor.values %[[VAL_24]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           scf.parallel (%[[VAL_81:.*]]) = (%[[VAL_3]]) to (%[[VAL_16]]) step (%[[VAL_4]]) {
+// CHECK:             %[[VAL_82:.*]] = addi %[[VAL_81]], %[[VAL_4]] : index
+// CHECK:             %[[VAL_83:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_81]]] : memref<?xi64>
+// CHECK:             %[[VAL_84:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_82]]] : memref<?xi64>
+// CHECK:             %[[VAL_85:.*]] = cmpi ne, %[[VAL_83]], %[[VAL_84]] : i64
+// CHECK:             scf.if %[[VAL_85]] {
+// CHECK:               %[[VAL_86:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_81]]] : memref<?xi64>
+// CHECK:               %[[VAL_87:.*]] = index_cast %[[VAL_86]] : i64 to index
+// CHECK:               %[[VAL_88:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_81]]] : memref<?xi64>
+// CHECK:               %[[VAL_89:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_82]]] : memref<?xi64>
+// CHECK:               %[[VAL_90:.*]] = index_cast %[[VAL_88]] : i64 to index
+// CHECK:               %[[VAL_91:.*]] = index_cast %[[VAL_89]] : i64 to index
+// CHECK:               %[[VAL_92:.*]] = memref.alloc(%[[VAL_18]]) : memref<?xf64>
+// CHECK:               %[[VAL_93:.*]] = memref.alloc(%[[VAL_18]]) : memref<?xi1>
+// CHECK:               linalg.fill(%[[VAL_93]], %[[VAL_10]]) : memref<?xi1>, i1
+// CHECK:               scf.parallel (%[[VAL_94:.*]]) = (%[[VAL_90]]) to (%[[VAL_91]]) step (%[[VAL_4]]) {
+// CHECK:                 %[[VAL_95:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_94]]] : memref<?xi64>
+// CHECK:                 %[[VAL_96:.*]] = index_cast %[[VAL_95]] : i64 to index
+// CHECK:                 memref.store %[[VAL_9]], %[[VAL_93]]{{\[}}%[[VAL_96]]] : memref<?xi1>
+// CHECK:                 %[[VAL_97:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_94]]] : memref<?xf64>
+// CHECK:                 memref.store %[[VAL_97]], %[[VAL_92]]{{\[}}%[[VAL_96]]] : memref<?xf64>
 // CHECK:                 scf.yield
 // CHECK:               }
-// CHECK:               %[[VAL_94:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_77]]] : memref<?xi64>
-// CHECK:               %[[VAL_95:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_78]]] : memref<?xi64>
-// CHECK:               %[[VAL_96:.*]] = index_cast %[[VAL_94]] : i64 to index
-// CHECK:               %[[VAL_97:.*]] = index_cast %[[VAL_95]] : i64 to index
-// CHECK:               %[[VAL_98:.*]] = scf.for %[[VAL_99:.*]] = %[[VAL_96]] to %[[VAL_97]] step %[[VAL_4]] iter_args(%[[VAL_100:.*]] = %[[VAL_3]]) -> (index) {
-// CHECK:                 %[[VAL_101:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_99]]] : memref<?xi64>
-// CHECK:                 %[[VAL_102:.*]] = index_cast %[[VAL_101]] : i64 to index
-// CHECK:                 %[[VAL_103:.*]] = addi %[[VAL_102]], %[[VAL_4]] : index
-// CHECK:                 %[[VAL_104:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_102]]] : memref<?xi64>
-// CHECK:                 %[[VAL_105:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_103]]] : memref<?xi64>
-// CHECK:                 %[[VAL_106:.*]] = index_cast %[[VAL_104]] : i64 to index
-// CHECK:                 %[[VAL_107:.*]] = index_cast %[[VAL_105]] : i64 to index
-// CHECK:                 %[[VAL_108:.*]]:2 = scf.for %[[VAL_109:.*]] = %[[VAL_106]] to %[[VAL_107]] step %[[VAL_4]] iter_args(%[[VAL_110:.*]] = %[[VAL_7]], %[[VAL_111:.*]] = %[[VAL_10]]) -> (f64, i1) {
-// CHECK:                   %[[VAL_112:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_109]]] : memref<?xi64>
-// CHECK:                   %[[VAL_113:.*]] = index_cast %[[VAL_112]] : i64 to index
-// CHECK:                   %[[VAL_114:.*]] = memref.load %[[VAL_89]]{{\[}}%[[VAL_113]]] : memref<?xi1>
-// CHECK:                   %[[VAL_115:.*]]:2 = scf.if %[[VAL_114]] -> (f64, i1) {
-// CHECK:                     %[[VAL_116:.*]] = addf %[[VAL_110]], %[[VAL_8]] : f64
-// CHECK:                     scf.yield %[[VAL_116]], %[[VAL_9]] : f64, i1
+// CHECK:               %[[VAL_98:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_81]]] : memref<?xi64>
+// CHECK:               %[[VAL_99:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_82]]] : memref<?xi64>
+// CHECK:               %[[VAL_100:.*]] = index_cast %[[VAL_98]] : i64 to index
+// CHECK:               %[[VAL_101:.*]] = index_cast %[[VAL_99]] : i64 to index
+// CHECK:               %[[VAL_102:.*]] = scf.for %[[VAL_103:.*]] = %[[VAL_100]] to %[[VAL_101]] step %[[VAL_4]] iter_args(%[[VAL_104:.*]] = %[[VAL_3]]) -> (index) {
+// CHECK:                 %[[VAL_105:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_103]]] : memref<?xi64>
+// CHECK:                 %[[VAL_106:.*]] = index_cast %[[VAL_105]] : i64 to index
+// CHECK:                 %[[VAL_107:.*]] = addi %[[VAL_106]], %[[VAL_4]] : index
+// CHECK:                 %[[VAL_108:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_106]]] : memref<?xi64>
+// CHECK:                 %[[VAL_109:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_107]]] : memref<?xi64>
+// CHECK:                 %[[VAL_110:.*]] = index_cast %[[VAL_108]] : i64 to index
+// CHECK:                 %[[VAL_111:.*]] = index_cast %[[VAL_109]] : i64 to index
+// CHECK:                 %[[VAL_112:.*]]:2 = scf.for %[[VAL_113:.*]] = %[[VAL_110]] to %[[VAL_111]] step %[[VAL_4]] iter_args(%[[VAL_114:.*]] = %[[VAL_7]], %[[VAL_115:.*]] = %[[VAL_10]]) -> (f64, i1) {
+// CHECK:                   %[[VAL_116:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_113]]] : memref<?xi64>
+// CHECK:                   %[[VAL_117:.*]] = index_cast %[[VAL_116]] : i64 to index
+// CHECK:                   %[[VAL_118:.*]] = memref.load %[[VAL_93]]{{\[}}%[[VAL_117]]] : memref<?xi1>
+// CHECK:                   %[[VAL_119:.*]]:2 = scf.if %[[VAL_118]] -> (f64, i1) {
+// CHECK:                     %[[VAL_120:.*]] = addf %[[VAL_114]], %[[VAL_8]] : f64
+// CHECK:                     scf.yield %[[VAL_120]], %[[VAL_9]] : f64, i1
 // CHECK:                   } else {
-// CHECK:                     scf.yield %[[VAL_110]], %[[VAL_111]] : f64, i1
+// CHECK:                     scf.yield %[[VAL_114]], %[[VAL_115]] : f64, i1
 // CHECK:                   }
-// CHECK:                   scf.yield %[[VAL_117:.*]]#0, %[[VAL_117]]#1 : f64, i1
+// CHECK:                   scf.yield %[[VAL_121:.*]]#0, %[[VAL_121]]#1 : f64, i1
 // CHECK:                 }
-// CHECK:                 %[[VAL_118:.*]] = scf.if %[[VAL_119:.*]]#1 -> (index) {
-// CHECK:                   %[[VAL_120:.*]] = addi %[[VAL_83]], %[[VAL_100]] : index
-// CHECK:                   memref.store %[[VAL_101]], %[[VAL_75]]{{\[}}%[[VAL_120]]] : memref<?xi64>
-// CHECK:                   memref.store %[[VAL_119]]#0, %[[VAL_76]]{{\[}}%[[VAL_120]]] : memref<?xf64>
-// CHECK:                   %[[VAL_121:.*]] = addi %[[VAL_100]], %[[VAL_4]] : index
-// CHECK:                   scf.yield %[[VAL_121]] : index
+// CHECK:                 %[[VAL_122:.*]] = scf.if %[[VAL_123:.*]]#1 -> (index) {
+// CHECK:                   %[[VAL_124:.*]] = addi %[[VAL_87]], %[[VAL_104]] : index
+// CHECK:                   memref.store %[[VAL_105]], %[[VAL_79]]{{\[}}%[[VAL_124]]] : memref<?xi64>
+// CHECK:                   memref.store %[[VAL_123]]#0, %[[VAL_80]]{{\[}}%[[VAL_124]]] : memref<?xf64>
+// CHECK:                   %[[VAL_125:.*]] = addi %[[VAL_104]], %[[VAL_4]] : index
+// CHECK:                   scf.yield %[[VAL_125]] : index
 // CHECK:                 } else {
-// CHECK:                   scf.yield %[[VAL_100]] : index
+// CHECK:                   scf.yield %[[VAL_104]] : index
 // CHECK:                 }
-// CHECK:                 scf.yield %[[VAL_122:.*]] : index
+// CHECK:                 scf.yield %[[VAL_126:.*]] : index
 // CHECK:               }
 // CHECK:             }
 // CHECK:             scf.yield
 // CHECK:           }
-// CHECK:           return %[[VAL_22]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           return %[[VAL_24]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
-
 
 func @matrix_multiply_mask_plus_pair(%a: tensor<?x?xf64, #CSR64>, %b: tensor<?x?xf64, #CSC64>, %m: tensor<?x?xf64, #CSR64>) -> tensor<?x?xf64, #CSR64> {
     %answer = graphblas.matrix_multiply %a, %b, %m { semiring = "plus_pair" } : (tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSC64>, tensor<?x?xf64, #CSR64>) to tensor<?x?xf64, #CSR64>

--- a/mlir_graphblas/src/test/GraphBLAS/lower_select_gt0.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_select_gt0.mlir
@@ -7,6 +7,12 @@
   indexBitWidth = 64
 }>
 
+// CHECK-LABEL:   func private @resize_values(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index)
+// CHECK:         func private @resize_index(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
+// CHECK:         func private @cast_csx_to_csr(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:         func private @dup_tensor(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:         func private @cast_csr_to_csx(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+
 // CHECK-LABEL:   func @select_gt0(
 // CHECK-SAME:                     %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:           %[[VAL_1:.*]] = constant 0 : index
@@ -15,41 +21,45 @@
 // CHECK:           %[[VAL_4:.*]] = constant 1 : i64
 // CHECK:           %[[VAL_5:.*]] = constant 0.000000e+00 : f64
 // CHECK:           %[[VAL_6:.*]] = memref.dim %[[VAL_0]], %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_8:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_9:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_10:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_11:.*]] = call @dup_tensor(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_12:.*]] = sparse_tensor.pointers %[[VAL_11]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_13:.*]] = sparse_tensor.indices %[[VAL_11]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_14:.*]] = sparse_tensor.values %[[VAL_11]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           memref.store %[[VAL_3]], %[[VAL_12]]{{\[}}%[[VAL_1]]] : memref<?xi64>
-// CHECK:           scf.for %[[VAL_15:.*]] = %[[VAL_1]] to %[[VAL_6]] step %[[VAL_2]] {
-// CHECK:             %[[VAL_16:.*]] = addi %[[VAL_15]], %[[VAL_2]] : index
-// CHECK:             %[[VAL_17:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_15]]] : memref<?xi64>
-// CHECK:             memref.store %[[VAL_17]], %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
-// CHECK:             %[[VAL_18:.*]] = memref.load %[[VAL_8]]{{\[}}%[[VAL_15]]] : memref<?xi64>
-// CHECK:             %[[VAL_19:.*]] = memref.load %[[VAL_8]]{{\[}}%[[VAL_16]]] : memref<?xi64>
-// CHECK:             %[[VAL_20:.*]] = index_cast %[[VAL_18]] : i64 to index
+// CHECK:           %[[VAL_7:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_8:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_9:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_10:.*]] = call @cast_csr_to_csx(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_11:.*]] = call @dup_tensor(%[[VAL_10]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_12:.*]] = call @cast_csx_to_csr(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_13:.*]] = sparse_tensor.pointers %[[VAL_12]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_14:.*]] = sparse_tensor.indices %[[VAL_12]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_15:.*]] = sparse_tensor.values %[[VAL_12]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           memref.store %[[VAL_3]], %[[VAL_13]]{{\[}}%[[VAL_1]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_16:.*]] = %[[VAL_1]] to %[[VAL_6]] step %[[VAL_2]] {
+// CHECK:             %[[VAL_17:.*]] = addi %[[VAL_16]], %[[VAL_2]] : index
+// CHECK:             %[[VAL_18:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_16]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_18]], %[[VAL_13]]{{\[}}%[[VAL_17]]] : memref<?xi64>
+// CHECK:             %[[VAL_19:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_16]]] : memref<?xi64>
+// CHECK:             %[[VAL_20:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_17]]] : memref<?xi64>
 // CHECK:             %[[VAL_21:.*]] = index_cast %[[VAL_19]] : i64 to index
-// CHECK:             scf.for %[[VAL_22:.*]] = %[[VAL_20]] to %[[VAL_21]] step %[[VAL_2]] {
-// CHECK:               %[[VAL_27:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_22]]] : memref<?xi64>
-// CHECK:               %[[VAL_23:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_22]]] : memref<?xf64>
-// CHECK:               %[[VAL_24:.*]] = cmpf ogt, %[[VAL_23]], %[[VAL_5]] : f64
-// CHECK:               scf.if %[[VAL_24]] {
-// CHECK:                 %[[VAL_25:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
-// CHECK:                 %[[VAL_26:.*]] = index_cast %[[VAL_25]] : i64 to index
-// CHECK:                 memref.store %[[VAL_27]], %[[VAL_13]]{{\[}}%[[VAL_26]]] : memref<?xi64>
-// CHECK:                 memref.store %[[VAL_23]], %[[VAL_14]]{{\[}}%[[VAL_26]]] : memref<?xf64>
-// CHECK:                 %[[VAL_28:.*]] = addi %[[VAL_25]], %[[VAL_4]] : i64
-// CHECK:                 memref.store %[[VAL_28]], %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
+// CHECK:             %[[VAL_22:.*]] = index_cast %[[VAL_20]] : i64 to index
+// CHECK:             scf.for %[[VAL_23:.*]] = %[[VAL_21]] to %[[VAL_22]] step %[[VAL_2]] {
+// CHECK:               %[[VAL_24:.*]] = memref.load %[[VAL_8]]{{\[}}%[[VAL_23]]] : memref<?xi64>
+// CHECK:               %[[VAL_25:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_23]]] : memref<?xf64>
+// CHECK:               %[[VAL_26:.*]] = cmpf ogt, %[[VAL_25]], %[[VAL_5]] : f64
+// CHECK:               scf.if %[[VAL_26]] {
+// CHECK:                 %[[VAL_27:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_17]]] : memref<?xi64>
+// CHECK:                 %[[VAL_28:.*]] = index_cast %[[VAL_27]] : i64 to index
+// CHECK:                 memref.store %[[VAL_24]], %[[VAL_14]]{{\[}}%[[VAL_28]]] : memref<?xi64>
+// CHECK:                 memref.store %[[VAL_25]], %[[VAL_15]]{{\[}}%[[VAL_28]]] : memref<?xf64>
+// CHECK:                 %[[VAL_29:.*]] = addi %[[VAL_27]], %[[VAL_4]] : i64
+// CHECK:                 memref.store %[[VAL_29]], %[[VAL_13]]{{\[}}%[[VAL_17]]] : memref<?xi64>
 // CHECK:               }
 // CHECK:             }
 // CHECK:           }
-// CHECK:           %[[VAL_29:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_6]]] : memref<?xi64>
-// CHECK:           %[[VAL_30:.*]] = index_cast %[[VAL_29]] : i64 to index
-// CHECK:           call @resize_index(%[[VAL_11]], %[[VAL_2]], %[[VAL_30]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @resize_values(%[[VAL_11]], %[[VAL_30]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
-// CHECK:           return %[[VAL_11]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_30:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_6]]] : memref<?xi64>
+// CHECK:           %[[VAL_31:.*]] = index_cast %[[VAL_30]] : i64 to index
+// CHECK:           %[[VAL_32:.*]] = call @cast_csr_to_csx(%[[VAL_12]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           call @resize_index(%[[VAL_32]], %[[VAL_2]], %[[VAL_31]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK:           %[[VAL_33:.*]] = call @cast_csr_to_csx(%[[VAL_12]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           call @resize_values(%[[VAL_33]], %[[VAL_31]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
+// CHECK:           return %[[VAL_12]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
 
 func @select_gt0(%sparse_tensor: tensor<?x?xf64, #CSR64>) -> tensor<?x?xf64, #CSR64> {

--- a/mlir_graphblas/src/test/GraphBLAS/lower_select_tril.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_select_tril.mlir
@@ -7,48 +7,58 @@
   indexBitWidth = 64
 }>
 
+// CHECK-LABEL:   func private @resize_values(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index)
+// CHECK:         func private @resize_index(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
+// CHECK:         func private @cast_csx_to_csr(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:         func private @dup_tensor(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:         func private @cast_csr_to_csx(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+
 // CHECK-LABEL:   func @select_tril(
 // CHECK-SAME:                      %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:           %[[VAL_1:.*]] = constant 0 : index
 // CHECK:           %[[VAL_2:.*]] = constant 1 : index
 // CHECK:           %[[VAL_3:.*]] = constant 0 : i64
 // CHECK:           %[[VAL_4:.*]] = constant 1 : i64
-// CHECK:           %[[VAL_6:.*]] = memref.dim %[[VAL_0]], %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_8:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_9:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_10:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_11:.*]] = call @dup_tensor(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_5:.*]] = memref.dim %[[VAL_0]], %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_6:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_7:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_8:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_9:.*]] = call @cast_csr_to_csx(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_10:.*]] = call @dup_tensor(%[[VAL_9]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_11:.*]] = call @cast_csx_to_csr(%[[VAL_10]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_12:.*]] = sparse_tensor.pointers %[[VAL_11]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_13:.*]] = sparse_tensor.indices %[[VAL_11]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_14:.*]] = sparse_tensor.values %[[VAL_11]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           memref.store %[[VAL_3]], %[[VAL_12]]{{\[}}%[[VAL_1]]] : memref<?xi64>
-// CHECK:           scf.for %[[VAL_15:.*]] = %[[VAL_1]] to %[[VAL_6]] step %[[VAL_2]] {
+// CHECK:           scf.for %[[VAL_15:.*]] = %[[VAL_1]] to %[[VAL_5]] step %[[VAL_2]] {
 // CHECK:             %[[VAL_16:.*]] = addi %[[VAL_15]], %[[VAL_2]] : index
 // CHECK:             %[[VAL_17:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_15]]] : memref<?xi64>
 // CHECK:             memref.store %[[VAL_17]], %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
-// CHECK:             %[[VAL_18:.*]] = memref.load %[[VAL_8]]{{\[}}%[[VAL_15]]] : memref<?xi64>
-// CHECK:             %[[VAL_19:.*]] = memref.load %[[VAL_8]]{{\[}}%[[VAL_16]]] : memref<?xi64>
+// CHECK:             %[[VAL_18:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_15]]] : memref<?xi64>
+// CHECK:             %[[VAL_19:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:             %[[VAL_20:.*]] = index_cast %[[VAL_18]] : i64 to index
 // CHECK:             %[[VAL_21:.*]] = index_cast %[[VAL_19]] : i64 to index
 // CHECK:             scf.for %[[VAL_22:.*]] = %[[VAL_20]] to %[[VAL_21]] step %[[VAL_2]] {
-// CHECK:               %[[VAL_23:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_22]]] : memref<?xi64>
+// CHECK:               %[[VAL_23:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_22]]] : memref<?xi64>
 // CHECK:               %[[VAL_24:.*]] = index_cast %[[VAL_23]] : i64 to index
-// CHECK:               %[[VAL_28:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_22]]] : memref<?xf64>
-// CHECK:               %[[VAL_25:.*]] = cmpi ult, %[[VAL_24]], %[[VAL_15]] : index
-// CHECK:               scf.if %[[VAL_25]] {
-// CHECK:                 %[[VAL_26:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
-// CHECK:                 %[[VAL_27:.*]] = index_cast %[[VAL_26]] : i64 to index
-// CHECK:                 memref.store %[[VAL_23]], %[[VAL_13]]{{\[}}%[[VAL_27]]] : memref<?xi64>
-// CHECK:                 memref.store %[[VAL_28]], %[[VAL_14]]{{\[}}%[[VAL_27]]] : memref<?xf64>
-// CHECK:                 %[[VAL_29:.*]] = addi %[[VAL_26]], %[[VAL_4]] : i64
+// CHECK:               %[[VAL_25:.*]] = memref.load %[[VAL_8]]{{\[}}%[[VAL_22]]] : memref<?xf64>
+// CHECK:               %[[VAL_26:.*]] = cmpi ult, %[[VAL_24]], %[[VAL_15]] : index
+// CHECK:               scf.if %[[VAL_26]] {
+// CHECK:                 %[[VAL_27:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
+// CHECK:                 %[[VAL_28:.*]] = index_cast %[[VAL_27]] : i64 to index
+// CHECK:                 memref.store %[[VAL_23]], %[[VAL_13]]{{\[}}%[[VAL_28]]] : memref<?xi64>
+// CHECK:                 memref.store %[[VAL_25]], %[[VAL_14]]{{\[}}%[[VAL_28]]] : memref<?xf64>
+// CHECK:                 %[[VAL_29:.*]] = addi %[[VAL_27]], %[[VAL_4]] : i64
 // CHECK:                 memref.store %[[VAL_29]], %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:               }
 // CHECK:             }
 // CHECK:           }
-// CHECK:           %[[VAL_30:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_6]]] : memref<?xi64>
+// CHECK:           %[[VAL_30:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_5]]] : memref<?xi64>
 // CHECK:           %[[VAL_31:.*]] = index_cast %[[VAL_30]] : i64 to index
-// CHECK:           call @resize_index(%[[VAL_11]], %[[VAL_2]], %[[VAL_31]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @resize_values(%[[VAL_11]], %[[VAL_31]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
+// CHECK:           %[[VAL_32:.*]] = call @cast_csr_to_csx(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           call @resize_index(%[[VAL_32]], %[[VAL_2]], %[[VAL_31]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK:           %[[VAL_33:.*]] = call @cast_csr_to_csx(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           call @resize_values(%[[VAL_33]], %[[VAL_31]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
 // CHECK:           return %[[VAL_11]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
 

--- a/mlir_graphblas/src/test/GraphBLAS/lower_select_triu.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_select_triu.mlir
@@ -7,48 +7,58 @@
   indexBitWidth = 64
 }>
 
+// CHECK-LABEL:   func private @resize_values(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index)
+// CHECK:         func private @resize_index(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
+// CHECK:         func private @cast_csx_to_csr(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:         func private @dup_tensor(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:         func private @cast_csr_to_csx(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+
 // CHECK-LABEL:   func @select_triu(
 // CHECK-SAME:                      %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:           %[[VAL_1:.*]] = constant 0 : index
 // CHECK:           %[[VAL_2:.*]] = constant 1 : index
 // CHECK:           %[[VAL_3:.*]] = constant 0 : i64
 // CHECK:           %[[VAL_4:.*]] = constant 1 : i64
-// CHECK:           %[[VAL_6:.*]] = memref.dim %[[VAL_0]], %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_8:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_9:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_10:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_11:.*]] = call @dup_tensor(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_5:.*]] = memref.dim %[[VAL_0]], %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_6:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_7:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_8:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_9:.*]] = call @cast_csr_to_csx(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_10:.*]] = call @dup_tensor(%[[VAL_9]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_11:.*]] = call @cast_csx_to_csr(%[[VAL_10]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_12:.*]] = sparse_tensor.pointers %[[VAL_11]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_13:.*]] = sparse_tensor.indices %[[VAL_11]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_14:.*]] = sparse_tensor.values %[[VAL_11]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           memref.store %[[VAL_3]], %[[VAL_12]]{{\[}}%[[VAL_1]]] : memref<?xi64>
-// CHECK:           scf.for %[[VAL_15:.*]] = %[[VAL_1]] to %[[VAL_6]] step %[[VAL_2]] {
+// CHECK:           scf.for %[[VAL_15:.*]] = %[[VAL_1]] to %[[VAL_5]] step %[[VAL_2]] {
 // CHECK:             %[[VAL_16:.*]] = addi %[[VAL_15]], %[[VAL_2]] : index
 // CHECK:             %[[VAL_17:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_15]]] : memref<?xi64>
 // CHECK:             memref.store %[[VAL_17]], %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
-// CHECK:             %[[VAL_18:.*]] = memref.load %[[VAL_8]]{{\[}}%[[VAL_15]]] : memref<?xi64>
-// CHECK:             %[[VAL_19:.*]] = memref.load %[[VAL_8]]{{\[}}%[[VAL_16]]] : memref<?xi64>
+// CHECK:             %[[VAL_18:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_15]]] : memref<?xi64>
+// CHECK:             %[[VAL_19:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:             %[[VAL_20:.*]] = index_cast %[[VAL_18]] : i64 to index
 // CHECK:             %[[VAL_21:.*]] = index_cast %[[VAL_19]] : i64 to index
 // CHECK:             scf.for %[[VAL_22:.*]] = %[[VAL_20]] to %[[VAL_21]] step %[[VAL_2]] {
-// CHECK:               %[[VAL_23:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_22]]] : memref<?xi64>
+// CHECK:               %[[VAL_23:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_22]]] : memref<?xi64>
 // CHECK:               %[[VAL_24:.*]] = index_cast %[[VAL_23]] : i64 to index
-// CHECK:               %[[VAL_28:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_22]]] : memref<?xf64>
-// CHECK:               %[[VAL_25:.*]] = cmpi ugt, %[[VAL_24]], %[[VAL_15]] : index
-// CHECK:               scf.if %[[VAL_25]] {
-// CHECK:                 %[[VAL_26:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
-// CHECK:                 %[[VAL_27:.*]] = index_cast %[[VAL_26]] : i64 to index
-// CHECK:                 memref.store %[[VAL_23]], %[[VAL_13]]{{\[}}%[[VAL_27]]] : memref<?xi64>
-// CHECK:                 memref.store %[[VAL_28]], %[[VAL_14]]{{\[}}%[[VAL_27]]] : memref<?xf64>
-// CHECK:                 %[[VAL_29:.*]] = addi %[[VAL_26]], %[[VAL_4]] : i64
+// CHECK:               %[[VAL_25:.*]] = memref.load %[[VAL_8]]{{\[}}%[[VAL_22]]] : memref<?xf64>
+// CHECK:               %[[VAL_26:.*]] = cmpi ugt, %[[VAL_24]], %[[VAL_15]] : index
+// CHECK:               scf.if %[[VAL_26]] {
+// CHECK:                 %[[VAL_27:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
+// CHECK:                 %[[VAL_28:.*]] = index_cast %[[VAL_27]] : i64 to index
+// CHECK:                 memref.store %[[VAL_23]], %[[VAL_13]]{{\[}}%[[VAL_28]]] : memref<?xi64>
+// CHECK:                 memref.store %[[VAL_25]], %[[VAL_14]]{{\[}}%[[VAL_28]]] : memref<?xf64>
+// CHECK:                 %[[VAL_29:.*]] = addi %[[VAL_27]], %[[VAL_4]] : i64
 // CHECK:                 memref.store %[[VAL_29]], %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:               }
 // CHECK:             }
 // CHECK:           }
-// CHECK:           %[[VAL_30:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_6]]] : memref<?xi64>
+// CHECK:           %[[VAL_30:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_5]]] : memref<?xi64>
 // CHECK:           %[[VAL_31:.*]] = index_cast %[[VAL_30]] : i64 to index
-// CHECK:           call @resize_index(%[[VAL_11]], %[[VAL_2]], %[[VAL_31]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @resize_values(%[[VAL_11]], %[[VAL_31]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
+// CHECK:           %[[VAL_32:.*]] = call @cast_csr_to_csx(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           call @resize_index(%[[VAL_32]], %[[VAL_2]], %[[VAL_31]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK:           %[[VAL_33:.*]] = call @cast_csr_to_csx(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           call @resize_values(%[[VAL_33]], %[[VAL_31]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
 // CHECK:           return %[[VAL_11]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
 


### PR DESCRIPTION
This PR introduces a CSX or CS-generic sparse encoding to be used with our external functions' signatures. In MLIR, it looks like this:
```
    #CSX64 = #sparse_tensor.encoding<{
      dimLevelType = [ "dense", "compressed" ],
      pointerBitWidth = 64,
      indexBitWidth = 64
    }>
```
This makes it so our lowering passes can emit fewer lines dedicated toward casting (which must be worked around using dummy function calls to identity functions since `tensor.cast` doesn't consistently work with sparse tensors) when duplicating sparse matrices.