### PR TITLE
Fix memory leaks

### DIFF
--- a/mlir_graphblas/engine.py
+++ b/mlir_graphblas/engine.py
@@ -500,24 +500,6 @@ def resolve_type_aliases(module: mlir.astnodes.Module) -> None:
     return
 
 
-def _preprocess_mlir(mlir_text: str):
-    START_MARKER = "// pymlir-skip: begin"
-    END_MARKER = "// pymlir-skip: end"
-    PATTERN = START_MARKER + r".*?" + END_MARKER
-    regex = re.compile(PATTERN, flags=re.DOTALL)
-    preprocessed_mlir_text = regex.sub("", mlir_text)
-    return preprocessed_mlir_text
-
-
-def parse_mlir_string(mlir_text: Union[str, bytes]) -> mlir.astnodes.Module:
-    if isinstance(mlir_text, bytes):
-        mlir_text = mlir_text.decode()
-    mlir_text = _preprocess_mlir(mlir_text)
-    mlir_ast = mlir.parse_string(mlir_text)
-    resolve_type_aliases(mlir_ast)
-    return mlir_ast
-
-
 def parse_mlir_functions(
     mlir_text: Union[str, bytes], cli: MlirOptCli
 ) -> mlir.astnodes.Module:

--- a/mlir_graphblas/functions.py
+++ b/mlir_graphblas/functions.py
@@ -73,17 +73,20 @@ module  {
     func private @ptr8_to_tensor(!llvm.ptr<i8>) -> tensor<?x?xf64, #CSX64>
     func private @tensor_to_ptr8(tensor<?x?xf64, #CSX64>) -> !llvm.ptr<i8>
     
+    func private @delSparseTensor(tensor<?x?xf64, #CSX64>) -> ()
+    func private @dup_tensor(tensor<?x?xf64, #CSX64>) -> tensor<?x?xf64, #CSX64>
+
     {{ body }}
 
 }
         """
     )
 
-    def get_mlir_module(self):
+    def get_mlir_module(self, make_private=False):
         """Get the MLIR text for this function wrapped in a MLIR module with
         declarations of external helper functions."""
         return self.MODULE_WRAPPER_TEXT.render(
-            body=self.get_mlir(make_private=False),
+            body=self.get_mlir(make_private=make_private),
         )
 
     def compile(self, engine=None, passes=None):

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
@@ -17,6 +17,7 @@ mlir::Value convertToExternalCSR(mlir::OpBuilder &builder, mlir::ModuleOp &mod, 
 mlir::Value convertToExternalCSC(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc, mlir::Value input);
 mlir::Value callEmptyLike(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc, mlir::Value tensor);
 mlir::Value callDupTensor(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc, mlir::Value tensor);
+void callDelSparseTensor(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc, mlir::Value tensor);
 
 mlir::CallOp callResizeDim(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc,
                            mlir::Value tensor, mlir::Value d, mlir::Value size);
@@ -26,5 +27,7 @@ mlir::CallOp callResizeIndex(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir
                              mlir::Value tensor, mlir::Value d, mlir::Value size);
 mlir::CallOp callResizeValues(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc,
                               mlir::Value tensor, mlir::Value size);
+
+void cleanupIntermediateTensor(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc, mlir::Value tensor);
 
 #endif // GRAPHBLAS_GRAPHBLASUTILS_H

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASUtils.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASUtils.cpp
@@ -243,7 +243,7 @@ void callDelSparseTensor(OpBuilder &builder, ModuleOp &mod, Location loc, Value 
     Type csxTensorType = csxTensor.getType();
 
     FlatSymbolRefAttr func = getFunc(mod, loc, "delSparseTensor", ArrayRef<Type>({}), csxTensorType);
-    builder.create<mlir::CallOp>(loc, func, ValueRange(), csxTensor);
+    builder.create<mlir::CallOp>(loc, func, TypeRange(), csxTensor);
     return;
 }
 


### PR DESCRIPTION
We create output MLIRSparseTensors, but weren't deleting them.
Now we inspect the function and add statements to delete intermediate
objects which aren't being returned from the function. This is done
as part of the graphblas lowering pass.

Additional memref buffers which were allocated weren't being deallocated.
That has been fixed now.