### PR TITLE
Initial implementation of the CLI tool tersify_mlir

### DIFF
--- a/mlir_graphblas/__init__.py
+++ b/mlir_graphblas/__init__.py
@@ -2,6 +2,7 @@ import donfig
 from ._version import get_versions
 from .cli import MlirOptCli, MlirOptError
 from .engine import MlirJitEngine
+from . import tools
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/mlir_graphblas/tests/test_tools.py
+++ b/mlir_graphblas/tests/test_tools.py
@@ -1,0 +1,114 @@
+import pytest
+import subprocess
+import mlir_graphblas
+
+TEST_CASES = (
+    pytest.param(
+        """
+module  {
+  func @test_func(%arg0: tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
+    return %arg0 : tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+  }
+}
+""",
+        """
+#CSC64 = #sparse_tensor.encoding<{ 
+    dimLevelType = [ "dense", "compressed" ], 
+    dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, 
+    pointerBitWidth = 64, 
+    indexBitWidth = 64 
+}>
+
+module  {
+  func @test_func(%arg0: tensor<2x3xf64, #CSC64>) -> tensor<2x3xf64, #CSC64> {
+    return %arg0 : tensor<2x3xf64, #CSC64>
+  }
+}        """,
+        id="csc",
+    ),
+    pytest.param(
+        """
+module  {
+  func @test_func(%arg0: tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
+    return %arg0 : tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+  }
+}
+""",
+        """
+#CSR64 = #sparse_tensor.encoding<{ 
+    dimLevelType = [ "dense", "compressed" ], 
+    dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, 
+    pointerBitWidth = 64, 
+    indexBitWidth = 64 
+}>
+
+module  {
+  func @test_func(%arg0: tensor<2x3xf64, #CSR64>) -> tensor<2x3xf64, #CSR64> {
+    return %arg0 : tensor<2x3xf64, #CSR64>
+  }
+}
+        """,
+        id="csr",
+    ),
+    pytest.param(
+        """
+module  {
+  func @convert_layout_wrapper(%arg0: tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
+    %0 = graphblas.convert_layout %arg0 : tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+    return %0 : tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+  }
+}
+""",
+        """
+#CSC64 = #sparse_tensor.encoding<{ 
+    dimLevelType = [ "dense", "compressed" ], 
+    dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, 
+    pointerBitWidth = 64, 
+    indexBitWidth = 64 
+}>
+
+#CSR64 = #sparse_tensor.encoding<{ 
+    dimLevelType = [ "dense", "compressed" ], 
+    dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, 
+    pointerBitWidth = 64, 
+    indexBitWidth = 64 
+}>
+
+module  {
+  func @convert_layout_wrapper(%arg0: tensor<2x3xf64, #CSR64>) -> tensor<2x3xf64, #CSC64> {
+    %0 = graphblas.convert_layout %arg0 : tensor<2x3xf64, #CSR64> to tensor<2x3xf64, #CSC64>
+    return %0 : tensor<2x3xf64, #CSC64>
+  }
+}
+        """,
+        id="csr_and_csc",
+    ),
+)
+
+
+@pytest.mark.parametrize("input_mlir, output_mlir", TEST_CASES)
+def test_tersify_mlir(input_mlir, output_mlir):
+    """Check that the tersify_mlir CLI tool works."""
+    process = subprocess.run(
+        ["tersify_mlir"],
+        capture_output=True,
+        input=input_mlir.encode(),
+    )
+    assert process.returncode == 0
+    stdout = process.stdout.decode().strip()
+    assert stdout == output_mlir.strip()
+    assert stdout == mlir_graphblas.tools.tersify_mlir(input_mlir).strip()
+    return
+
+
+def test_tersify_mlir_with_invalid_mlir():
+    input_mlir = "asdf"
+    process = subprocess.run(
+        ["tersify_mlir"],
+        capture_output=True,
+        input=input_mlir.encode(),
+    )
+    assert process.returncode != 0
+    assert len(process.stdout) == 0
+    assert input_mlir in process.stderr.decode()
+    return

--- a/mlir_graphblas/tools/__init__.py
+++ b/mlir_graphblas/tools/__init__.py
@@ -1,0 +1,1 @@
+from .tersify_mlir import *

--- a/mlir_graphblas/tools/tersify_mlir.py
+++ b/mlir_graphblas/tools/tersify_mlir.py
@@ -1,0 +1,54 @@
+import fileinput
+import subprocess
+
+from ..cli import MlirOptCli
+
+CSR64_LINES = (
+    "#sparse_tensor.encoding<{ ",
+    '    dimLevelType = [ "dense", "compressed" ], ',
+    "    dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, ",
+    "    pointerBitWidth = 64, ",
+    "    indexBitWidth = 64 ",
+    "}>",
+)
+
+CSC64_LINES = (
+    "#sparse_tensor.encoding<{ ",
+    '    dimLevelType = [ "dense", "compressed" ], ',
+    "    dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, ",
+    "    pointerBitWidth = 64, ",
+    "    indexBitWidth = 64 ",
+    "}>",
+)
+
+CSR64_PRETTY_TEXT = "\n".join(CSR64_LINES)
+CSC64_PRETTY_TEXT = "\n".join(CSC64_LINES)
+
+CSR64_EXPANDED_TEXT = " ".join(line.strip() for line in CSR64_LINES)
+CSC64_EXPANDED_TEXT = " ".join(line.strip() for line in CSC64_LINES)
+
+CLI = None
+
+
+def tersify_mlir(input_string: str) -> str:
+    global CLI
+    if CLI is None:
+        # Lazily initialize CLI to avoid circular import in MlirOptCli.__init__
+        CLI = MlirOptCli()
+    terse_string = CLI.apply_passes(input_string.encode(), [])
+    if not isinstance(terse_string, str):
+        raise terse_string
+    if CSR64_EXPANDED_TEXT in terse_string:
+        terse_string = terse_string.replace(CSR64_EXPANDED_TEXT, "#CSR64")
+        terse_string = f"#CSR64 = {CSR64_PRETTY_TEXT}\n\n" + terse_string
+    if CSC64_EXPANDED_TEXT in terse_string:
+        terse_string = terse_string.replace(CSC64_EXPANDED_TEXT, "#CSC64")
+        terse_string = f"#CSC64 = {CSC64_PRETTY_TEXT}\n\n" + terse_string
+    return terse_string
+
+
+def tersify_mlir_cli():
+    input_string = "\n".join(fileinput.input())
+    output_string = tersify_mlir(input_string)
+    print(output_string)
+    return

--- a/setup.py
+++ b/setup.py
@@ -56,5 +56,10 @@ setup(
     ext_modules=ext_modules,
     package_data={"mlir_graphblas": ["*.pyx"]},
     include_package_data=True,
+    entry_points={
+        "console_scripts": [
+            "tersify_mlir=mlir_graphblas.tools:tersify_mlir_cli",
+        ]
+    },
     install_requires=["pymlir", "pygments"],
 )


### PR DESCRIPTION
This PR implements the CLI tool `tersify_mlir`. It's implemented using python's entry points. Thus, using it will require running `setup.py`.

Here's an example use:
```
(mlirgraphblas) pnguyen@0584:/Users/pnguyen/code/mlir-graphblas$ python3 setup.py develop | wc -l
      41
(mlirgraphblas) pnguyen@0584:/Users/pnguyen/code/mlir-graphblas$ cat ./mlir_graphblas/src/test/GraphBLAS/check_ops.mlir | tersify_mlir | head -n 25
#CSC64 = #sparse_tensor.encoding<{ 
    dimLevelType = [ "dense", "compressed" ], 
    dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, 
    pointerBitWidth = 64, 
    indexBitWidth = 64 
}>

#CSR64 = #sparse_tensor.encoding<{ 
    dimLevelType = [ "dense", "compressed" ], 
    dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, 
    pointerBitWidth = 64, 
    indexBitWidth = 64 
}>

module  {
  module  {
    func @convert_layout_wrapper(%arg0: tensor<2x3xf64, #CSR64>) -> tensor<2x3xf64, #CSC64> {
      %0 = graphblas.convert_layout %arg0 : tensor<2x3xf64, #CSR64> to tensor<2x3xf64, #CSC64>
      return %0 : tensor<2x3xf64, #CSC64>
    }
  }
  module  {
    func @matrix_select_triu(%arg0: tensor<100x100xf64, #CSR64>) -> tensor<100x100xf64, #CSR64> {
      %0 = graphblas.matrix_select %arg0 {selectors = ["triu"]} : tensor<100x100xf64, #CSR64> to tensor<100x100xf64, #CSR64>
      return %0 : tensor<100x100xf64, #CSR64>
(mlirgraphblas) pnguyen@0584:/Users/pnguyen/code/mlir-graphblas$ 
```
