### PR TITLE
convert matrix_reduce_to_scalar and matrix_multiply_reduce_to_scalar to structural form

### DIFF
--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
@@ -185,6 +185,32 @@ def GraphBLAS_MatrixReduceToScalarOp : GraphBLAS_Op<"matrix_reduce_to_scalar", [
     }];
 }
 
+def GraphBLAS_MatrixReduceToScalarGenericOp : GraphBLAS_Op<"matrix_reduce_to_scalar_generic", [NoSideEffect]> {
+    let summary = "matrix reduce to scalar generic operation";
+    let description = [{
+        Reduces a sparse tensor to a scalar according to the given aggregator block.
+        The given sparse tensor must be a matrix, i.e. have rank 2.
+        The given tensor must have a CSR sparsity or a CSC sparsity.
+        The resulting scalar's type will depend on the type of the input tensor.
+
+        Example:
+        ```%answer = graphblas.matrix_reduce_to_scalar_generic %sparse_tensor : tensor<?x?xi64, #CSR64> to i64 {
+            ^bb0(%a : i64, %b : i64):
+              %result = std.addi %a, %b : i64
+              graphblas.yield agg %result : i64
+        }        
+        ```
+    }];
+
+    let arguments = (ins AnyTensor:$input);
+    let results = (outs AnyType:$output);
+    let regions = (region VariadicRegion<SizedRegion<1>>:$extensions);
+    
+    let assemblyFormat = [{
+           $input attr-dict `:` type($input) `to` type($output) $extensions
+    }];
+}
+
 def GraphBLAS_MatrixApplyOp : GraphBLAS_Op<"matrix_apply", [NoSideEffect]> {
     let summary = "matrix apply operation";
     let description = [{
@@ -284,31 +310,24 @@ def GraphBLAS_MatrixMultiplyGenericOp : GraphBLAS_Op<"matrix_multiply_generic", 
     }];
 }
 
-def GraphBLAS_MatrixMultiplyReduceToScalarOp : GraphBLAS_Op<"matrix_multiply_reduce_to_scalar", [NoSideEffect]> {
+def GraphBLAS_MatrixMultiplyReduceToScalarGenericOp : GraphBLAS_Op<"matrix_multiply_reduce_to_scalar_generic", [NoSideEffect]> {
     let summary = "matrix multiply followed by reduction to a scalar with an optional structural mask";
     let description = [{
         Performs a matrix multiply followed by a reduction to scalar.
-        The multiplication is done according to the given semiring and optional structural mask.
-        The semiring must be one of "plus_times", "plus_pair", or "plus_plus".
-        The reduction to scalar is done according to the given aggregator.
-        The aggregator must be "sum".
+        Supports same extension blocks as matrix_multiply_generic, and also requires binary aggregation
+        block (aggregation assumes same identity as semiring add).
+
         The given sparse tensors must be a matrix, i.e. have rank 2.
         The first input tensors must be CSR format, while the second input tensor must be CSC format.
         The mask (if provided) must be CSR format.
-
-        No Mask Example:
-        ```%answer = graphblas.matrix_multiply_reduce_to_scalar %argA, %argB { semiring = "plus_plus", aggregator = "sum" } : (tensor<?x?xi64, #CSR64>, tensor<?x?xi64, #CSC64>) to f64```
-
-        Mask Example:
-        ```%answer = graphblas.matrix_multiply_reduce_to_scalar %argA, %argB, %mask { semiring = "plus_times", aggregator = "sum" } : (tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSC64>, tensor<?x?xf64, #CSR64>) to f64```
-
     }];
 
-    let arguments = (ins AnyTensor:$a, AnyTensor:$b, Optional<AnyTensor>:$mask, StrAttr:$semiring, StrAttr:$aggregator);
+    let arguments = (ins AnyTensor:$a, AnyTensor:$b, Optional<AnyTensor>:$mask);
     let results = (outs AnyType:$output);
+    let regions = (region VariadicRegion<SizedRegion<1>>:$extensions);
 
     let assemblyFormat = [{
-           $a `,` $b (`,` $mask^)? attr-dict `:` `(` type($a) `,` type($b)  (`,` type($mask)^)? `)` `to` type($output)
+           $a `,` $b (`,` $mask^)? attr-dict `:` `(` type($a) `,` type($b)  (`,` type($mask)^)? `)` `to` type($output) $extensions
     }];
 }
 
@@ -367,13 +386,16 @@ def YIELD_ADD_IDENTITY   : I64EnumAttrCase<"ADD_IDENTITY", 6, "add_identity">;
 def YIELD_ADD            : I64EnumAttrCase<"ADD", 7, "add">;
 def YIELD_MULT_IDENTITY  : I64EnumAttrCase<"MULT_IDENTITY", 8, "mult_identity">;
 def YIELD_MULT           : I64EnumAttrCase<"MULT", 9, "mult">;
+def YIELD_AGG_IDENTITY   : I64EnumAttrCase<"AGG_IDENTITY", 10, "agg_identity">;
+def YIELD_AGG            : I64EnumAttrCase<"AGG", 11, "agg">;
 
 def YieldKindAttr : I64EnumAttr<
     "YieldKind", "",
     [YIELD_TRANSFORM_IN_A, YIELD_TRANSFORM_IN_B, YIELD_TRANSFORM_OUT,
      YIELD_SELECT_IN_A,    YIELD_SELECT_IN_B,    YIELD_SELECT_OUT,
      YIELD_ADD_IDENTITY,   YIELD_ADD,
-     YIELD_MULT_IDENTITY,  YIELD_MULT]
+     YIELD_MULT_IDENTITY,  YIELD_MULT, 
+     YIELD_AGG_IDENTITY,   YIELD_AGG]
     > {
   let cppNamespace = "::mlir::graphblas";
 }

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
@@ -14,6 +14,9 @@ bool typeIsCSC(mlir::Type inputType);
 mlir::RankedTensorType getCSRTensorType(mlir::MLIRContext *context, llvm::ArrayRef<int64_t> shape, mlir::Type valueType);
 mlir::RankedTensorType getCSCTensorType(mlir::MLIRContext *context, llvm::ArrayRef<int64_t> shape, mlir::Type valueType);
 
+int64_t getRank(mlir::Type inputType);
+int64_t getRank(mlir::Value inputValue);
+
 mlir::Value convertToExternalCSR(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc, mlir::Value input);
 mlir::Value convertToExternalCSC(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc, mlir::Value input);
 mlir::Value callEmptyLike(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc, mlir::Value tensor);

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
@@ -42,6 +42,8 @@ struct ExtensionBlocks {
     mlir::Block *add = nullptr;
     mlir::Block *multIdentity = nullptr;
     mlir::Block *mult = nullptr;
+    mlir::Block *aggIdentity = nullptr;
+    mlir::Block *agg = nullptr;
 
     ExtensionBlocks() { };
     mlir::LogicalResult extractBlocks(mlir::Operation *op, mlir::RegionRange &regions,

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASLowerPass.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASLowerPass.cpp
@@ -487,12 +487,63 @@ public:
   };
 };
 
-class LowerMatrixReduceToScalarRewrite : public OpRewritePattern<graphblas::MatrixReduceToScalarOp> {
+class LowerMatrixReduceToScalarRewrite : public OpRewritePattern<graphblas::MatrixReduceToScalarOp>
+{
 public:
   using OpRewritePattern<graphblas::MatrixReduceToScalarOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::MatrixReduceToScalarOp op, PatternRewriter &rewriter) const {
+  LogicalResult matchAndRewrite(graphblas::MatrixReduceToScalarOp op, PatternRewriter &rewriter) const
+  {
     Value input = op.input();
     StringRef aggregator = op.aggregator();
+    Location loc = rewriter.getUnknownLoc();
+
+    RankedTensorType operandType = op.input().getType().dyn_cast<RankedTensorType>();
+    Type valueType = operandType.getElementType();
+
+    // New op
+    graphblas::MatrixReduceToScalarGenericOp newReduceOp = rewriter.create<graphblas::MatrixReduceToScalarGenericOp>(
+        loc, op->getResultTypes(), input, 2);
+
+    if (aggregator == "sum")
+    {
+      // Insert agg identity block
+      Region &aggIdentityRegion = newReduceOp.getRegion(0);
+      /*Block *aggIdentityBlock = */ rewriter.createBlock(&aggIdentityRegion, {}, {});
+
+      Value aggIdentity = llvm::TypeSwitch<Type, Value>(valueType)
+                              .Case<IntegerType>([&](IntegerType type)
+                                                 { return rewriter.create<ConstantIntOp>(loc, 0, type.getWidth()); })
+                              .Case<FloatType>([&](FloatType type)
+                                               { return rewriter.create<ConstantFloatOp>(loc, APFloat(0.0), type); });
+      rewriter.create<graphblas::YieldOp>(loc, graphblas::YieldKind::AGG_IDENTITY, aggIdentity);
+
+      // Insert agg block
+      Region &aggRegion = newReduceOp.getRegion(1);
+      Block *aggBlock = rewriter.createBlock(&aggRegion, {}, {valueType, valueType});
+      Value lhs = aggBlock->getArgument(0);
+      Value rhs = aggBlock->getArgument(1);
+
+      Value aggResult = llvm::TypeSwitch<Type, Value>(valueType)
+                        .Case<IntegerType>([&](IntegerType type)
+                                           { return rewriter.create<AddIOp>(loc, lhs, rhs).getResult(); })
+                        .Case<FloatType>([&](FloatType type)
+                                         { return rewriter.create<AddFOp>(loc, lhs, rhs).getResult(); });
+      rewriter.create<graphblas::YieldOp>(loc, graphblas::YieldKind::AGG, aggResult);
+    } else {
+      return op.emitError("\"" + aggregator + "\" is not a supported aggregator.");
+    }
+
+    rewriter.replaceOp(op, newReduceOp.getResult());
+
+    return success();
+  };
+};
+
+class LowerMatrixReduceToScalarGenericRewrite : public OpRewritePattern<graphblas::MatrixReduceToScalarGenericOp> {
+public:
+  using OpRewritePattern<graphblas::MatrixReduceToScalarGenericOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(graphblas::MatrixReduceToScalarGenericOp op, PatternRewriter &rewriter) const {
+    Value input = op.input();
     Location loc = rewriter.getUnknownLoc();
 
     RankedTensorType operandType = op.input().getType().dyn_cast<RankedTensorType>();
@@ -500,18 +551,24 @@ public:
     Type int64Type = rewriter.getIntegerType(64); // TODO should we get this from the sparse encoding?
     Type indexType = rewriter.getIndexType();
 
-    // Initial constants
-    llvm::Optional<ConstantOp> c0Accumulator = llvm::TypeSwitch<Type, llvm::Optional<ConstantOp>>(valueType)
-      .Case<IntegerType>([&](IntegerType type) {
-                           return rewriter.create<ConstantIntOp>(loc, 0, type.getWidth());
-                         })
-      .Case<FloatType>([&](FloatType type) {
-                         return rewriter.create<ConstantFloatOp>(loc, APFloat(type.getFloatSemantics()), type);
-                       })
-      .Default([&](Type type) { return llvm::None; });
-    if (!c0Accumulator.hasValue()) {
-      return failure(); // TODO test this case
+    // Required blocks
+    RegionRange extensions = op.extensions();
+    ExtensionBlocks extBlocks;
+    std::set<graphblas::YieldKind> required = {graphblas::YieldKind::AGG_IDENTITY, graphblas::YieldKind::AGG};
+    LogicalResult extractResult = extBlocks.extractBlocks(op, extensions, required, {});
+
+    if (extractResult.failed())
+    {
+      return extractResult;
     }
+
+    // insert agg identity
+    graphblas::YieldOp aggIdentityYield = llvm::dyn_cast_or_null<graphblas::YieldOp>(extBlocks.aggIdentity->getTerminator());
+    rewriter.mergeBlocks(extBlocks.aggIdentity, rewriter.getInsertionBlock(), {});
+    Value c0Accumulator = aggIdentityYield.values().front();
+    rewriter.eraseOp(aggIdentityYield);
+
+    // initial constants
     Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
     Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
 
@@ -526,7 +583,7 @@ public:
     IndexCastOp nnz = rewriter.create<IndexCastOp>(loc, nnz64, indexType);
 
     // begin loop
-    scf::ParallelOp valueLoop = rewriter.create<scf::ParallelOp>(loc, c0, nnz.getResult(), c1, c0Accumulator.getValue().getResult());
+    scf::ParallelOp valueLoop = rewriter.create<scf::ParallelOp>(loc, c0, nnz.getResult(), c1, c0Accumulator);
     ValueRange valueLoopIdx = valueLoop.getInductionVars();
 
     rewriter.setInsertionPointToStart(valueLoop.getBody());
@@ -538,19 +595,12 @@ public:
 
     rewriter.setInsertionPointToStart(&reducer.getRegion().front());
 
-    llvm::Optional<Value> z;
-    if (aggregator == "sum") {
-      z = llvm::TypeSwitch<Type, llvm::Optional<Value>>(valueType)
-        .Case<IntegerType>([&](IntegerType type) { return rewriter.create<AddIOp>(loc, lhs, rhs).getResult(); })
-        .Case<FloatType>([&](FloatType type) { return rewriter.create<AddFOp>(loc, lhs, rhs).getResult(); })
-        .Default([&](Type type) { return llvm::None; });
-      if (!z.hasValue()) {
-        return failure();
-      }
-    } else {
-      return failure(); // TODO test this
-    }
-    rewriter.create<scf::ReduceReturnOp>(loc, z.getValue());
+    graphblas::YieldOp aggYield = llvm::dyn_cast_or_null<graphblas::YieldOp>(extBlocks.agg->getTerminator());
+    rewriter.mergeBlocks(extBlocks.agg, &reducer.getRegion().getBlocks().front(), {lhs, rhs});
+    Value result = aggYield.values().front();
+    rewriter.eraseOp(aggYield);
+
+    rewriter.create<scf::ReduceReturnOp>(loc, result);
 
     rewriter.setInsertionPointAfter(reducer);
 
@@ -564,6 +614,7 @@ class LowerMatrixApplyRewrite : public OpRewritePattern<graphblas::MatrixApplyOp
 public:
   using OpRewritePattern<graphblas::MatrixApplyOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(graphblas::MatrixApplyOp op, PatternRewriter &rewriter) const {
+    ModuleOp module = op->getParentOfType<ModuleOp>(); /* ignore unused variable for debugging */ (void)module;
     Location loc = op->getLoc();
 
     Type valueType = op.input().getType().dyn_cast<RankedTensorType>().getElementType();
@@ -669,6 +720,7 @@ class LowerMatrixMultiplyRewrite : public OpRewritePattern<graphblas::MatrixMult
 public:
   using OpRewritePattern<graphblas::MatrixMultiplyOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(graphblas::MatrixMultiplyOp op, PatternRewriter &rewriter) const {
+    ModuleOp module = op->getParentOfType<ModuleOp>(); /* ignore unused variable for debugging */ (void)module;
     Location loc = rewriter.getUnknownLoc();
 
     // Inputs
@@ -1486,18 +1538,34 @@ private:
   }
 };
 
-class LowerMatrixMultiplyReduceToScalarRewrite : public OpRewritePattern<graphblas::MatrixMultiplyReduceToScalarOp> {
+class LowerMatrixMultiplyReduceToScalarGenericRewrite : public OpRewritePattern<graphblas::MatrixMultiplyReduceToScalarGenericOp> {
 public:
-  using OpRewritePattern<graphblas::MatrixMultiplyReduceToScalarOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::MatrixMultiplyReduceToScalarOp op, PatternRewriter &rewriter) const {
+  using OpRewritePattern<graphblas::MatrixMultiplyReduceToScalarGenericOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(graphblas::MatrixMultiplyReduceToScalarGenericOp op, PatternRewriter &rewriter) const {
+    ModuleOp module = op->getParentOfType<ModuleOp>(); /* ignore unused variable for debugging */ (void) module;
     Location loc = rewriter.getUnknownLoc();
 
     // Inputs
     Value A = op.a();
     Value B = op.b();
     Value mask = op.mask();
-    StringRef semiring = op.semiring();
-    StringRef aggregator = op.aggregator();
+
+    // Required blocks
+    RegionRange extensions = op.extensions();
+    ExtensionBlocks extBlocks;
+    std::set<graphblas::YieldKind> required = {
+        graphblas::YieldKind::ADD_IDENTITY,
+        graphblas::YieldKind::ADD,
+        graphblas::YieldKind::MULT,
+        graphblas::YieldKind::AGG_IDENTITY,
+        graphblas::YieldKind::AGG};
+    std::set<graphblas::YieldKind> optional = {};
+    LogicalResult extractResult = extBlocks.extractBlocks(op, extensions, required, optional);
+
+    if (extractResult.failed())
+    {
+      return extractResult;
+    }
 
     // Types
     Type indexType = rewriter.getIndexType();
@@ -1604,7 +1672,13 @@ public:
     Value iStart = rewriter.create<IndexCastOp>(loc, iStart64, indexType);
     Value iEnd = rewriter.create<IndexCastOp>(loc, iEnd64, indexType);
 
-    scf::ForOp kLoop = rewriter.create<scf::ForOp>(loc, iStart, iEnd, c1, cf0);
+    // insert add identity block
+    graphblas::YieldOp addIdentityYield = llvm::dyn_cast_or_null<graphblas::YieldOp>(extBlocks.addIdentity->getTerminator());
+    rewriter.mergeBlocks(extBlocks.addIdentity, &colLoop2.getLoopBody().getBlocks().front(), {});
+    Value addIdentity = addIdentityYield.values().front();
+    rewriter.eraseOp(addIdentityYield);
+
+    scf::ForOp kLoop = rewriter.create<scf::ForOp>(loc, iStart, iEnd, c1, addIdentity);
     Value ii = kLoop.getInductionVar();
     Value curr = kLoop.getLoopBody().getArgument(1);
     rewriter.setInsertionPointToStart(kLoop.getBody());
@@ -1615,21 +1689,23 @@ public:
     scf::IfOp ifBlock_cmpPair = rewriter.create<scf::IfOp>(loc, valueType, cmpPair, true);
     // if cmpPair
     rewriter.setInsertionPointToStart(ifBlock_cmpPair.thenBlock());
-    Value newVal;
-    if (semiring == "plus_pair") {
-        newVal = rewriter.create<AddFOp>(loc, curr, cf1);
-    } else {
-        Value aVal = rewriter.create<memref::LoadOp>(loc, kvec, kk);
-        Value bVal = rewriter.create<memref::LoadOp>(loc, Bx, ii);
-        if (semiring == "plus_times") {
-            val = rewriter.create<MulFOp>(loc, aVal, bVal);
-            newVal = rewriter.create<AddFOp>(loc, curr, val);
-        } else if (semiring == "plus_plus") {
-            val = rewriter.create<AddFOp>(loc, aVal, bVal);
-            newVal = rewriter.create<AddFOp>(loc, curr, val);
-        }
-    }
-    rewriter.create<scf::YieldOp>(loc, newVal);
+
+    Value aVal = rewriter.create<memref::LoadOp>(loc, kvec, kk);
+    Value bVal = rewriter.create<memref::LoadOp>(loc, Bx, ii);
+
+    // insert multiply operation block
+    graphblas::YieldOp multYield = llvm::dyn_cast_or_null<graphblas::YieldOp>(extBlocks.mult->getTerminator());
+    Value multResult = multYield.values().front();
+    rewriter.eraseOp(multYield);
+    rewriter.mergeBlocks(extBlocks.mult, rewriter.getBlock(), {aVal, bVal});
+
+    // insert add operation block
+    graphblas::YieldOp addYield = llvm::dyn_cast_or_null<graphblas::YieldOp>(extBlocks.add->getTerminator());
+    Value addResult = addYield.values().front();
+    rewriter.eraseOp(addYield);
+    rewriter.mergeBlocks(extBlocks.add, rewriter.getBlock(), {curr, multResult});
+
+    rewriter.create<scf::YieldOp>(loc, addResult);
 
     // else
     rewriter.setInsertionPointToStart(ifBlock_cmpPair.elseBlock());
@@ -1645,19 +1721,25 @@ public:
 
     Value colVal = kLoop.getResult(0);
 
+    // FIXME: this is where transform_out goes
+
     scf::ReduceOp colReducer = rewriter.create<scf::ReduceOp>(loc, colVal);
     BlockArgument lhs = colReducer.getRegion().getArgument(0);
     BlockArgument rhs = colReducer.getRegion().getArgument(1);
 
     rewriter.setInsertionPointToStart(&colReducer.getRegion().front());
 
-    Value z;
-    if (aggregator == "sum") {
-      z = llvm::TypeSwitch<Type, Value>(valueType)
-        .Case<IntegerType>([&](IntegerType type) { return rewriter.create<AddIOp>(loc, lhs, rhs); })
-        .Case<FloatType>([&](FloatType type) { return rewriter.create<AddFOp>(loc, lhs, rhs); });
-    }
-    rewriter.create<scf::ReduceReturnOp>(loc, z);
+
+    Region *aggRegion = extBlocks.agg->getParent();
+    BlockAndValueMapping mapper;
+    // Clone blocks into front of region to displace existing entry block, which will be removed
+    // by canonicalization later
+    aggRegion->cloneInto(&colReducer.getRegion(), colReducer.getRegion().begin(), mapper);
+    graphblas::YieldOp colYield = llvm::dyn_cast_or_null<graphblas::YieldOp>(colReducer.getRegion().front().getTerminator());
+    Value colAggResult = colYield.values().front();
+    rewriter.setInsertionPointAfter(colYield);
+    rewriter.create<scf::ReduceReturnOp>(loc, colAggResult);
+    rewriter.eraseOp(colYield);
 
     rewriter.setInsertionPointAfter(colReducer);
 
@@ -1680,12 +1762,13 @@ public:
 
     rewriter.setInsertionPointToStart(&rowReducer.getRegion().front());
 
-    if (aggregator == "sum") {
-      z = llvm::TypeSwitch<Type, Value>(valueType)
-        .Case<IntegerType>([&](IntegerType type) { return rewriter.create<AddIOp>(loc, lhs, rhs); })
-        .Case<FloatType>([&](FloatType type) { return rewriter.create<AddFOp>(loc, lhs, rhs); });
-    }
-    rewriter.create<scf::ReduceReturnOp>(loc, z);
+    graphblas::YieldOp yield = llvm::dyn_cast_or_null<graphblas::YieldOp>(extBlocks.agg->getTerminator());
+    Value aggResult = yield.values().front();
+
+    // we can safely merge this agg block now, since the previous agg instance was cloned above
+    rewriter.mergeBlocks(extBlocks.agg, rewriter.getInsertionBlock(), {lhs, rhs});
+    rewriter.create<scf::ReduceReturnOp>(loc, aggResult);
+    rewriter.eraseOp(yield);
 
     // end row loop
     rewriter.setInsertionPointAfter(rowLoop);
@@ -1702,11 +1785,12 @@ void populateGraphBLASLoweringPatterns(RewritePatternSet &patterns) {
   patterns.add<
       LowerMatrixSelectRewrite,
       LowerMatrixReduceToScalarRewrite,
+      LowerMatrixReduceToScalarGenericRewrite,
       LowerMatrixMultiplyRewrite,
       LowerConvertLayoutRewrite,
       LowerMatrixApplyRewrite,
       LowerMatrixApplyGenericRewrite,
-      LowerMatrixMultiplyReduceToScalarRewrite,
+      LowerMatrixMultiplyReduceToScalarGenericRewrite,
       LowerMatrixMultiplyGenericRewrite,
       LowerSizeRewrite,
       LowerNumRowsRewrite,
@@ -1730,7 +1814,8 @@ void populateGraphBLASStructuralizePatterns(RewritePatternSet &patterns)
 {
   patterns.add<
       LowerMatrixMultiplyRewrite,
-      LowerMatrixApplyRewrite
+      LowerMatrixApplyRewrite,
+      LowerMatrixReduceToScalarRewrite
       >(patterns.getContext());
 }
 

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASLowerPass.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASLowerPass.cpp
@@ -564,7 +564,7 @@ public:
 
     // insert agg identity
     graphblas::YieldOp aggIdentityYield = llvm::dyn_cast_or_null<graphblas::YieldOp>(extBlocks.aggIdentity->getTerminator());
-    rewriter.mergeBlocks(extBlocks.aggIdentity, rewriter.getInsertionBlock(), {});
+    rewriter.mergeBlocks(extBlocks.aggIdentity, rewriter.getBlock(), {});
     Value c0Accumulator = aggIdentityYield.values().front();
     rewriter.eraseOp(aggIdentityYield);
 
@@ -596,7 +596,7 @@ public:
     rewriter.setInsertionPointToStart(&reducer.getRegion().front());
 
     graphblas::YieldOp aggYield = llvm::dyn_cast_or_null<graphblas::YieldOp>(extBlocks.agg->getTerminator());
-    rewriter.mergeBlocks(extBlocks.agg, &reducer.getRegion().getBlocks().front(), {lhs, rhs});
+    rewriter.mergeBlocks(extBlocks.agg, rewriter.getBlock(), {lhs, rhs});
     Value result = aggYield.values().front();
     rewriter.eraseOp(aggYield);
 
@@ -980,7 +980,7 @@ void computeInnerProduct(PatternRewriter &rewriter, Value nk,
 
   // insert add identity block
   graphblas::YieldOp addIdentityYield = llvm::dyn_cast_or_null<graphblas::YieldOp>(extBlocks.addIdentity->getTerminator());
-  rewriter.mergeBlocks(extBlocks.addIdentity, &colLoop3f.getLoopBody().getBlocks().front(), {});
+  rewriter.mergeBlocks(extBlocks.addIdentity, rewriter.getBlock(), {});
   Value addIdentity = addIdentityYield.values().front();
   rewriter.eraseOp(addIdentityYield);
 
@@ -1043,7 +1043,7 @@ void computeInnerProduct(PatternRewriter &rewriter, Value nk,
     graphblas::YieldOp yield = llvm::dyn_cast_or_null<graphblas::YieldOp>(extBlocks.transformOut->getTerminator());
     Value transformResult = yield.values().front();
 
-    rewriter.mergeBlocks(extBlocks.transformOut, ifBlock_newOffset.thenBlock(), {total});
+    rewriter.mergeBlocks(extBlocks.transformOut, rewriter.getBlock(), {total});
 
     rewriter.create<memref::StoreOp>(loc, transformResult, outputValues, cjPos);
     rewriter.eraseOp(yield);
@@ -1674,7 +1674,7 @@ public:
 
     // insert add identity block
     graphblas::YieldOp addIdentityYield = llvm::dyn_cast_or_null<graphblas::YieldOp>(extBlocks.addIdentity->getTerminator());
-    rewriter.mergeBlocks(extBlocks.addIdentity, &colLoop2.getLoopBody().getBlocks().front(), {});
+    rewriter.mergeBlocks(extBlocks.addIdentity, rewriter.getBlock(), {});
     Value addIdentity = addIdentityYield.values().front();
     rewriter.eraseOp(addIdentityYield);
 
@@ -1766,7 +1766,7 @@ public:
     Value aggResult = yield.values().front();
 
     // we can safely merge this agg block now, since the previous agg instance was cloned above
-    rewriter.mergeBlocks(extBlocks.agg, rewriter.getInsertionBlock(), {lhs, rhs});
+    rewriter.mergeBlocks(extBlocks.agg, rewriter.getBlock(), {lhs, rhs});
     rewriter.create<scf::ReduceReturnOp>(loc, aggResult);
     rewriter.eraseOp(yield);
 

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOps.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOps.cpp
@@ -13,6 +13,7 @@
 #include "llvm/ADT/None.h"
 
 #include "GraphBLAS/GraphBLASOpsEnums.cpp.inc"
+#include "GraphBLAS/GraphBLASUtils.h"
 
 using namespace mlir;
 using namespace mlir::graphblas;
@@ -97,17 +98,6 @@ static llvm::Optional<std::string> checkCompressedVector(
       "dimLevelType = [ \"dense\", \"compressed\" ] in the sparse encoding.";
   
   return llvm::None;
-}
-
-static int64_t getRank(Type inputType)
-{
-  mlir::sparse_tensor::SparseTensorEncodingAttr sparseEncoding =
-    mlir::sparse_tensor::getSparseTensorEncoding(inputType);
-  if (!sparseEncoding)
-    return -1;
-
-  RankedTensorType inputTensorType = inputType.dyn_cast<RankedTensorType>();
-  return inputTensorType.getRank();
 }
 
 //===--------------------------------------------------------------------===//
@@ -310,7 +300,6 @@ static LogicalResult verifyMatrixMultiplyArgs(T op, bool checkResultTensorType)
       resultTensorType = resultType.dyn_cast<RankedTensorType>();
       resultShape = resultTensorType.getShape();
       resultRank = getRank(resultType);
-      RankedTensorType resultTensorType = resultType.dyn_cast<RankedTensorType>();
       resultElementType = resultTensorType.getElementType();
     }
   }

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOps.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOps.cpp
@@ -278,7 +278,7 @@ static LogicalResult verify(MatrixApplyGenericOp op)
 
 
 template <class T>
-static LogicalResult verifyMatrixMultiplyArgs(T op)
+static LogicalResult verifyMatrixMultiplyArgs(T op, bool checkResultTensorType)
 {
   Type aType = op.a().getType();
   Type bType = op.b().getType();
@@ -297,22 +297,26 @@ static LogicalResult verifyMatrixMultiplyArgs(T op)
 
   ArrayRef<int64_t> aShape = aTensorType.getShape();
   ArrayRef<int64_t> bShape = bTensorType.getShape();
-
-  // Vector-vector result is a scalar; Otherwise, get the tensor properties of the result
   int64_t resultRank = 0;
   ArrayRef<int64_t> resultShape;
   Type resultElementType = resultType;
-  if (aRank == 2 || bRank == 2) {
-    resultRank = getRank(resultType);
-    RankedTensorType resultTensorType = resultType.dyn_cast<RankedTensorType>();
-    resultShape = resultTensorType.getShape();
-    resultElementType = resultTensorType.getElementType();
+  RankedTensorType resultTensorType;
+
+  // Vector-vector result is a scalar; Otherwise, get the tensor properties of the result
+  if (checkResultTensorType)
+  {
+    if (aRank == 2 || bRank == 2)
+    {
+      resultTensorType = resultType.dyn_cast<RankedTensorType>();
+      resultShape = resultTensorType.getShape();
+      resultRank = getRank(resultType);
+      RankedTensorType resultTensorType = resultType.dyn_cast<RankedTensorType>();
+      resultElementType = resultTensorType.getElementType();
+    }
   }
 
   if (aTensorType.getElementType() != bTensorType.getElementType())
     return op.emitError("Operand element types must be identical.");
-  if (aTensorType.getElementType() != resultElementType)
-    return op.emitError("Result element type differs from the input element types.");
 
   llvm::Optional<std::string> errMsg;
   if (aRank == 2 && bRank == 2)
@@ -326,15 +330,19 @@ static LogicalResult verifyMatrixMultiplyArgs(T op)
     if (errMsg)
       return op.emitError(errMsg.getValue());
 
-    errMsg = checkCompressedMatrix(resultType, -1, CSR);
-    if (errMsg)
-      return op.emitError(errMsg.getValue());
+    if (checkResultTensorType) {
+      errMsg = checkCompressedMatrix(resultType, -1, CSR);
+      if (errMsg)
+        return op.emitError(errMsg.getValue());
+      if (resultShape[0] != aShape[0] || resultShape[1] != bShape[1])
+        return op.emitError("Operand shapes incompatible with output shape.");
+      if (aTensorType.getElementType() != resultElementType)
+        return op.emitError("Result element type differs from the input element types.");
+    }
 
     // TODO intelligently handle arbitrarily shaped tensors, i.e. tensors with shapes using "?"
     if (aShape[1] != bShape[0])
       return op.emitError("Operand shapes are incompatible.");
-    if (resultShape[0] != aShape[0] || resultShape[1] != bShape[1])
-      return op.emitError("Operand shapes incompatible with output shape.");
   }
   else if (aRank == 2 && bRank == 1)
   {
@@ -347,14 +355,18 @@ static LogicalResult verifyMatrixMultiplyArgs(T op)
     if (errMsg)
       return op.emitError(errMsg.getValue());
 
-    errMsg = checkCompressedVector(resultType, -1);
-    if (errMsg)
-      return op.emitError(errMsg.getValue());
+    if (checkResultTensorType) {
+      errMsg = checkCompressedVector(resultType, -1);
+      if (errMsg)
+        return op.emitError(errMsg.getValue());
 
+      if (resultShape[0] != aShape[0])
+        return op.emitError("Operand shapes incompatible with output shape.");
+      if (aTensorType.getElementType() != resultElementType)
+        return op.emitError("Result element type differs from the input element types.");
+    }
     if (aShape[1] != bShape[0])
       return op.emitError("Operand shapes are incompatible.");
-    if (resultShape[0] != aShape[0])
-      return op.emitError("Operand shapes incompatible with output shape.");
   }
   else if (aRank == 1 && bRank == 2)
   {
@@ -367,14 +379,19 @@ static LogicalResult verifyMatrixMultiplyArgs(T op)
     if (errMsg)
       return op.emitError(errMsg.getValue());
 
-    errMsg = checkCompressedVector(resultType, -1);
-    if (errMsg)
-      return op.emitError(errMsg.getValue());
-
     if (aShape[0] != bShape[0])
       return op.emitError("Operand shapes are incompatible.");
-    if (resultShape[0] != bShape[1])
-      return op.emitError("Operand shapes incompatible with output shape.");
+
+    if (checkResultTensorType)
+    {
+      errMsg = checkCompressedVector(resultType, -1);
+      if (errMsg)
+        return op.emitError(errMsg.getValue());
+      if (resultShape[0] != bShape[1])
+        return op.emitError("Operand shapes incompatible with output shape.");
+      if (aTensorType.getElementType() != resultElementType)
+        return op.emitError("Result element type differs from the input element types.");
+    }
   }
   else
   {
@@ -389,36 +406,41 @@ static LogicalResult verifyMatrixMultiplyArgs(T op)
 
     if (aShape[0] != bShape[0])
       return op.emitError("Operand shapes are incompatible.");
+    if (aTensorType.getElementType() != resultElementType)
+      return op.emitError("Result element type differs from the input element types.");
   }
 
   Value mask = op.mask();
   if (mask)
   {
     Type maskType = mask.getType();
-    if (resultRank == 2)
-    {
-      errMsg = checkCompressedMatrix(maskType, 2, CSR);
-      if (errMsg)
-        return op.emitError(errMsg.getValue());
 
-      RankedTensorType maskTensorType = maskType.dyn_cast<RankedTensorType>();
-      ArrayRef<int64_t> maskShape = maskTensorType.getShape();
-      if (resultShape[0] != maskShape[0] || resultShape[1] != maskShape[1])
-        return op.emitError("Mask shape must match output shape.");
-    }
-    else if (resultRank == 1)
-    {
-      errMsg = checkCompressedVector(maskType, 2);
-      if (errMsg)
-        return op.emitError(errMsg.getValue());
+    if (checkResultTensorType) {
+      if (resultRank == 2)
+      {
+        errMsg = checkCompressedMatrix(maskType, 2, CSR);
+        if (errMsg)
+          return op.emitError(errMsg.getValue());
 
-      RankedTensorType maskTensorType = maskType.dyn_cast<RankedTensorType>();
-      ArrayRef<int64_t> maskShape = maskTensorType.getShape();
-      if (resultShape[0] != maskShape[0])
-        return op.emitError("Mask shape must match output shape.");
-    }
-    else {
-      return op.emitError("Mask not allowed for vector times vector multiplication.");
+        RankedTensorType maskTensorType = maskType.dyn_cast<RankedTensorType>();
+        ArrayRef<int64_t> maskShape = maskTensorType.getShape();
+        if (resultShape[0] != maskShape[0] || resultShape[1] != maskShape[1])
+          return op.emitError("Mask shape must match shape of matrix multiply result.");
+      }
+      else if (resultRank == 1)
+      {
+        errMsg = checkCompressedVector(maskType, 2);
+        if (errMsg)
+          return op.emitError(errMsg.getValue());
+
+        RankedTensorType maskTensorType = maskType.dyn_cast<RankedTensorType>();
+        ArrayRef<int64_t> maskShape = maskTensorType.getShape();
+        if (resultShape[0] != maskShape[0])
+          return op.emitError("Mask shape must match shape of matrix multiply result.");
+      }
+      else {
+        return op.emitError("Mask not allowed for vector times vector multiplication.");
+      }
     }
   }
 
@@ -428,7 +450,7 @@ static LogicalResult verifyMatrixMultiplyArgs(T op)
 static const std::vector<std::string> supportedSemirings{"plus_times", "plus_pair", "plus_plus"};
 
 static LogicalResult verify(MatrixMultiplyOp op) {
-  LogicalResult argResult = verifyMatrixMultiplyArgs(op);
+  LogicalResult argResult = verifyMatrixMultiplyArgs(op, true);
 
   if (argResult.failed())
     return argResult;
@@ -448,11 +470,9 @@ static LogicalResult verify(MatrixMultiplyOp op) {
   return success();
 }
 
-
-
 static LogicalResult verify(MatrixMultiplyGenericOp op)
 {
-  LogicalResult argResult = verifyMatrixMultiplyArgs(op);
+  LogicalResult argResult = verifyMatrixMultiplyArgs(op, true);
 
   if (argResult.failed())
     return argResult;
@@ -466,59 +486,16 @@ static LogicalResult verify(MatrixMultiplyGenericOp op)
   return success();
 }
 
-static LogicalResult verify(MatrixMultiplyReduceToScalarOp op) {
-  Type aType = op.a().getType();
-  Type bType = op.b().getType();
-  Type resultType = op.getResult().getType();
+static LogicalResult verify(MatrixMultiplyReduceToScalarGenericOp op) {
+  LogicalResult argResult = verifyMatrixMultiplyArgs(op, false /* no result tensor */);
 
-  llvm::Optional<std::string> aCompressionErrorMessage = checkCompressedMatrix(aType, 0, CSR);
-  if (aCompressionErrorMessage)
-    return op.emitError(aCompressionErrorMessage.getValue());
+  if (argResult.failed())
+    return argResult;
 
-  llvm::Optional<std::string> bCompressionErrorMessage = checkCompressedMatrix(bType, 1, CSC);
-  if (bCompressionErrorMessage)
-    return op.emitError(bCompressionErrorMessage.getValue());
-
-  static const std::vector<std::string> supportedAggregators{"sum"};
-  std::string aggregator = op.aggregator().str();
-  bool aggregatorSupported = std::find(supportedAggregators.begin(), supportedAggregators.end(), aggregator)
-    != supportedAggregators.end();
-  if (!aggregatorSupported)
-    return op.emitError("\""+aggregator+"\" is not a supported aggregator.");
-
-  RankedTensorType operandTensorType = aType.dyn_cast<RankedTensorType>();
-  if (resultType != operandTensorType.getElementType())
-    return op.emitError("Operand and output types are incompatible.");
-
-  std::string semiring = op.semiring().str();
-  bool semiringSupported = std::find(supportedSemirings.begin(), supportedSemirings.end(), semiring)
-    != supportedSemirings.end();
-  if (!semiringSupported)
-    return op.emitError("\""+semiring+"\" is not a supported semiring.");
-
-  RankedTensorType aTensorType = aType.dyn_cast<RankedTensorType>();
-  RankedTensorType bTensorType = bType.dyn_cast<RankedTensorType>();
-
-  ArrayRef<int64_t> aShape = aTensorType.getShape();
-  ArrayRef<int64_t> bShape = bTensorType.getShape();
-  // TODO intelligently handle arbitrarily shaped tensors, i.e. tensors with shapes using "?"
-  if (aShape[1] != bShape[0])
-    return op.emitError("Operand shapes are incompatible.");
-
-  if (aTensorType.getElementType() != bTensorType.getElementType())
-    return op.emitError("Operand element types must be identical.");
-
-  Value mask = op.mask();
-  if (mask) {
-    Type maskType = mask.getType();
-    llvm::Optional<std::string> maskCompressionErrorMessage = checkCompressedMatrix(maskType, 2, CSR);
-    if (maskCompressionErrorMessage)
-      return op.emitError(maskCompressionErrorMessage.getValue());
-
-    RankedTensorType maskTensorType = maskType.dyn_cast<RankedTensorType>();
-    ArrayRef<int64_t> maskShape = maskTensorType.getShape();
-    if (aShape[0] != maskShape[0] || bShape[1] != maskShape[1])
-      return op.emitError("Mask shape must match shape from result of matrix multiply.");
+  RegionRange extensions = op.extensions();
+  if (extensions.size() < 4)
+  {
+    return op.emitError("Must have at least 4 regions: add_identity, add, mult, agg.");
   }
 
   return success();
@@ -568,12 +545,28 @@ static LogicalResult verify(VectorEqualsOp op) {
   return success();
 }
 
-static LogicalResult verify(MatrixReduceToScalarOp op) {
+template <class T>
+static LogicalResult verifyMatrixReduceToScalarArgs(T op)
+{
   Type operandType = op.input().getType();
 
   llvm::Optional<std::string> compressionErrorMessage = checkCompressedMatrix(operandType, 0, EITHER);
   if (compressionErrorMessage)
     return op.emitError(compressionErrorMessage.getValue());
+
+  Type resultType = op.getResult().getType();
+  RankedTensorType operandTensorType = operandType.dyn_cast<RankedTensorType>();
+  if (resultType != operandTensorType.getElementType())
+    return op.emitError("Operand and output types are incompatible.");
+
+  return success();
+}
+
+static LogicalResult verify(MatrixReduceToScalarOp op) {
+  LogicalResult argResult = verifyMatrixReduceToScalarArgs(op);
+
+  if (argResult.failed())
+    return argResult;
 
   static const std::vector<std::string> supportedAggregators{"sum"};
   std::string aggregator = op.aggregator().str();
@@ -582,10 +575,21 @@ static LogicalResult verify(MatrixReduceToScalarOp op) {
   if (!aggregatorSupported)
     return op.emitError("\""+aggregator+"\" is not a supported aggregator.");
 
-  Type resultType = op.getResult().getType();
-  RankedTensorType operandTensorType = operandType.dyn_cast<RankedTensorType>();
-  if (resultType != operandTensorType.getElementType())
-    return op.emitError("Operand and output types are incompatible.");
+  return success();
+}
+
+static LogicalResult verify(MatrixReduceToScalarGenericOp op)
+{
+  LogicalResult argResult = verifyMatrixReduceToScalarArgs(op);
+
+  if (argResult.failed())
+    return argResult;
+
+  RegionRange extensions = op.extensions();
+  if (extensions.size() < 1)
+  {
+    return op.emitError("Must have at least 2 regions: agg_identity, agg.");
+  }
 
   return success();
 }

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOptimizePass.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOptimizePass.cpp
@@ -97,6 +97,9 @@ public:
     if (predecessor != nullptr && predecessor->hasOneUse()) {
       Location loc = op->getLoc();
 
+      if (getRank(predecessor.a()) < 2 || getRank(predecessor.b()) < 2)
+        return failure();
+
       // Build new MatrixMultiplyReduceToScalarGeneric op with the operands and regions of the multiply,
       // then add in the aggregator from the reduce
       ValueRange operands = predecessor.getOperands();
@@ -190,7 +193,6 @@ public:
       RegionRange applyExtensions = op.extensions();
 
       RankedTensorType tensorType = predecessor.a().getType().dyn_cast<RankedTensorType>();
-      Type valueType = tensorType.getElementType();
 
       graphblas::MatrixMultiplyGenericOp newMultOp = rewriter.create<graphblas::MatrixMultiplyGenericOp>(loc,
                                 op->getResultTypes(), operands, attributes.getAttrs(),

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOptimizePass.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOptimizePass.cpp
@@ -134,17 +134,6 @@ public:
       }
 
       RegionRange reduceExtensions = op.extensions();
-
-      // ExtensionBlocks aggBlocks;
-      // std::set<graphblas::YieldKind> aggRequired = {
-      //     graphblas::YieldKind::AGG_IDENTITY,
-      //     graphblas::YieldKind::AGG};
-      // LogicalResult result = multiplyBlocks.extractBlocks(op, aggExtensions, aggRequired, {});
-      // if (result.failed())
-      // {
-      //   return result;
-      // }
-
       Region &aggRegion0 = newMultOp.getRegion(newRegions - 2);
       aggRegion0.takeBody(*reduceExtensions[0]);
       Region &aggRegion1 = newMultOp.getRegion(newRegions - 1);

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOptimizePass.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOptimizePass.cpp
@@ -86,30 +86,72 @@ public:
   };
 };
 
-class FuseMatrixMultiplyReduceRewrite : public OpRewritePattern<graphblas::MatrixReduceToScalarOp>
+class FuseMatrixMultiplyReduceRewrite : public OpRewritePattern<graphblas::MatrixReduceToScalarGenericOp>
 {
 public:
-  using OpRewritePattern<graphblas::MatrixReduceToScalarOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::MatrixReduceToScalarOp op, PatternRewriter &rewriter) const
+  using OpRewritePattern<graphblas::MatrixReduceToScalarGenericOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(graphblas::MatrixReduceToScalarGenericOp op, PatternRewriter &rewriter) const
   {
     Value input = op.input();
-    graphblas::MatrixMultiplyOp predecessor = input.getDefiningOp<graphblas::MatrixMultiplyOp>();
+    graphblas::MatrixMultiplyGenericOp predecessor = input.getDefiningOp<graphblas::MatrixMultiplyGenericOp>();
     if (predecessor != nullptr && predecessor->hasOneUse()) {
       Location loc = op->getLoc();
 
-      // Build new MatrixMultiplyReduce op with the operands and arguments of the multiply,
+      // Build new MatrixMultiplyReduceToScalarGeneric op with the operands and regions of the multiply,
       // then add in the aggregator from the reduce
       ValueRange operands = predecessor.getOperands();
       NamedAttrList attributes = predecessor->getAttrs();
+      RegionRange multiplyExtensions = predecessor.extensions();
+      unsigned newRegions = multiplyExtensions.size();
 
-      StringAttr aggregator = rewriter.getStringAttr(op.aggregator());
-      attributes.push_back(rewriter.getNamedAttr("aggregator", aggregator));
+      ExtensionBlocks multiplyBlocks;
+      std::set<graphblas::YieldKind> required = {
+          graphblas::YieldKind::ADD_IDENTITY,
+          graphblas::YieldKind::ADD,
+          graphblas::YieldKind::MULT};
+      std::set<graphblas::YieldKind> optional = {graphblas::YieldKind::TRANSFORM_OUT};
+      LogicalResult result = multiplyBlocks.extractBlocks(op, multiplyExtensions, required, optional);
+      if (result.failed())
+      {
+        return result;
+      }
 
-      Value result = rewriter.create<graphblas::MatrixMultiplyReduceToScalarOp>(loc, 
-        op->getResultTypes(), operands, attributes.getAttrs());
+      if (multiplyBlocks.transformOut)
+      {
+        return failure(); // FIXME: cannot fuse with existing transform for now
+      }
+      else
+      {
+        newRegions += 2; // adding new agg and agg identity block
+      }
 
-      rewriter.replaceOp(op, result);
-      
+      graphblas::MatrixMultiplyReduceToScalarGenericOp newMultOp = rewriter.create<graphblas::MatrixMultiplyReduceToScalarGenericOp>(loc,
+          op->getResultTypes(), operands, attributes.getAttrs(), newRegions);
+
+      for (unsigned i = 0; i < newRegions - 2; i++)
+      {
+        newMultOp.getRegion(i).takeBody(*multiplyExtensions[i]);
+      }
+
+      RegionRange reduceExtensions = op.extensions();
+
+      // ExtensionBlocks aggBlocks;
+      // std::set<graphblas::YieldKind> aggRequired = {
+      //     graphblas::YieldKind::AGG_IDENTITY,
+      //     graphblas::YieldKind::AGG};
+      // LogicalResult result = multiplyBlocks.extractBlocks(op, aggExtensions, aggRequired, {});
+      // if (result.failed())
+      // {
+      //   return result;
+      // }
+
+      Region &aggRegion0 = newMultOp.getRegion(newRegions - 2);
+      aggRegion0.takeBody(*reduceExtensions[0]);
+      Region &aggRegion1 = newMultOp.getRegion(newRegions - 1);
+      aggRegion1.takeBody(*reduceExtensions[1]);
+
+      rewriter.replaceOp(op, newMultOp.getResult());
+      rewriter.eraseOp(predecessor);
       return success();
     }
     return failure();
@@ -129,7 +171,7 @@ public:
     {
       Location loc = op->getLoc();
 
-      // Build new MatrixMultiplyApply op with the operands and arguments of the multiply,
+      // Build new MatrixMultiplyApply op with the operands and regions of the multiply,
       // then add in the aggregator from the Apply
       ValueRange operands = predecessor.getOperands();
       NamedAttrList attributes = predecessor->getAttrs();

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASUtils.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASUtils.cpp
@@ -495,6 +495,12 @@ LogicalResult ExtensionBlocks::extractBlocks(Operation *op, RegionRange &regions
     case graphblas::YieldKind::MULT:
       this->mult = &block;
       break;
+    case graphblas::YieldKind::AGG_IDENTITY:
+      this->aggIdentity = &block;
+      break;
+    case graphblas::YieldKind::AGG:
+      this->agg = &block;
+      break;
     default:
       return op->emitError("unsupported graphblas extension block type");
     }

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASUtils.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASUtils.cpp
@@ -92,6 +92,23 @@ bool typeIsCSC(Type inputType) {
   return true;
 }
 
+int64_t getRank(Type inputType)
+{
+  mlir::sparse_tensor::SparseTensorEncodingAttr sparseEncoding =
+      mlir::sparse_tensor::getSparseTensorEncoding(inputType);
+  if (!sparseEncoding)
+    return -1;
+
+  RankedTensorType inputTensorType = inputType.dyn_cast<RankedTensorType>();
+  return inputTensorType.getRank();
+}
+
+int64_t getRank(Value inputValue)
+{
+  Type inputType = inputValue.getType();
+  return getRank(inputType);
+}
+
 // make Compressed Vector type
 RankedTensorType getCompressedVectorType(MLIRContext *context, ArrayRef<int64_t> shape, Type valueType)
 {

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_matrix_multiply.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_matrix_multiply.mlir
@@ -200,7 +200,7 @@ module {
 
 module {
     func @matrix_multiply_wrapper(%argA: tensor<2x3xi64, #CSR64>, %argB: tensor<3x2xi64, #CSC64>, %mask: tensor<2x999xi64, #CSR64>) -> tensor<2x2xi64, #CSR64> {
-        %answer = graphblas.matrix_multiply %argA, %argB, %mask{ semiring = "plus_times" } : (tensor<2x3xi64, #CSR64>, tensor<3x2xi64, #CSC64>, tensor<2x999xi64, #CSR64>) to tensor<2x2xi64, #CSR64> // expected-error {{Mask shape must match output shape.}}
+        %answer = graphblas.matrix_multiply %argA, %argB, %mask{ semiring = "plus_times" } : (tensor<2x3xi64, #CSR64>, tensor<3x2xi64, #CSC64>, tensor<2x999xi64, #CSR64>) to tensor<2x2xi64, #CSR64> // expected-error {{Mask shape must match shape of matrix multiply result.}}
         return %answer : tensor<2x2xi64, #CSR64>
     }
 }
@@ -223,7 +223,7 @@ module {
 
 module {
     func @matrix_multiply_wrapper(%argA: tensor<2x3xi64, #CSR64>, %argB: tensor<3x2xi64, #CSC64>, %mask: tensor<999x2xi64, #CSR64>) -> tensor<2x2xi64, #CSR64> {
-        %answer = graphblas.matrix_multiply %argA, %argB, %mask{ semiring = "plus_pair" } : (tensor<2x3xi64, #CSR64>, tensor<3x2xi64, #CSC64>, tensor<999x2xi64, #CSR64>) to tensor<2x2xi64, #CSR64> // expected-error {{Mask shape must match output shape.}}
+        %answer = graphblas.matrix_multiply %argA, %argB, %mask{ semiring = "plus_pair" } : (tensor<2x3xi64, #CSR64>, tensor<3x2xi64, #CSC64>, tensor<999x2xi64, #CSR64>) to tensor<2x2xi64, #CSR64> // expected-error {{Mask shape must match shape of matrix multiply result.}}
         return %answer : tensor<2x2xi64, #CSR64>
     }
 }
@@ -246,7 +246,7 @@ module {
 
 module {
     func @matrix_multiply_wrapper(%argA: tensor<2x3xi64, #CSR64>, %argB: tensor<3x2xi64, #CSC64>, %mask: tensor<999x999xi64, #CSR64>) -> tensor<2x2xi64, #CSR64> {
-        %answer = graphblas.matrix_multiply %argA, %argB, %mask{ semiring = "plus_times" } : (tensor<2x3xi64, #CSR64>, tensor<3x2xi64, #CSC64>, tensor<999x999xi64, #CSR64>) to tensor<2x2xi64, #CSR64> // expected-error {{Mask shape must match output shape.}}
+        %answer = graphblas.matrix_multiply %argA, %argB, %mask{ semiring = "plus_times" } : (tensor<2x3xi64, #CSR64>, tensor<3x2xi64, #CSC64>, tensor<999x999xi64, #CSR64>) to tensor<2x2xi64, #CSR64> // expected-error {{Mask shape must match shape of matrix multiply result.}}
         return %answer : tensor<2x2xi64, #CSR64>
     }
 }

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_matrix_vector_multiply.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_matrix_vector_multiply.mlir
@@ -136,7 +136,7 @@ module {
 module {
 
    func @matrix_vector_multiply_plus_times(%matrix: tensor<2x3xi64, #CSR64>, %vector: tensor<3xi64, #SparseVec64>, %mask: tensor<99xi64, #SparseVec64>) -> tensor<2xi64, #SparseVec64> {
-       %answer = graphblas.matrix_multiply %matrix, %vector, %mask { semiring = "plus_times" } : (tensor<2x3xi64, #CSR64>, tensor<3xi64, #SparseVec64>, tensor<99xi64, #SparseVec64>) to tensor<2xi64, #SparseVec64> // expected-error {{Mask shape must match output shape.}}
+       %answer = graphblas.matrix_multiply %matrix, %vector, %mask { semiring = "plus_times" } : (tensor<2x3xi64, #CSR64>, tensor<3xi64, #SparseVec64>, tensor<99xi64, #SparseVec64>) to tensor<2xi64, #SparseVec64> // expected-error {{Mask shape must match shape of matrix multiply result.}}
        return %answer : tensor<2xi64, #SparseVec64>
    }
 

--- a/mlir_graphblas/src/test/GraphBLAS/opt_matrix_multiply_reduce.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/opt_matrix_multiply_reduce.mlir
@@ -13,42 +13,148 @@
   pointerBitWidth = 64,
   indexBitWidth = 64
 }>
-
-
 // CHECK-LABEL:   func @fuse_adjacent(
 // CHECK-SAME:                        %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                        %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> f64 {
-// CHECK:           %[[VAL_2:.*]] = graphblas.matrix_multiply_reduce_to_scalar %[[VAL_0]], %[[VAL_1]] {aggregator = "sum", semiring = "plus_plus"} : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) to f64
-// CHECK:           return %[[VAL_2]] : f64
+// CHECK:           %[[VAL_2:.*]] = constant 0.000000e+00 : f64
+// CHECK:           %[[VAL_3:.*]] = graphblas.matrix_multiply_reduce_to_scalar_generic %[[VAL_0]], %[[VAL_1]] : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) to f64  {
+// CHECK:             graphblas.yield add_identity %[[VAL_2]] : f64
+// CHECK:           },  {
+// CHECK:           ^bb0(%[[VAL_4:.*]]: f64, %[[VAL_5:.*]]: f64):
+// CHECK:             %[[VAL_6:.*]] = addf %[[VAL_4]], %[[VAL_5]] : f64
+// CHECK:             graphblas.yield add %[[VAL_6]] : f64
+// CHECK:           },  {
+// CHECK:           ^bb0(%[[VAL_7:.*]]: f64, %[[VAL_8:.*]]: f64):
+// CHECK:             %[[VAL_9:.*]] = mulf %[[VAL_7]], %[[VAL_8]] : f64
+// CHECK:             graphblas.yield mult %[[VAL_9]] : f64
+// CHECK:           },  {
+// CHECK:             graphblas.yield agg_identity %[[VAL_2]] : f64
+// CHECK:           },  {
+// CHECK:           ^bb0(%[[VAL_10:.*]]: f64, %[[VAL_11:.*]]: f64):
+// CHECK:             %[[VAL_12:.*]] = addf %[[VAL_10]], %[[VAL_11]] : f64
+// CHECK:             graphblas.yield agg %[[VAL_12]] : f64
+// CHECK:           }
+// CHECK:           return %[[VAL_3]] : f64
 // CHECK:         }
 func @fuse_adjacent(%A: tensor<?x?xf64, #CSR64>, %B: tensor<?x?xf64, #CSC64>) -> f64 {
-    %C = graphblas.matrix_multiply %A, %B { semiring = "plus_plus" } : (tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSC64>) to tensor<?x?xf64, #CSR64> 
-    %reduce_result = graphblas.matrix_reduce_to_scalar %C { aggregator = "sum" } : tensor<?x?xf64, #CSR64> to f64
+    %cst = constant 0.000000e+00 : f64
+    %C = graphblas.matrix_multiply_generic %A, %B : (tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSC64>) to tensor<?x?xf64, #CSR64> {
+        ^bb0:
+            %identity = constant 0.0 : f64
+            graphblas.yield add_identity %identity : f64
+    },{
+        ^bb0(%add_a: f64, %add_b: f64):
+            %add_result = std.addf %add_a, %add_b : f64
+            graphblas.yield add %add_result : f64
+    },{
+        ^bb0(%mult_a: f64, %mult_b: f64):
+            %mult_result = std.mulf %mult_a, %mult_b : f64
+            graphblas.yield mult %mult_result : f64
+    }
+    %reduce_result = graphblas.matrix_reduce_to_scalar_generic %C : tensor<?x?xf64, #CSR64> to f64  {
+      graphblas.yield agg_identity %cst : f64
+    },  {
+    ^bb0(%arg1: f64, %arg2: f64):
+      %1 = addf %arg1, %arg2 : f64
+      graphblas.yield agg %1 : f64
+    }
     return %reduce_result : f64
 }
+
 
 // CHECK-LABEL:   func @fuse_adjacent_with_mask(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                                  %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> f64 {
-// CHECK:           %[[VAL_2:.*]] = graphblas.matrix_multiply_reduce_to_scalar %[[VAL_0]], %[[VAL_1]], %[[VAL_0]] {aggregator = "sum", semiring = "plus_pair"} : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) to f64
-// CHECK:           return %[[VAL_2]] : f64
+// CHECK:           %[[VAL_2:.*]] = constant 0.000000e+00 : f64
+// CHECK:           %[[VAL_3:.*]] = graphblas.matrix_multiply_reduce_to_scalar_generic %[[VAL_0]], %[[VAL_1]], %[[VAL_0]] : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) to f64  {
+// CHECK:             graphblas.yield add_identity %[[VAL_2]] : f64
+// CHECK:           },  {
+// CHECK:           ^bb0(%[[VAL_4:.*]]: f64, %[[VAL_5:.*]]: f64):
+// CHECK:             %[[VAL_6:.*]] = addf %[[VAL_4]], %[[VAL_5]] : f64
+// CHECK:             graphblas.yield add %[[VAL_6]] : f64
+// CHECK:           },  {
+// CHECK:           ^bb0(%[[VAL_7:.*]]: f64, %[[VAL_8:.*]]: f64):
+// CHECK:             %[[VAL_9:.*]] = mulf %[[VAL_7]], %[[VAL_8]] : f64
+// CHECK:             graphblas.yield mult %[[VAL_9]] : f64
+// CHECK:           },  {
+// CHECK:             graphblas.yield agg_identity %[[VAL_2]] : f64
+// CHECK:           },  {
+// CHECK:           ^bb0(%[[VAL_10:.*]]: f64, %[[VAL_11:.*]]: f64):
+// CHECK:             %[[VAL_12:.*]] = addf %[[VAL_10]], %[[VAL_11]] : f64
+// CHECK:             graphblas.yield agg %[[VAL_12]] : f64
+// CHECK:           }
+// CHECK:           return %[[VAL_3]] : f64
 // CHECK:         }
 func @fuse_adjacent_with_mask(%A: tensor<?x?xf64, #CSR64>, %B: tensor<?x?xf64, #CSC64>) -> f64 {
-    %C = graphblas.matrix_multiply %A, %B, %A { semiring = "plus_pair" } : (tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSC64>, tensor<?x?xf64, #CSR64>) to tensor<?x?xf64, #CSR64> 
-    %reduce_result = graphblas.matrix_reduce_to_scalar %C { aggregator = "sum" } : tensor<?x?xf64, #CSR64> to f64
+    %cst = constant 0.000000e+00 : f64
+    %C = graphblas.matrix_multiply_generic %A, %B, %A : (tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSC64>, tensor<?x?xf64, #CSR64>) to tensor<?x?xf64, #CSR64> {
+        ^bb0:
+            %identity = constant 0.0 : f64
+            graphblas.yield add_identity %identity : f64
+    },{
+        ^bb0(%add_a: f64, %add_b: f64):
+            %add_result = std.addf %add_a, %add_b : f64
+            graphblas.yield add %add_result : f64
+    },{
+        ^bb0(%mult_a: f64, %mult_b: f64):
+            %mult_result = std.mulf %mult_a, %mult_b : f64
+            graphblas.yield mult %mult_result : f64
+    }
+    %reduce_result = graphblas.matrix_reduce_to_scalar_generic %C : tensor<?x?xf64, #CSR64> to f64  {
+      graphblas.yield agg_identity %cst : f64
+    },  {
+    ^bb0(%arg1: f64, %arg2: f64):
+      %1 = addf %arg1, %arg2 : f64
+      graphblas.yield agg %1 : f64
+    }
     return %reduce_result : f64
 }
-
 
 // CHECK-LABEL:   func @nofuse_multi_use(
 // CHECK-SAME:                           %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                           %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> (f64, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) {
-// CHECK:           %[[VAL_2:.*]] = graphblas.matrix_multiply %[[VAL_0]], %[[VAL_1]] {semiring = "plus_plus"} : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) to tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_3:.*]] = graphblas.matrix_reduce_to_scalar %[[VAL_2]] {aggregator = "sum"} : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to f64
-// CHECK:           return %[[VAL_3]], %[[VAL_2]] : f64, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_2:.*]] = constant 0.000000e+00 : f64
+// CHECK:           %[[VAL_3:.*]] = graphblas.matrix_multiply_generic %[[VAL_0]], %[[VAL_1]], %[[VAL_0]] : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) to tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
+// CHECK:             graphblas.yield add_identity %[[VAL_2]] : f64
+// CHECK:           },  {
+// CHECK:           ^bb0(%[[VAL_4:.*]]: f64, %[[VAL_5:.*]]: f64):
+// CHECK:             %[[VAL_6:.*]] = addf %[[VAL_4]], %[[VAL_5]] : f64
+// CHECK:             graphblas.yield add %[[VAL_6]] : f64
+// CHECK:           },  {
+// CHECK:           ^bb0(%[[VAL_7:.*]]: f64, %[[VAL_8:.*]]: f64):
+// CHECK:             %[[VAL_9:.*]] = mulf %[[VAL_7]], %[[VAL_8]] : f64
+// CHECK:             graphblas.yield mult %[[VAL_9]] : f64
+// CHECK:           }
+// CHECK:           %[[VAL_10:.*]] = graphblas.matrix_reduce_to_scalar_generic %[[VAL_11:.*]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to f64  {
+// CHECK:             graphblas.yield agg_identity %[[VAL_2]] : f64
+// CHECK:           },  {
+// CHECK:           ^bb0(%[[VAL_12:.*]]: f64, %[[VAL_13:.*]]: f64):
+// CHECK:             %[[VAL_14:.*]] = addf %[[VAL_12]], %[[VAL_13]] : f64
+// CHECK:             graphblas.yield agg %[[VAL_14]] : f64
+// CHECK:           }
+// CHECK:           return %[[VAL_10]], %[[VAL_3]] : f64, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
 func @nofuse_multi_use(%A: tensor<?x?xf64, #CSR64>, %B: tensor<?x?xf64, #CSC64>) -> (f64, tensor<?x?xf64, #CSR64>) {
-    %C = graphblas.matrix_multiply %A, %B { semiring = "plus_plus" } : (tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSC64>) to tensor<?x?xf64, #CSR64> 
-    %reduce_result = graphblas.matrix_reduce_to_scalar %C { aggregator = "sum" } : tensor<?x?xf64, #CSR64> to f64
+    %cst = constant 0.000000e+00 : f64
+    %C = graphblas.matrix_multiply_generic %A, %B, %A : (tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSC64>, tensor<?x?xf64, #CSR64>) to tensor<?x?xf64, #CSR64> {
+        ^bb0:
+            %identity = constant 0.0 : f64
+            graphblas.yield add_identity %identity : f64
+    },{
+        ^bb0(%add_a: f64, %add_b: f64):
+            %add_result = std.addf %add_a, %add_b : f64
+            graphblas.yield add %add_result : f64
+    },{
+        ^bb0(%mult_a: f64, %mult_b: f64):
+            %mult_result = std.mulf %mult_a, %mult_b : f64
+            graphblas.yield mult %mult_result : f64
+    }
+    %reduce_result = graphblas.matrix_reduce_to_scalar_generic %C : tensor<?x?xf64, #CSR64> to f64  {
+      graphblas.yield agg_identity %cst : f64
+    },  {
+    ^bb0(%arg1: f64, %arg2: f64):
+      %1 = addf %arg1, %arg2 : f64
+      graphblas.yield agg %1 : f64
+    }
     return %reduce_result, %C : f64, tensor<?x?xf64, #CSR64>
 }

--- a/mlir_graphblas/src/test/GraphBLAS/structuralize_reduce_to_scalar.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/structuralize_reduce_to_scalar.mlir
@@ -1,0 +1,28 @@
+// RUN: graphblas-opt %s | graphblas-opt --graphblas-structuralize | FileCheck %s
+
+#CSR64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "dense", "compressed" ],
+  dimOrdering = affine_map<(i,j) -> (i,j)>,
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+module {
+
+    // CHECK-LABEL:   func @matrix_reduce_to_scalar_f64(
+    // CHECK-SAME:                                      %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> f64 {
+    // CHECK:           %[[VAL_1:.*]] = constant 0.000000e+00 : f64
+    // CHECK:           %[[VAL_2:.*]] = graphblas.matrix_reduce_to_scalar_generic %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to f64  {
+    // CHECK:             graphblas.yield agg_identity %[[VAL_1]] : f64
+    // CHECK:           },  {
+    // CHECK:           ^bb0(%[[VAL_3:.*]]: f64, %[[VAL_4:.*]]: f64):
+    // CHECK:             %[[VAL_5:.*]] = addf %[[VAL_3]], %[[VAL_4]] : f64
+    // CHECK:             graphblas.yield agg %[[VAL_5]] : f64
+    // CHECK:           }
+    // CHECK:           return %[[VAL_2]] : f64
+    // CHECK:         }
+    func @matrix_reduce_to_scalar_f64(%sparse_tensor: tensor<?x?xf64, #CSR64>) -> f64 {
+        %answer = graphblas.matrix_reduce_to_scalar %sparse_tensor { aggregator = "sum" } : tensor<?x?xf64, #CSR64> to f64
+        return %answer : f64
+    }
+}


### PR DESCRIPTION
This PR splits matrix_reduce_to_scalar into:
- `matrix_reduce_to_scalar`
- `matrix_reduce_to_scalar_generic`

It also converts the `matrix_multiply_reduce_to_scalar` to `matrix_multiply_reduce_to_scalar_generic`, as this op exists only to facilitate optimization.  Compiler frontends should not need to generate this op.

The optimization pass which fuses multiply and reduce is also rewritten to fuse the new generic ops instead.