### PR TITLE
Initial implementation of graphblas.transpose op

### DIFF
--- a/mlir_graphblas/ops.py
+++ b/mlir_graphblas/ops.py
@@ -274,6 +274,20 @@ class GraphBLAS_ConvertLayout(BaseOp):
         )
 
 
+class GraphBLAS_Transpose(BaseOp):
+    dialect = "graphblas"
+    name = "transpose"
+
+    @classmethod
+    def call(cls, irbuilder, input, return_type):
+        cls.ensure_mlirvar(input, TensorType)
+        ret_val = irbuilder.new_var(return_type)
+        return ret_val, (
+            f"{ret_val.assign} = graphblas.transpose {input} : "
+            f"{input.type} to {ret_val.type}"
+        )
+
+
 class GraphBLAS_MatrixSelect(BaseOp):
     dialect = "graphblas"
     name = "matrix_select"

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
@@ -140,6 +140,29 @@ def GraphBLAS_ConvertLayoutOp : GraphBLAS_Op<"convert_layout", [NoSideEffect]> {
     }];
 }
 
+def GraphBLAS_TransposeOp : GraphBLAS_Op<"transpose", [NoSideEffect]> {
+    let summary = "transpose";
+    let description = [{
+        Returns a new sparse matrix that's the transpose of the input matrix.
+        The given sparse tensor must be a matrix, i.e. have rank 2.
+        The given tensor must have a CSR sparsity or a CSC sparsity.
+        The output type must be CSR or CSC.
+
+        Example:
+        ```
+        %a = graphblas.transpose %sparse_tensor : tensor<?x?xf64, #CSR64> to tensor<?x?xf64, #CSC64>
+        %b = graphblas.transpose %sparse_tensor : tensor<?x?xf64, #CSR64> to tensor<?x?xf64, #CSR64>
+        ```
+    }];
+
+    let arguments = (ins AnyTensor:$input);
+    let results = (outs AnyTensor:$output);
+    
+    let assemblyFormat = [{
+           $input attr-dict `:` type($input) `to` type($output)
+    }];
+}
+
 def GraphBLAS_MatrixSelectOp : GraphBLAS_Op<"matrix_select", [NoSideEffect, SameOperandsAndResultType]> {
     let summary = "matrix select operation";
     let description = [{

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASLowerPass.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASLowerPass.cpp
@@ -296,6 +296,69 @@ public:
   };
 };
 
+class LowerTransposeRewrite : public OpRewritePattern<graphblas::TransposeOp> {
+public:
+  using OpRewritePattern<graphblas::TransposeOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(graphblas::TransposeOp op, PatternRewriter &rewriter) const {
+    ModuleOp module = op->getParentOfType<ModuleOp>();
+    Location loc = op->getLoc();
+
+    Value inputTensor = op.input();
+    RankedTensorType inputType = inputTensor.getType().dyn_cast<RankedTensorType>();
+    RankedTensorType outputType = op->getResultTypes()[0].dyn_cast<RankedTensorType>();
+    
+    bool inputTypeIsCSR = typeIsCSR(inputType);
+    bool outputTypeIsCSR = typeIsCSR(outputType);
+
+    // Add a graphblas.convert_layout op if the input and output compression types are the same
+    if (inputTypeIsCSR == outputTypeIsCSR) {
+      // TODO consider separating this out into its own rewrite pattern
+      MLIRContext* context = op.getContext();
+      Type inputTensorValueType = inputType.getElementType();
+      llvm::ArrayRef<int64_t> inputShape = inputType.getShape();
+      RankedTensorType newType = inputTypeIsCSR ?
+       	getCSCTensorType(context, inputShape, inputTensorValueType) :
+      	getCSRTensorType(context, inputShape, inputTensorValueType);
+      graphblas::ConvertLayoutOp newConvertLayoutOp =
+      	rewriter.create<graphblas::ConvertLayoutOp>(loc, newType, inputTensor);
+      Value newLayOutInputTensor = newConvertLayoutOp.getResult();
+      graphblas::TransposeOp newTransposeOp =
+	rewriter.create<graphblas::TransposeOp>(loc, outputType, newLayOutInputTensor);
+      
+      rewriter.replaceOp(op, newTransposeOp.getResult()); 
+      
+      return success();
+    }
+
+    // Cast types
+    Value output = callDupTensor(rewriter, module, loc, inputTensor);
+    if (inputTypeIsCSR) {
+      output = convertToExternalCSC(rewriter, module, loc, output);
+    } else {
+      output = convertToExternalCSR(rewriter, module, loc, output);
+    }
+
+    // Swap sizes
+    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
+    Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
+    Value nrow = rewriter.create<graphblas::NumRowsOp>(loc, inputTensor);
+    Value ncol = rewriter.create<graphblas::NumColsOp>(loc, inputTensor);
+    Value cond = rewriter.create<CmpIOp>(op.getLoc(), CmpIPredicate::ne, nrow, ncol);
+    scf::IfOp ifOp = rewriter.create<scf::IfOp>(loc, cond, /*withElseRegion=*/ false);
+    rewriter.setInsertionPointToStart(&ifOp.thenRegion().front());
+    callResizeDim(rewriter, module, loc, output, c0, ncol);
+    callResizeDim(rewriter, module, loc, output, c1, nrow);
+    
+    // TODO we get an error when we have hard-coded/known sizes at compile time.
+
+    rewriter.replaceOp(op, output);
+
+    cleanupIntermediateTensor(rewriter, module, loc, output);
+    
+    return success();
+  };
+};
+  
 struct MatrixSelectOutputWriter {
   MatrixSelectOutputWriter(StringRef _selector) : selector(_selector)
   {
@@ -309,6 +372,7 @@ struct MatrixSelectOutputWriter {
     c1 = rewriter.create<ConstantIndexOp>(loc, 1);
     c0_64 = rewriter.create<ConstantIntOp>(loc, 0, int64Type);
     c1_64 = rewriter.create<ConstantIntOp>(loc, 1, int64Type);
+    // TODO support other element types besides f64
     cf0 = rewriter.create<ConstantFloatOp>(loc, APFloat(0.0), float64Type);
   }
 
@@ -1788,6 +1852,7 @@ void populateGraphBLASLoweringPatterns(RewritePatternSet &patterns) {
       LowerMatrixReduceToScalarGenericRewrite,
       LowerMatrixMultiplyRewrite,
       LowerConvertLayoutRewrite,
+      LowerTransposeRewrite,
       LowerMatrixApplyRewrite,
       LowerMatrixApplyGenericRewrite,
       LowerMatrixMultiplyReduceToScalarGenericRewrite,
@@ -1796,7 +1861,8 @@ void populateGraphBLASLoweringPatterns(RewritePatternSet &patterns) {
       LowerNumRowsRewrite,
       LowerNumColsRewrite,
       LowerNumValsRewrite,
-      LowerDupRewrite>(patterns.getContext());
+      LowerDupRewrite
+    >(patterns.getContext());
 }
 
 struct GraphBLASLoweringPass : public GraphBLASLoweringBase<GraphBLASLoweringPass> {

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOptimizePass.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOptimizePass.cpp
@@ -192,8 +192,6 @@ public:
 
       RegionRange applyExtensions = op.extensions();
 
-      RankedTensorType tensorType = predecessor.a().getType().dyn_cast<RankedTensorType>();
-
       graphblas::MatrixMultiplyGenericOp newMultOp = rewriter.create<graphblas::MatrixMultiplyGenericOp>(loc,
                                 op->getResultTypes(), operands, attributes.getAttrs(),
                                 newRegions);

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASUtils.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASUtils.cpp
@@ -205,7 +205,9 @@ Value convertToExternalCSX(OpBuilder &builder, ModuleOp &mod, Location loc, Valu
   if (typeIsCSX(inputType))
     return input;
   
-  RankedTensorType csxType = getCSXTensorType(context, {-1, -1}, builder.getF64Type()); 
+  llvm::ArrayRef<int64_t> inputShape = inputType.getShape();
+  Type inputTensorValueType = inputType.getElementType();
+  RankedTensorType csxType = getCSXTensorType(context, inputShape, inputTensorValueType);
   FlatSymbolRefAttr castFuncSymbol;
   if (typeIsCSC(inputType))
     castFuncSymbol = getFunc(mod, loc, "cast_csc_to_csx", csxType, inputType);
@@ -239,7 +241,9 @@ Value convertToExternalCSR(OpBuilder &builder, ModuleOp &mod, Location loc, Valu
   }
   
   // all external calls are currently for unknown size float64 tensors
-  RankedTensorType csrType = getCSRTensorType(context, {-1, -1}, builder.getF64Type()); 
+  llvm::ArrayRef<int64_t> inputShape = inputType.getShape();
+  Type inputTensorValueType = inputType.getElementType();
+  RankedTensorType csrType = getCSRTensorType(context, inputShape, inputTensorValueType); 
   FlatSymbolRefAttr castFuncSymbol = getFunc(mod, loc, "cast_csx_to_csr", csrType, inputType);
   CallOp castCallOp = builder.create<CallOp>(loc,
                                              castFuncSymbol,
@@ -263,7 +267,9 @@ Value convertToExternalCSC(OpBuilder &builder, ModuleOp &mod, Location loc, Valu
     inputType = input.getType().dyn_cast<RankedTensorType>();
   }
   
-  RankedTensorType cscType = getCSCTensorType(context, {-1, -1}, builder.getF64Type()); 
+  llvm::ArrayRef<int64_t> inputShape = inputType.getShape();
+  Type inputTensorValueType = inputType.getElementType();
+  RankedTensorType cscType = getCSCTensorType(context, inputShape, inputTensorValueType); 
   FlatSymbolRefAttr castFuncSymbol = getFunc(mod, loc, "cast_csx_to_csc", cscType, inputType);
   CallOp castCallOp = builder.create<CallOp>(loc,
                                              castFuncSymbol,

--- a/mlir_graphblas/src/test/GraphBLAS/check_ops.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/check_ops.mlir
@@ -34,6 +34,18 @@ module {
 
 module {
 
+    // CHECK: func @transpose_wrapper(%[[ARG0:.*]]: [[CSR_TYPE:tensor<.*->.*>]]) -> [[CSC_TYPE:tensor<.*->.*>]] {
+    func @transpose_wrapper(%sparse_tensor: tensor<2x3xf64, #CSR64>) -> tensor<3x2xf64, #CSC64> {
+        // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.transpose %[[ARG0]] : [[CSR_TYPE]] to [[CSC_TYPE]]
+        %answer = graphblas.transpose %sparse_tensor : tensor<2x3xf64, #CSR64> to tensor<3x2xf64, #CSC64>
+        // CHECK-NEXT: return %[[ANSWER]] : [[CSC_TYPE]]
+        return %answer : tensor<3x2xf64, #CSC64>
+    }
+
+}
+
+module {
+
     // CHECK: func @matrix_select_triu(%[[ARG0:.*]]: [[CSR_TYPE:tensor<.*->.*>]]) -> [[CSR_TYPE]] {
     func @matrix_select_triu(%sparse_tensor: tensor<100x100xf64, #CSR64>) -> tensor<100x100xf64, #CSR64> {
         // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.matrix_select %[[ARG0]] {selectors = ["triu"]} : [[CSR_TYPE]]

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_matrix_transpose.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_matrix_transpose.mlir
@@ -1,0 +1,77 @@
+// RUN: graphblas-opt %s -split-input-file -verify-diagnostics
+
+#CSR64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "dense", "compressed" ],
+  dimOrdering = affine_map<(i,j) -> (i,j)>,
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+module {
+    func @transpose_wrapper(%sparse_tensor: tensor<2x3xi16, #CSR64>) -> tensor<2x3xi16, #CSR64> {
+        %answer = graphblas.transpose %sparse_tensor : tensor<2x3xi16, #CSR64> to tensor<2x3xi16, #CSR64> // expected-error {{Input and output shapes are expected to be swapped.}}
+        return %answer : tensor<2x3xi16, #CSR64>
+    }
+}
+
+// -----
+
+#CSR64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "dense", "compressed" ],
+  dimOrdering = affine_map<(i,j) -> (i,j)>,
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+module {
+    func @transpose_wrapper(%sparse_tensor: tensor<2x3xi16, #CSR64>) -> tensor<99x2xi16, #CSR64> {
+        %answer = graphblas.transpose %sparse_tensor : tensor<2x3xi16, #CSR64> to tensor<99x2xi16, #CSR64> // expected-error {{Input and output shapes are expected to be swapped.}}
+        return %answer : tensor<99x2xi16, #CSR64>
+    }
+}
+
+// -----
+
+#CSR64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "dense", "compressed" ],
+  dimOrdering = affine_map<(i,j) -> (i,j)>,
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+#CSR_BOGUS = #sparse_tensor.encoding<{
+  dimLevelType = [ "dense", "compressed" ],
+  dimOrdering = affine_map<(i,j) -> (j,i)>,
+  pointerBitWidth = 32,
+  indexBitWidth = 64
+}>
+
+module {
+    func @transpose_wrapper(%sparse_tensor: tensor<2x3xi16, #CSR64>) -> tensor<3x2xi16, #CSR_BOGUS> {
+        %answer = graphblas.transpose %sparse_tensor : tensor<2x3xi16, #CSR64> to tensor<3x2xi16, #CSR_BOGUS> // expected-error {{Sparse encoding pointer bit widths of input and result tensors do not match.}}
+        return %answer : tensor<3x2xi16, #CSR_BOGUS>
+    }
+}
+
+// -----
+
+#CSR64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "dense", "compressed" ],
+  dimOrdering = affine_map<(i,j) -> (i,j)>,
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+#CSR_BOGUS = #sparse_tensor.encoding<{
+  dimLevelType = [ "dense", "compressed" ],
+  dimOrdering = affine_map<(i,j) -> (j,i)>,
+  pointerBitWidth = 64,
+  indexBitWidth = 32
+}>
+
+module {
+    func @transpose_wrapper(%sparse_tensor: tensor<2x3xi16, #CSR64>) -> tensor<3x2xi16, #CSR_BOGUS> {
+        %answer = graphblas.transpose %sparse_tensor : tensor<2x3xi16, #CSR64> to tensor<3x2xi16, #CSR_BOGUS> // expected-error {{Sparse encoding index bit widths of input and result tensors do not match.}}
+        return %answer : tensor<3x2xi16, #CSR_BOGUS>
+    }
+}

--- a/mlir_graphblas/src/test/GraphBLAS/lower_transpose.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_transpose.mlir
@@ -1,0 +1,136 @@
+// RUN: graphblas-opt %s | graphblas-opt --graphblas-lower | FileCheck %s
+
+#CSR64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "dense", "compressed" ],
+  dimOrdering = affine_map<(i,j) -> (i,j)>,
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+#CSC64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "dense", "compressed" ],
+  dimOrdering = affine_map<(i,j) -> (j,i)>,
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+module {
+// CHECK-LABEL:   func @transpose_different_compression(
+// CHECK-SAME:                                          %[[VAL_0:.*]]: tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK:           %[[VAL_1:.*]] = constant 0 : index
+// CHECK:           %[[VAL_2:.*]] = constant 1 : index
+// CHECK:           %[[VAL_3:.*]] = call @cast_csr_to_csx(%[[VAL_0]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_4:.*]] = call @dup_matrix(%[[VAL_3]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_5:.*]] = call @cast_csx_to_csc(%[[VAL_4]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_6:.*]] = memref.dim %[[VAL_0]], %[[VAL_1]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_7:.*]] = memref.dim %[[VAL_0]], %[[VAL_2]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_8:.*]] = cmpi ne, %[[VAL_6]], %[[VAL_7]] : index
+// CHECK:           scf.if %[[VAL_8]] {
+// CHECK:             %[[VAL_9:.*]] = call @cast_csc_to_csx(%[[VAL_5]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:             call @matrix_resize_dim(%[[VAL_9]], %[[VAL_1]], %[[VAL_7]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK:             %[[VAL_10:.*]] = call @cast_csc_to_csx(%[[VAL_5]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:             call @matrix_resize_dim(%[[VAL_10]], %[[VAL_2]], %[[VAL_6]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK:           }
+// CHECK:           return %[[VAL_5]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:         }
+    func @transpose_different_compression(%sparse_tensor: tensor<?x?xi64, #CSR64>) -> tensor<?x?xi64, #CSC64> {
+        %answer = graphblas.transpose %sparse_tensor : tensor<?x?xi64, #CSR64> to tensor<?x?xi64, #CSC64>
+        return %answer : tensor<?x?xi64, #CSC64>
+    }
+ 
+// CHECK-LABEL:   func @transpose_same_compression(
+// CHECK-SAME:                                     %[[VAL_0:.*]]: tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK:           %[[VAL_1:.*]] = constant 0 : i64
+// CHECK:           %[[VAL_2:.*]] = constant 1 : i64
+// CHECK:           %[[VAL_3:.*]] = constant 0 : index
+// CHECK:           %[[VAL_4:.*]] = constant 1 : index
+// CHECK:           %[[VAL_5:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_4]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_6:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_4]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_7:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_8:.*]] = memref.dim %[[VAL_0]], %[[VAL_3]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_9:.*]] = memref.dim %[[VAL_0]], %[[VAL_4]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_10:.*]] = addi %[[VAL_9]], %[[VAL_4]] : index
+// CHECK:           %[[VAL_11:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_4]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_12:.*]] = memref.dim %[[VAL_0]], %[[VAL_3]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_13:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_12]]] : memref<?xi64>
+// CHECK:           %[[VAL_14:.*]] = index_cast %[[VAL_13]] : i64 to index
+// CHECK:           %[[VAL_15:.*]] = call @cast_csr_to_csx(%[[VAL_0]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_16:.*]] = call @matrix_empty_like(%[[VAL_15]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           call @matrix_resize_dim(%[[VAL_16]], %[[VAL_3]], %[[VAL_8]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK:           call @matrix_resize_dim(%[[VAL_16]], %[[VAL_4]], %[[VAL_9]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK:           call @matrix_resize_pointers(%[[VAL_16]], %[[VAL_4]], %[[VAL_10]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK:           call @matrix_resize_index(%[[VAL_16]], %[[VAL_4]], %[[VAL_14]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK:           call @matrix_resize_values(%[[VAL_16]], %[[VAL_14]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
+// CHECK:           %[[VAL_17:.*]] = call @cast_csx_to_csc(%[[VAL_16]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_18:.*]] = sparse_tensor.pointers %[[VAL_17]], %[[VAL_4]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_19:.*]] = sparse_tensor.indices %[[VAL_17]], %[[VAL_4]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_20:.*]] = sparse_tensor.values %[[VAL_17]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           scf.for %[[VAL_21:.*]] = %[[VAL_3]] to %[[VAL_9]] step %[[VAL_4]] {
+// CHECK:             memref.store %[[VAL_1]], %[[VAL_18]]{{\[}}%[[VAL_21]]] : memref<?xi64>
+// CHECK:           }
+// CHECK:           scf.for %[[VAL_22:.*]] = %[[VAL_3]] to %[[VAL_14]] step %[[VAL_4]] {
+// CHECK:             %[[VAL_23:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_22]]] : memref<?xi64>
+// CHECK:             %[[VAL_24:.*]] = index_cast %[[VAL_23]] : i64 to index
+// CHECK:             %[[VAL_25:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_24]]] : memref<?xi64>
+// CHECK:             %[[VAL_26:.*]] = addi %[[VAL_25]], %[[VAL_2]] : i64
+// CHECK:             memref.store %[[VAL_26]], %[[VAL_18]]{{\[}}%[[VAL_24]]] : memref<?xi64>
+// CHECK:           }
+// CHECK:           memref.store %[[VAL_1]], %[[VAL_18]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_27:.*]] = %[[VAL_3]] to %[[VAL_9]] step %[[VAL_4]] {
+// CHECK:             %[[VAL_28:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_27]]] : memref<?xi64>
+// CHECK:             %[[VAL_29:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_29]], %[[VAL_18]]{{\[}}%[[VAL_27]]] : memref<?xi64>
+// CHECK:             %[[VAL_30:.*]] = addi %[[VAL_29]], %[[VAL_28]] : i64
+// CHECK:             memref.store %[[VAL_30]], %[[VAL_18]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:           }
+// CHECK:           scf.for %[[VAL_31:.*]] = %[[VAL_3]] to %[[VAL_8]] step %[[VAL_4]] {
+// CHECK:             %[[VAL_32:.*]] = index_cast %[[VAL_31]] : index to i64
+// CHECK:             %[[VAL_33:.*]] = memref.load %[[VAL_5]]{{\[}}%[[VAL_31]]] : memref<?xi64>
+// CHECK:             %[[VAL_34:.*]] = index_cast %[[VAL_33]] : i64 to index
+// CHECK:             %[[VAL_35:.*]] = addi %[[VAL_31]], %[[VAL_4]] : index
+// CHECK:             %[[VAL_36:.*]] = memref.load %[[VAL_5]]{{\[}}%[[VAL_35]]] : memref<?xi64>
+// CHECK:             %[[VAL_37:.*]] = index_cast %[[VAL_36]] : i64 to index
+// CHECK:             scf.for %[[VAL_38:.*]] = %[[VAL_34]] to %[[VAL_37]] step %[[VAL_4]] {
+// CHECK:               %[[VAL_39:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_38]]] : memref<?xi64>
+// CHECK:               %[[VAL_40:.*]] = index_cast %[[VAL_39]] : i64 to index
+// CHECK:               %[[VAL_41:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_40]]] : memref<?xi64>
+// CHECK:               %[[VAL_42:.*]] = index_cast %[[VAL_41]] : i64 to index
+// CHECK:               memref.store %[[VAL_32]], %[[VAL_19]]{{\[}}%[[VAL_42]]] : memref<?xi64>
+// CHECK:               %[[VAL_43:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_38]]] : memref<?xi64>
+// CHECK:               memref.store %[[VAL_43]], %[[VAL_20]]{{\[}}%[[VAL_42]]] : memref<?xi64>
+// CHECK:               %[[VAL_44:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_40]]] : memref<?xi64>
+// CHECK:               %[[VAL_45:.*]] = addi %[[VAL_44]], %[[VAL_2]] : i64
+// CHECK:               memref.store %[[VAL_45]], %[[VAL_18]]{{\[}}%[[VAL_40]]] : memref<?xi64>
+// CHECK:             }
+// CHECK:           }
+// CHECK:           %[[VAL_46:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:           memref.store %[[VAL_1]], %[[VAL_18]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_47:.*]] = %[[VAL_3]] to %[[VAL_9]] step %[[VAL_4]] {
+// CHECK:             %[[VAL_48:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_47]]] : memref<?xi64>
+// CHECK:             %[[VAL_49:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_49]], %[[VAL_18]]{{\[}}%[[VAL_47]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_48]], %[[VAL_18]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:           }
+// CHECK:           memref.store %[[VAL_46]], %[[VAL_18]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:           %[[VAL_50:.*]] = call @cast_csc_to_csx(%[[VAL_17]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_51:.*]] = call @dup_matrix(%[[VAL_50]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_52:.*]] = call @cast_csx_to_csr(%[[VAL_51]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_53:.*]] = memref.dim %[[VAL_17]], %[[VAL_3]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_54:.*]] = memref.dim %[[VAL_17]], %[[VAL_4]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_55:.*]] = cmpi ne, %[[VAL_53]], %[[VAL_54]] : index
+// CHECK:           scf.if %[[VAL_55]] {
+// CHECK:             %[[VAL_56:.*]] = call @cast_csr_to_csx(%[[VAL_52]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:             call @matrix_resize_dim(%[[VAL_56]], %[[VAL_3]], %[[VAL_54]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK:             %[[VAL_57:.*]] = call @cast_csr_to_csx(%[[VAL_52]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:             call @matrix_resize_dim(%[[VAL_57]], %[[VAL_4]], %[[VAL_53]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK:           }
+// CHECK:           %[[VAL_58:.*]] = call @cast_csc_to_csx(%[[VAL_17]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           call @delSparseMatrix(%[[VAL_58]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> ()
+// CHECK:           return %[[VAL_52]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:         }
+    func @transpose_same_compression(%sparse_tensor: tensor<?x?xi64, #CSR64>) -> tensor<?x?xi64, #CSR64> {
+        %answer = graphblas.transpose %sparse_tensor : tensor<?x?xi64, #CSR64> to tensor<?x?xi64, #CSR64>
+        return %answer : tensor<?x?xi64, #CSR64>
+    }
+   
+}

--- a/mlir_graphblas/tools/tersify_mlir.py
+++ b/mlir_graphblas/tools/tersify_mlir.py
@@ -21,11 +21,21 @@ CSC64_LINES = (
     "}>",
 )
 
+CSX64_LINES = (
+    "#sparse_tensor.encoding<{ ",
+    '    dimLevelType = [ "dense", "compressed" ], ',
+    "    pointerBitWidth = 64, ",
+    "    indexBitWidth = 64 ",
+    "}>",
+)
+
 CSR64_PRETTY_TEXT = "\n".join(CSR64_LINES)
 CSC64_PRETTY_TEXT = "\n".join(CSC64_LINES)
+CSX64_PRETTY_TEXT = "\n".join(CSX64_LINES)
 
 CSR64_EXPANDED_TEXT = " ".join(line.strip() for line in CSR64_LINES)
 CSC64_EXPANDED_TEXT = " ".join(line.strip() for line in CSC64_LINES)
+CSX64_EXPANDED_TEXT = " ".join(line.strip() for line in CSX64_LINES)
 
 CLI = None
 
@@ -44,6 +54,9 @@ def tersify_mlir(input_string: str) -> str:
     if CSC64_EXPANDED_TEXT in terse_string:
         terse_string = terse_string.replace(CSC64_EXPANDED_TEXT, "#CSC64")
         terse_string = f"#CSC64 = {CSC64_PRETTY_TEXT}\n\n" + terse_string
+    if CSX64_EXPANDED_TEXT in terse_string:
+        terse_string = terse_string.replace(CSX64_EXPANDED_TEXT, "#CSX64")
+        terse_string = f"#CSX64 = {CSX64_PRETTY_TEXT}\n\n" + terse_string
     return terse_string
 
 


### PR DESCRIPTION
This PR:
- Implements the `graphblas.transpose` op. 
- Adds a rewrite pattern for the `graphblas.transpose` op as part of `--graphblas-lower`.
- Makes the util function `checkCompressedMatrix` more strict by not allowing `CSX`.
- Updates various parts of `mlir_graphblas/src/lib/GraphBLAS/GraphBLASUtils.cpp` to not assume a shape of `?x?`/`{-1, -1}` and instead grab the shape from the input tensor. 
- Updates the `tersify_mlir` tool to also handle `CSX64`.
- Add `graphblas.transpose` to the IR builder. 
- Add the test `test_ir_project_and_filter`, which takes a rectangular sparse matrix representing a bipartite graph, does a graph projection (i.e. matmul), and filter (i.e. matrix select) via the IR builder. 