### PR TITLE
Add necessary flags and also save MLIR to disk when profiling

### DIFF
--- a/mlir_graphblas/cli.py
+++ b/mlir_graphblas/cli.py
@@ -49,8 +49,7 @@ class MlirOptCli:
         elif hasattr(file, "close"):
             return file.read()
         else:
-            with open(file, "rb") as f:
-                return f.read()
+            raise TypeError('file must be bytes or a file object')
 
     def apply_passes(self, file, passes: List[str]) -> Union[str, "DebugResult"]:
         """
@@ -62,14 +61,21 @@ class MlirOptCli:
         :return: str (if successful)
                  list of str containing transformations and eventual error (if failure)
         """
-        input = self._read_input(file)
+        args = [self._executable] + self._options + list(passes)
+        if isinstance(file, str):
+            args.append(file)
+            input = None
+        else:
+            input = self._read_input(file)
         result = logged_subprocess_run(
-            [self._executable] + self._options + list(passes),
+            args,
             capture_output=True,
             input=input,
         )
+
         if result.returncode == 0:
             return result.stdout.decode()
+
         err_lines = result.stderr.split(b"\n")
         err = MlirOptError("\n".join(el.decode() for el in err_lines[:3]))
         err.debug_result = self.debug_passes(input, passes) if passes else None

--- a/mlir_graphblas/cli.py
+++ b/mlir_graphblas/cli.py
@@ -49,7 +49,7 @@ class MlirOptCli:
         elif hasattr(file, "close"):
             return file.read()
         else:
-            raise TypeError('file must be bytes or a file object')
+            raise TypeError("file must be bytes or a file object")
 
     def apply_passes(self, file, passes: List[str]) -> Union[str, "DebugResult"]:
         """

--- a/mlir_graphblas/cli.py
+++ b/mlir_graphblas/cli.py
@@ -1,4 +1,5 @@
 import os
+import io
 import math
 import subprocess
 import tempfile
@@ -43,7 +44,7 @@ class MlirOptCli:
             options = []
         self._options = options
 
-    def _read_input(self, file) -> bytes:
+    def _read_input(self, file: Union[bytes, io.IOBase]) -> bytes:
         if isinstance(file, bytes):
             return file
         elif hasattr(file, "close"):
@@ -51,12 +52,14 @@ class MlirOptCli:
         else:
             raise TypeError("file must be bytes or a file object")
 
-    def apply_passes(self, file, passes: List[str]) -> Union[str, "DebugResult"]:
+    def apply_passes(
+        self, file: Union[bytes, str, io.IOBase], passes: List[str]
+    ) -> Union[str, "DebugResult"]:
         """
         Converts a file of MLIR by applying passes sequentially.
         Returns a string of the result.
 
-        :param file: file-like object -or- path to file on disk -or- bytes of file content
+        :param file: file-like object -or- path to file on disk (as string) -or- bytes of file content
         :param passes: list of mlir-opt pass options
         :return: str (if successful)
                  list of str containing transformations and eventual error (if failure)

--- a/mlir_graphblas/engine.py
+++ b/mlir_graphblas/engine.py
@@ -689,11 +689,13 @@ class MlirJitEngine:
         """Translates MLIR code -> LLVM dialect of MLIR -> actual LLVM IR."""
 
         if profile:
-            prof_filename=os.path.join(self.profile_dir_name, f'prof-{uuid.uuid4()}.mlir')
-            with open(prof_filename, 'wb') as f:
+            prof_filename = os.path.join(
+                self.profile_dir_name, f"prof-{uuid.uuid4()}.mlir"
+            )
+            with open(prof_filename, "wb") as f:
                 f.write(mlir_text)
             mlir_text = prof_filename
-        
+
         if debug:
             try:
                 llvm_dialect_text = self._cli.apply_passes(mlir_text, passes)

--- a/mlir_graphblas/engine.py
+++ b/mlir_graphblas/engine.py
@@ -594,7 +594,7 @@ class MlirJitEngine:
                 stderr=subprocess.PIPE,
             )
             record_command = f"""
-            perf record -p {execution_process_id} --output={perf_data_file_name}
+            perf record -g -p {execution_process_id} --output={perf_data_file_name}
             exit
             """
             record_process.stdin.write(record_command.encode())
@@ -669,7 +669,7 @@ class MlirJitEngine:
                 files_to_link.append(profile._name)
             so_file_name = f"shared-{uuid.uuid4()}.so"
             so_file_name = os.path.join(self.profile_dir_name, so_file_name)
-            self.c_compiler.link_shared_object(files_to_link, so_file_name)
+            self.c_compiler.link_shared_object(files_to_link, so_file_name, debug=True)
             ctypes.cdll.LoadLibrary(so_file_name)
             shared_lib = ctypes.CDLL(so_file_name)
             self._engine.set_object_cache(notify_func=None)
@@ -687,6 +687,13 @@ class MlirJitEngine:
         profile: Union[bool, ctypes.CDLL] = False,
     ) -> Optional[Union[DebugResult, ctypes.CDLL]]:
         """Translates MLIR code -> LLVM dialect of MLIR -> actual LLVM IR."""
+
+        if profile:
+            prof_filename=os.path.join(self.profile_dir_name, f'prof-{uuid.uuid4()}.mlir')
+            with open(prof_filename, 'wb') as f:
+                f.write(mlir_text)
+            mlir_text = prof_filename
+        
         if debug:
             try:
                 llvm_dialect_text = self._cli.apply_passes(mlir_text, passes)


### PR DESCRIPTION
This PR finishes out #98 by adding a few extra flags and also saving the input MLIR to disk when profiling.  Putting the MLIR into a file on the filesystem enables tools (like perf) to find source code lines uses the DWARF line information in the .so file.  There is technically an extension to DWARFv5 that allows source text to be embedded in DWARF directly, but that may or may not be supported by debugging tools.  Saving the MLIR to disk long enough to run profiling is a simpler solution.

Here is a test script:
``` python
from mlir_graphblas import MlirJitEngine

STANDARD_PASSES = [
    "--mlir-print-debuginfo",
    "--sparsification",
    "--sparse-tensor-conversion",
    "--linalg-bufferize",
    "--func-bufferize",
    "--tensor-bufferize",
    "--tensor-constant-bufferize",
    "--finalizing-bufferize",
    "--convert-linalg-to-loops",
    "--convert-scf-to-std",
    "--convert-std-to-llvm",
]

engine = MlirJitEngine()

mlir_text = """
func @single_value_slow_mul(%input_val: i64) -> i64 {
  %ci0 = constant 0 : i64
  %c0 = constant 0 : index
  %c1 = constant 1 : index
  %num_iterations = constant 12345678901 : index
  %answer = scf.for %i = %c0 to %num_iterations step %c1 iter_args(%current_sum=%ci0) -> (i64) {
    %new_sum = addi %current_sum, %input_val : i64
    scf.yield %new_sum : i64
  }
  return %answer : i64
}
"""

engine.add(mlir_text, STANDARD_PASSES, profile=True, profile_result_directory='prof')

compiled_func = getattr(engine, "single_value_slow_mul")
input_val = 10
result = compiled_func(input_val)
print(f"result {repr(result)}")
```

Note that `--mlir-print-debuginfo` in the pass list (it is not technically a pass, but this was the most direct way to pass extra options to `graphblas-opt`) is needed to capture the initial location information from the input MLIR file.  Once recorded, the location information will be carried through all of the MLIR passes and then translated into DWARF metadata when the IR is converted to LLVM IR.

The output from the above script is:
```
Profile Results:
    [kernel.kallsyms] with build id cf1794eeb3b0240b85534152fe5d736c4af8e741 not found, continuing without symbols

    Sorted summary for file /home/sseibert/repo/mlir-graphblas/mlir_graphblas/src/build/prof/shared-18e0d84f-a562-4254-8a14-f9f551b60341.so
    ----------------------------------------------

       99.96 prof-771b8df2-0f78-4934-bac4-fc229b16f135.mlir:7
     Percent |	Source code & Disassembly of shared-18e0d84f-a562-4254-8a14-f9f551b60341.so for cycles:ppp (18687 samples)
    --------------------------------------------------------------------------------------------------------------------------
             :
             :
             :
             :	Disassembly of section .text:
             :
             :	0000000000000590 <single_value_slow_mul>:
             :	single_value_slow_mul():
             :
             :	func @single_value_slow_mul(%input_val: i64) -> i64 {
        0.00 :	  590:   xor    %ecx,%ecx
        0.00 :	  592:   movabs $0x2dfdc1c34,%rdx
        0.00 :	  59c:   xor    %eax,%eax
             :	  %ci0 = constant 0 : i64
             :	  %c0 = constant 0 : index
             :	  %c1 = constant 1 : index
             :	  %num_iterations = constant 12345678901 : index
             :	  %answer = scf.for %i = %c0 to %num_iterations step %c1 iter_args(%current_sum=%ci0) -> (i64) {
        0.00 :	  59e:   cmp    %rdx,%rcx
        0.00 :	  5a1:   jg     5bb <single_value_slow_mul+0x2b>
        0.00 :	  5a3:   nop
        0.00 :	  5a4:   nop
        0.00 :	  5a5:   nop
        0.00 :	  5a6:   nop
        0.00 :	  5a7:   nop
        0.00 :	  5a8:   nop
        0.00 :	  5a9:   nop
        0.00 :	  5aa:   nop
        0.00 :	  5ab:   nop
        0.00 :	  5ac:   nop
        0.00 :	  5ad:   nop
        0.00 :	  5ae:   nop
        0.00 :	  5af:   nop
             :	    %new_sum = addi %current_sum, %input_val : i64
        0.03 :	  5b0:   add    %rdi,%rax
             :	  %answer = scf.for %i = %c0 to %num_iterations step %c1 iter_args(%current_sum=%ci0) -> (i64) {
        0.01 :	  5b3:   inc    %rcx
        0.00 :	  5b6:   cmp    %rdx,%rcx
     prof-771b8df2-0f78-4934-bac4-fc229b16f135.mlir:7   99.96 :	  5b9:   jle    5b0 <single_value_slow_mul+0x20>
             :	    scf.yield %new_sum : i64
             :	  }
             :	  return %answer : i64
        0.00 :	  5bb:   retq
result 123456789010
```
Not the most readable thing, but it does show that 99.96% of the runtime is spent jumping, presumably because integer addition and increment is so fast.


