### PR TITLE
clang-format all the source code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: LLVM
+AlwaysBreakTemplateDeclarations: Yes

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASArrayUtils.h
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASArrayUtils.h
@@ -1,42 +1,46 @@
 #ifndef GRAPHBLAS_GRAPHBLASARRAYUTILS_H
 #define GRAPHBLAS_GRAPHBLASARRAYUTILS_H
 
-#include <string>
-#include <set>
-#include "mlir/IR/BuiltinOps.h"
+#include "GraphBLAS/GraphBLASUtils.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "llvm/ADT/APInt.h"
+#include <set>
+#include <string>
 
 using namespace mlir;
 
 Value computeNumOverlaps(PatternRewriter &rewriter, Value nk,
-                         Value fixedIndices, Value fixedIndexStart, Value fixedIndexEnd,
-                         Value iterPointers, Value iterIndices,
-                         Value maskIndices, Value maskStart, Value maskEnd,
-                         Type valueType
-                         );
+                         Value fixedIndices, Value fixedIndexStart,
+                         Value fixedIndexEnd, Value iterPointers,
+                         Value iterIndices, Value maskIndices, Value maskStart,
+                         Value maskEnd, Type valueType);
 
 void computeInnerProduct(PatternRewriter &rewriter, Value nk,
-                         Value fixedIndices, Value fixedValues, Value fixedIndexStart, Value fixedIndexEnd,
-                         Value iterPointers, Value iterIndices, Value iterValues,
-                         Value maskIndices, Value maskStart, Value maskEnd,
-                         Type valueType, ExtensionBlocks extBlocks,
-                         Value outputIndices, Value outputValues, Value indexOffset
-                         );
+                         Value fixedIndices, Value fixedValues,
+                         Value fixedIndexStart, Value fixedIndexEnd,
+                         Value iterPointers, Value iterIndices,
+                         Value iterValues, Value maskIndices, Value maskStart,
+                         Value maskEnd, Type valueType,
+                         ExtensionBlocks extBlocks, Value outputIndices,
+                         Value outputValues, Value indexOffset);
 
 Value computeIndexOverlapSize(PatternRewriter &rewriter, bool intersect,
                               Value aPosStart, Value aPosEnd, Value Ai,
                               Value bPosStart, Value bPosEnd, Value Bi);
 
-Value computeUnionAggregation(PatternRewriter &rewriter, bool intersect, std::string agg, Type valueType,
-                              Value aPosStart, Value aPosEnd, Value Ai, Value Ax,
-                              Value bPosStart, Value bPosEnd, Value Bi, Value Bx,
-                              Value oPosStart, Value Oi, Value Ox);
+Value computeUnionAggregation(PatternRewriter &rewriter, bool intersect,
+                              std::string agg, Type valueType, Value aPosStart,
+                              Value aPosEnd, Value Ai, Value Ax,
+                              Value bPosStart, Value bPosEnd, Value Bi,
+                              Value Bx, Value oPosStart, Value Oi, Value Ox);
 
 void computeVectorElementWise(PatternRewriter &rewriter, ModuleOp module,
-                              Value lhs, Value rhs, Value output, std::string op, bool intersect);
+                              Value lhs, Value rhs, Value output,
+                              std::string op, bool intersect);
 void computeMatrixElementWise(PatternRewriter &rewriter, ModuleOp module,
-                              Value lhs, Value rhs, Value output, std::string op, bool intersect);
+                              Value lhs, Value rhs, Value output,
+                              std::string op, bool intersect);
 
 #endif // GRAPHBLAS_GRAPHBLASARRAYUTILS_H

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.h
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.h
@@ -7,11 +7,11 @@
 #ifndef GRAPHBLAS_GRAPHBLASOPS_H
 #define GRAPHBLAS_GRAPHBLASOPS_H
 
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
-#include "mlir/Dialect/StandardOps/IR/Ops.h"
 
 #include "GraphBLAS/GraphBLASOpsEnums.h.inc"
 

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASPasses.h
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASPasses.h
@@ -1,5 +1,6 @@
 
-//===- GraphBLASPasses.h - GraphBLAS dialect passes -----------------*- C++ -*-===//
+//===- GraphBLASPasses.h - GraphBLAS dialect passes -----------------*- C++
+//-*-===//
 //
 // TODO add documentation
 //
@@ -14,15 +15,7 @@ namespace mlir {
 std::unique_ptr<OperationPass<ModuleOp>> createGraphBLASLoweringPass();
 std::unique_ptr<OperationPass<ModuleOp>> createGraphBLASOptimizePass();
 std::unique_ptr<OperationPass<ModuleOp>> createGraphBLASStructuralizePass();
-}
-
-//===----------------------------------------------------------------------===//
-// Ops declaration.
-//===----------------------------------------------------------------------===//
-#include "GraphBLAS/GraphBLASOpsEnums.h.inc"
-
-#define GET_OP_CLASSES
-#include "GraphBLAS/GraphBLASOps.h.inc"
+} // namespace mlir
 
 //===----------------------------------------------------------------------===//
 // Registration.

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
@@ -1,21 +1,25 @@
 #ifndef GRAPHBLAS_GRAPHBLASUTILS_H
 #define GRAPHBLAS_GRAPHBLASUTILS_H
 
-#include <string>
-#include <set>
-#include "mlir/IR/BuiltinOps.h"
+#include "GraphBLAS/GraphBLASOps.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/StringSet.h"
+#include <set>
+#include <string>
 
-static const llvm::StringSet<> supportedIntersectOperators{"plus", "min", "times"};
+static const llvm::StringSet<> supportedIntersectOperators{"plus", "min",
+                                                           "times"};
 
 static const llvm::StringSet<> supportedUnionOperators{"plus", "min", "times"};
 
-static const llvm::StringSet<> supportedUpdateAccumulateOperators{"plus", "min"};
+static const llvm::StringSet<> supportedUpdateAccumulateOperators{"plus",
+                                                                  "min"};
 
-static const llvm::StringSet<> supportedSemirings{"plus_times", "plus_pair", "plus_plus", "min_plus"};
+static const llvm::StringSet<> supportedSemirings{"plus_times", "plus_pair",
+                                                  "plus_plus", "min_plus"};
 
 static const llvm::StringSet<> supportedReduceAggregators{"plus"};
 
@@ -26,53 +30,74 @@ static const llvm::StringSet<> supportedApplyOperators{"min"};
 
 bool typeIsCSR(mlir::Type inputType);
 bool typeIsCSC(mlir::Type inputType);
-mlir::RankedTensorType getCompressedVectorType(mlir::MLIRContext *context, mlir::ArrayRef<int64_t> shape, mlir::Type valueType);
-mlir::RankedTensorType getCSRTensorType(mlir::MLIRContext *context, llvm::ArrayRef<int64_t> shape, mlir::Type valueType);
-mlir::RankedTensorType getCSCTensorType(mlir::MLIRContext *context, llvm::ArrayRef<int64_t> shape, mlir::Type valueType);
+mlir::RankedTensorType getCompressedVectorType(mlir::MLIRContext *context,
+                                               mlir::ArrayRef<int64_t> shape,
+                                               mlir::Type valueType);
+mlir::RankedTensorType getCSRTensorType(mlir::MLIRContext *context,
+                                        llvm::ArrayRef<int64_t> shape,
+                                        mlir::Type valueType);
+mlir::RankedTensorType getCSCTensorType(mlir::MLIRContext *context,
+                                        llvm::ArrayRef<int64_t> shape,
+                                        mlir::Type valueType);
 
 int64_t getRank(mlir::Type inputType);
 int64_t getRank(mlir::Value inputValue);
 
-mlir::Value convertToExternalCSR(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc, mlir::Value input);
-mlir::Value convertToExternalCSC(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc, mlir::Value input);
-mlir::Value callEmpty(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc, mlir::Value inputTensor, llvm::ArrayRef<int64_t> resultShape);
-mlir::Value callEmptyLike(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc, mlir::Value tensor);
-mlir::Value callDupTensor(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc, mlir::Value tensor);
-void callDelSparseTensor(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc, mlir::Value tensor);
+mlir::Value convertToExternalCSR(mlir::OpBuilder &builder, mlir::ModuleOp &mod,
+                                 mlir::Location loc, mlir::Value input);
+mlir::Value convertToExternalCSC(mlir::OpBuilder &builder, mlir::ModuleOp &mod,
+                                 mlir::Location loc, mlir::Value input);
+mlir::Value callEmpty(mlir::OpBuilder &builder, mlir::ModuleOp &mod,
+                      mlir::Location loc, mlir::Value inputTensor,
+                      llvm::ArrayRef<int64_t> resultShape);
+mlir::Value callEmptyLike(mlir::OpBuilder &builder, mlir::ModuleOp &mod,
+                          mlir::Location loc, mlir::Value tensor);
+mlir::Value callDupTensor(mlir::OpBuilder &builder, mlir::ModuleOp &mod,
+                          mlir::Location loc, mlir::Value tensor);
+void callDelSparseTensor(mlir::OpBuilder &builder, mlir::ModuleOp &mod,
+                         mlir::Location loc, mlir::Value tensor);
 
-mlir::CallOp callResizeDim(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc,
-                           mlir::Value tensor, mlir::Value d, mlir::Value size);
-mlir::CallOp callResizePointers(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc,
-                                mlir::Value tensor, mlir::Value d, mlir::Value size);
-mlir::CallOp callResizeIndex(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc,
-                             mlir::Value tensor, mlir::Value d, mlir::Value size);
-mlir::CallOp callResizeValues(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc,
-                              mlir::Value tensor, mlir::Value size);
+mlir::CallOp callResizeDim(mlir::OpBuilder &builder, mlir::ModuleOp &mod,
+                           mlir::Location loc, mlir::Value tensor,
+                           mlir::Value d, mlir::Value size);
+mlir::CallOp callResizePointers(mlir::OpBuilder &builder, mlir::ModuleOp &mod,
+                                mlir::Location loc, mlir::Value tensor,
+                                mlir::Value d, mlir::Value size);
+mlir::CallOp callResizeIndex(mlir::OpBuilder &builder, mlir::ModuleOp &mod,
+                             mlir::Location loc, mlir::Value tensor,
+                             mlir::Value d, mlir::Value size);
+mlir::CallOp callResizeValues(mlir::OpBuilder &builder, mlir::ModuleOp &mod,
+                              mlir::Location loc, mlir::Value tensor,
+                              mlir::Value size);
 
-void cleanupIntermediateTensor(mlir::OpBuilder &builder, mlir::ModuleOp &mod, mlir::Location loc, mlir::Value tensor);
+void cleanupIntermediateTensor(mlir::OpBuilder &builder, mlir::ModuleOp &mod,
+                               mlir::Location loc, mlir::Value tensor);
 
 struct ExtensionBlocks {
-    mlir::Block *transformInA = nullptr;
-    mlir::Block *transformInB = nullptr;
-    mlir::Block *transformOut = nullptr;
-    mlir::Block *selectInA = nullptr;
-    mlir::Block *selectInB = nullptr;
-    mlir::Block *selectOut = nullptr;
-    mlir::Block *addIdentity = nullptr;
-    mlir::Block *add = nullptr;
-    mlir::Block *multIdentity = nullptr;
-    mlir::Block *mult = nullptr;
-    mlir::Block *aggIdentity = nullptr;
-    mlir::Block *agg = nullptr;
+  mlir::Block *transformInA = nullptr;
+  mlir::Block *transformInB = nullptr;
+  mlir::Block *transformOut = nullptr;
+  mlir::Block *selectInA = nullptr;
+  mlir::Block *selectInB = nullptr;
+  mlir::Block *selectOut = nullptr;
+  mlir::Block *addIdentity = nullptr;
+  mlir::Block *add = nullptr;
+  mlir::Block *multIdentity = nullptr;
+  mlir::Block *mult = nullptr;
+  mlir::Block *aggIdentity = nullptr;
+  mlir::Block *agg = nullptr;
 
-    ExtensionBlocks() { };
-    mlir::LogicalResult extractBlocks(mlir::Operation *op, mlir::RegionRange &regions,
-                                      const std::set<mlir::graphblas::YieldKind> &required,
-                                      const std::set<mlir::graphblas::YieldKind> &optional);
+  ExtensionBlocks(){};
+  mlir::LogicalResult
+  extractBlocks(mlir::Operation *op, mlir::RegionRange &regions,
+                const std::set<mlir::graphblas::YieldKind> &required,
+                const std::set<mlir::graphblas::YieldKind> &optional);
 };
 
-mlir::LogicalResult populateSemiringRegions(mlir::OpBuilder &builder, mlir::Location loc,
-                                            mlir::StringRef semiring, mlir::Type valueType,
+mlir::LogicalResult populateSemiringRegions(mlir::OpBuilder &builder,
+                                            mlir::Location loc,
+                                            mlir::StringRef semiring,
+                                            mlir::Type valueType,
                                             mlir::RegionRange regions);
 
 #endif // GRAPHBLAS_GRAPHBLASUTILS_H

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASLowerPass.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASLowerPass.cpp
@@ -6,17 +6,17 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
+#include "mlir/IR/Region.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include "mlir/IR/Region.h"
-#include "llvm/Support/raw_ostream.h"
-#include "llvm/ADT/TypeSwitch.h"
-#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/None.h"
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/raw_ostream.h"
 
+#include "GraphBLAS/GraphBLASArrayUtils.h"
 #include "GraphBLAS/GraphBLASPasses.h"
 #include "GraphBLAS/GraphBLASUtils.h"
-#include "GraphBLAS/GraphBLASArrayUtils.h"
 
 using namespace ::mlir;
 
@@ -36,7 +36,8 @@ namespace {
 class LowerSizeRewrite : public OpRewritePattern<graphblas::SizeOp> {
 public:
   using OpRewritePattern<graphblas::SizeOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::SizeOp op, PatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(graphblas::SizeOp op,
+                                PatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
 
     Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
@@ -51,7 +52,8 @@ public:
 class LowerNumRowsRewrite : public OpRewritePattern<graphblas::NumRowsOp> {
 public:
   using OpRewritePattern<graphblas::NumRowsOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::NumRowsOp op, PatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(graphblas::NumRowsOp op,
+                                PatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
 
     Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
@@ -66,7 +68,8 @@ public:
 class LowerNumColsRewrite : public OpRewritePattern<graphblas::NumColsOp> {
 public:
   using OpRewritePattern<graphblas::NumColsOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::NumColsOp op, PatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(graphblas::NumColsOp op,
+                                PatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
 
     Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
@@ -81,12 +84,14 @@ public:
 class LowerNumValsRewrite : public OpRewritePattern<graphblas::NumValsOp> {
 public:
   using OpRewritePattern<graphblas::NumValsOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::NumValsOp op, PatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(graphblas::NumValsOp op,
+                                PatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
     Value inputTensor = op.input();
     Type inputType = inputTensor.getType();
 
-    sparse_tensor::SparseTensorEncodingAttr sparseEncoding = sparse_tensor::getSparseTensorEncoding(inputType);
+    sparse_tensor::SparseTensorEncodingAttr sparseEncoding =
+        sparse_tensor::getSparseTensorEncoding(inputType);
     unsigned pointerBitWidth = sparseEncoding.getPointerBitWidth();
     Type pointerType = rewriter.getIntegerType(pointerBitWidth);
     Type indexType = rewriter.getIndexType();
@@ -95,20 +100,22 @@ public:
     Type memref1DPointerType = MemRefType::get({-1}, pointerType);
     unsigned rank = inputType.dyn_cast<RankedTensorType>().getRank();
     Value c_rank_minus_1 = rewriter.create<ConstantIndexOp>(loc, rank - 1);
-    Value ptrs = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DPointerType, inputTensor, c_rank_minus_1);
+    Value ptrs = rewriter.create<sparse_tensor::ToPointersOp>(
+        loc, memref1DPointerType, inputTensor, c_rank_minus_1);
 
     // Find length of pointer array
     Value npointers;
     if (rank == 1) {
-        npointers = rewriter.create<ConstantIndexOp>(loc, 1);
+      npointers = rewriter.create<ConstantIndexOp>(loc, 1);
     } else {
-        Value dimForPointers;
-        if (rank == 1 || typeIsCSR(inputType)) {
-          dimForPointers = rewriter.create<ConstantIndexOp>(loc, 0);
-        } else {
-          dimForPointers = rewriter.create<ConstantIndexOp>(loc, 1);
-        }
-        npointers = rewriter.create<tensor::DimOp>(loc, inputTensor, dimForPointers);
+      Value dimForPointers;
+      if (rank == 1 || typeIsCSR(inputType)) {
+        dimForPointers = rewriter.create<ConstantIndexOp>(loc, 0);
+      } else {
+        dimForPointers = rewriter.create<ConstantIndexOp>(loc, 1);
+      }
+      npointers =
+          rewriter.create<tensor::DimOp>(loc, inputTensor, dimForPointers);
     }
 
     // The last value from the pointers is the number of nonzero values
@@ -123,7 +130,8 @@ public:
 class LowerDupRewrite : public OpRewritePattern<graphblas::DupOp> {
 public:
   using OpRewritePattern<graphblas::DupOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::DupOp op, PatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(graphblas::DupOp op,
+                                PatternRewriter &rewriter) const override {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
     Value inputTensor = op.input();
@@ -144,10 +152,12 @@ public:
   };
 };
 
-class LowerConvertLayoutRewrite : public OpRewritePattern<graphblas::ConvertLayoutOp> {
+class LowerConvertLayoutRewrite
+    : public OpRewritePattern<graphblas::ConvertLayoutOp> {
 public:
   using OpRewritePattern<graphblas::ConvertLayoutOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::ConvertLayoutOp op, PatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(graphblas::ConvertLayoutOp op,
+                                PatternRewriter &rewriter) const override {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
 
@@ -156,8 +166,7 @@ public:
     Type outputType = op->getResultTypes()[0];
 
     // Shortcut operation if no change
-    if (inputType == outputType)
-    {
+    if (inputType == outputType) {
       rewriter.replaceOp(op, inputTensor);
       return success();
     }
@@ -177,9 +186,12 @@ public:
     Type memref1DI64Type = MemRefType::get({-1}, int64Type);
     Type memref1DValueType = MemRefType::get({-1}, valueType);
 
-    Value inputPtrs = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, inputTensor, c1);
-    Value inputIndices = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, inputTensor, c1);
-    Value inputValues = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, inputTensor);
+    Value inputPtrs = rewriter.create<sparse_tensor::ToPointersOp>(
+        loc, memref1DI64Type, inputTensor, c1);
+    Value inputIndices = rewriter.create<sparse_tensor::ToIndicesOp>(
+        loc, memref1DI64Type, inputTensor, c1);
+    Value inputValues = rewriter.create<sparse_tensor::ToValuesOp>(
+        loc, memref1DValueType, inputTensor);
     Value nrow = rewriter.create<graphblas::NumRowsOp>(loc, inputTensor);
     Value ncol = rewriter.create<graphblas::NumColsOp>(loc, inputTensor);
     Value ncols_plus_one = rewriter.create<mlir::AddIOp>(loc, ncol, c1);
@@ -203,9 +215,12 @@ public:
       assert(false && "Output type must be CSC or CSR.");
     }
 
-    Value outputPtrs = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, output, c1);
-    Value outputIndices = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, output, c1);
-    Value outputValues = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, output);
+    Value outputPtrs = rewriter.create<sparse_tensor::ToPointersOp>(
+        loc, memref1DI64Type, output, c1);
+    Value outputIndices = rewriter.create<sparse_tensor::ToIndicesOp>(
+        loc, memref1DI64Type, output, c1);
+    Value outputValues = rewriter.create<sparse_tensor::ToValuesOp>(
+        loc, memref1DValueType, output);
 
     // compute number of non-zero entries per column of A
 
@@ -221,7 +236,8 @@ public:
     Value ptrLoopIdx = ptrLoop.getInductionVar();
 
     rewriter.setInsertionPointToStart(ptrLoop.getBody());
-    Value colA64 = rewriter.create<memref::LoadOp>(loc, inputIndices, ptrLoopIdx);
+    Value colA64 =
+        rewriter.create<memref::LoadOp>(loc, inputIndices, ptrLoopIdx);
     Value colA = rewriter.create<mlir::IndexCastOp>(loc, colA64, indexType);
     Value colB = rewriter.create<memref::LoadOp>(loc, outputPtrs, colA);
     Value colB1 = rewriter.create<mlir::AddIOp>(loc, colB, c1_64);
@@ -236,7 +252,8 @@ public:
     Value colAccLoopIdx = colAccLoop.getInductionVar();
 
     rewriter.setInsertionPointToStart(colAccLoop.getBody());
-    Value temp = rewriter.create<memref::LoadOp>(loc, outputPtrs, colAccLoopIdx);
+    Value temp =
+        rewriter.create<memref::LoadOp>(loc, outputPtrs, colAccLoopIdx);
     Value cumsum = rewriter.create<memref::LoadOp>(loc, outputPtrs, ncol);
     rewriter.create<memref::StoreOp>(loc, cumsum, outputPtrs, colAccLoopIdx);
     Value cumsum2 = rewriter.create<mlir::AddIOp>(loc, cumsum, temp);
@@ -251,7 +268,8 @@ public:
     rewriter.setInsertionPointToStart(outerLoop.getBody());
     Value row_64 = rewriter.create<mlir::IndexCastOp>(loc, rowIdx, int64Type);
     Value j_start_64 = rewriter.create<memref::LoadOp>(loc, inputPtrs, rowIdx);
-    Value j_start = rewriter.create<mlir::IndexCastOp>(loc, j_start_64, indexType);
+    Value j_start =
+        rewriter.create<mlir::IndexCastOp>(loc, j_start_64, indexType);
     Value row_plus1 = rewriter.create<mlir::AddIOp>(loc, rowIdx, c1);
     Value j_end_64 = rewriter.create<memref::LoadOp>(loc, inputPtrs, row_plus1);
     Value j_end = rewriter.create<mlir::IndexCastOp>(loc, j_end_64, indexType);
@@ -310,26 +328,32 @@ public:
     Location loc = op->getLoc();
 
     Value inputTensor = op.input();
-    RankedTensorType inputType = inputTensor.getType().dyn_cast<RankedTensorType>();
-    RankedTensorType outputType = op->getResultTypes()[0].dyn_cast<RankedTensorType>();
+    RankedTensorType inputType =
+        inputTensor.getType().dyn_cast<RankedTensorType>();
+    RankedTensorType outputType =
+        op->getResultTypes()[0].dyn_cast<RankedTensorType>();
 
     bool inputTypeIsCSR = typeIsCSR(inputType);
     bool outputTypeIsCSR = typeIsCSR(outputType);
 
-    // Add a graphblas.convert_layout op if the input and output compression types are the same
+    // Add a graphblas.convert_layout op if the input and output compression
+    // types are the same
     if (inputTypeIsCSR == outputTypeIsCSR) {
       // TODO consider separating this out into its own rewrite pattern
-      MLIRContext* context = op.getContext();
+      MLIRContext *context = op.getContext();
       Type inputTensorValueType = inputType.getElementType();
       llvm::ArrayRef<int64_t> inputShape = inputType.getShape();
-      RankedTensorType newType = inputTypeIsCSR ?
-        getCSCTensorType(context, inputShape, inputTensorValueType) :
-        getCSRTensorType(context, inputShape, inputTensorValueType);
+      RankedTensorType newType =
+          inputTypeIsCSR
+              ? getCSCTensorType(context, inputShape, inputTensorValueType)
+              : getCSRTensorType(context, inputShape, inputTensorValueType);
       graphblas::ConvertLayoutOp newConvertLayoutOp =
-        rewriter.create<graphblas::ConvertLayoutOp>(loc, newType, inputTensor);
+          rewriter.create<graphblas::ConvertLayoutOp>(loc, newType,
+                                                      inputTensor);
       Value newLayOutInputTensor = newConvertLayoutOp.getResult();
       graphblas::TransposeOp newTransposeOp =
-        rewriter.create<graphblas::TransposeOp>(loc, outputType, newLayOutInputTensor);
+          rewriter.create<graphblas::TransposeOp>(loc, outputType,
+                                                  newLayOutInputTensor);
 
       rewriter.replaceOp(op, newTransposeOp.getResult());
 
@@ -349,8 +373,10 @@ public:
     Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
     Value nrow = rewriter.create<graphblas::NumRowsOp>(loc, inputTensor);
     Value ncol = rewriter.create<graphblas::NumColsOp>(loc, inputTensor);
-    Value cond = rewriter.create<CmpIOp>(op.getLoc(), CmpIPredicate::ne, nrow, ncol);
-    scf::IfOp ifOp = rewriter.create<scf::IfOp>(loc, cond, /*withElseRegion=*/ false);
+    Value cond =
+        rewriter.create<CmpIOp>(op.getLoc(), CmpIPredicate::ne, nrow, ncol);
+    scf::IfOp ifOp =
+        rewriter.create<scf::IfOp>(loc, cond, /*withElseRegion=*/false);
     rewriter.setInsertionPointToStart(&ifOp.thenRegion().front());
     callResizeDim(rewriter, module, loc, output, c0, ncol);
     callResizeDim(rewriter, module, loc, output, c1, nrow);
@@ -367,10 +393,7 @@ public:
 
 struct MatrixSelectOutputWriter {
   MatrixSelectOutputWriter(StringRef _selector, llvm::Optional<Value> _thunk)
-    : selector(_selector)
-    , thunk(_thunk)
-  {
-  };
+      : selector(_selector), thunk(_thunk){};
 
   void createConstants(PatternRewriter &rewriter, Location loc) {
     Type int64Type = rewriter.getIntegerType(64);
@@ -384,8 +407,8 @@ struct MatrixSelectOutputWriter {
     cf0 = rewriter.create<ConstantFloatOp>(loc, APFloat(0.0), float64Type);
   }
 
-  void createTensor(PatternRewriter &rewriter, Location loc, ModuleOp module, Value input)
-  {
+  void createTensor(PatternRewriter &rewriter, Location loc, ModuleOp module,
+                    Value input) {
     Type valueType = input.getType().dyn_cast<TensorType>().getElementType();
     Type int64Type = rewriter.getIntegerType(64);
 
@@ -393,49 +416,48 @@ struct MatrixSelectOutputWriter {
     Type memref1DValueType = MemRefType::get({-1}, valueType);
 
     tensor = rewriter.create<graphblas::DupOp>(loc, input);
-    Bp = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, tensor, c1);
-    Bj = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, tensor, c1);
-    Bx = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, tensor);
+    Bp = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type,
+                                                      tensor, c1);
+    Bj = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type,
+                                                     tensor, c1);
+    Bx = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType,
+                                                    tensor);
     rewriter.create<memref::StoreOp>(loc, c0_64, Bp, c0);
   };
 
-  void createUpdateCurrCount(PatternRewriter &rewriter, Location loc, Value row, Value row_plus1)
-  {
+  void createUpdateCurrCount(PatternRewriter &rewriter, Location loc, Value row,
+                             Value row_plus1) {
     Value bp_curr_count = rewriter.create<memref::LoadOp>(loc, Bp, row);
     rewriter.create<memref::StoreOp>(loc, bp_curr_count, Bp, row_plus1);
   };
 
-  void createTestAndStore(PatternRewriter &rewriter, Location loc,
-             Value row,
-             Value col, Value val, Value row_plus1, Value col_64)
-  {
+  void createTestAndStore(PatternRewriter &rewriter, Location loc, Value row,
+                          Value col, Value val, Value row_plus1, Value col_64) {
     Type indexType = rewriter.getIndexType();
 
     Value keep;
-    if (selector == "triu")
-    {
-      keep = rewriter.create<mlir::CmpIOp>(loc, mlir::CmpIPredicate::ugt, col, row);
-    }
-    else if (selector == "tril")
-    {
-      keep = rewriter.create<mlir::CmpIOp>(loc, mlir::CmpIPredicate::ult, col, row);
-    }
-    else if (selector == "gt")
-    {
-      keep = rewriter.create<mlir::CmpFOp>(loc, mlir::CmpFPredicate::OGT, val, thunk.getValue());
-    }
-    else
-    {
+    if (selector == "triu") {
+      keep = rewriter.create<mlir::CmpIOp>(loc, mlir::CmpIPredicate::ugt, col,
+                                           row);
+    } else if (selector == "tril") {
+      keep = rewriter.create<mlir::CmpIOp>(loc, mlir::CmpIPredicate::ult, col,
+                                           row);
+    } else if (selector == "gt") {
+      keep = rewriter.create<mlir::CmpFOp>(loc, mlir::CmpFPredicate::OGT, val,
+                                           thunk.getValue());
+    } else {
       // this should be impossible becasue of validation
       assert(0);
     }
 
-    scf::IfOp ifKeep = rewriter.create<scf::IfOp>(loc, keep, false /* no else region */);
+    scf::IfOp ifKeep =
+        rewriter.create<scf::IfOp>(loc, keep, false /* no else region */);
 
     rewriter.setInsertionPointToStart(ifKeep.thenBlock());
 
     Value bj_pos_64 = rewriter.create<memref::LoadOp>(loc, Bp, row_plus1);
-    Value bj_pos = rewriter.create<mlir::IndexCastOp>(loc, bj_pos_64, indexType);
+    Value bj_pos =
+        rewriter.create<mlir::IndexCastOp>(loc, bj_pos_64, indexType);
 
     rewriter.create<memref::StoreOp>(loc, col_64, Bj, bj_pos);
     rewriter.create<memref::StoreOp>(loc, val, Bx, bj_pos);
@@ -446,15 +468,16 @@ struct MatrixSelectOutputWriter {
     rewriter.setInsertionPointAfter(ifKeep);
   };
 
-  void createTrimValues(PatternRewriter &rewriter, Location loc, ModuleOp module)
-  {
+  void createTrimValues(PatternRewriter &rewriter, Location loc,
+                        ModuleOp module) {
     Value nnz = rewriter.create<graphblas::NumValsOp>(loc, tensor);
 
     callResizeIndex(rewriter, module, loc, tensor, c1, nnz);
     callResizeValues(rewriter, module, loc, tensor, nnz);
 
     assert(typeIsCSR(tensor.getType()) &&
-           "tensor expected to be CSR since createTensor is expected to have been called first.");
+           "tensor expected to be CSR since createTensor is expected to have "
+           "been called first.");
   };
 
   StringRef selector;
@@ -474,10 +497,12 @@ struct MatrixSelectOutputWriter {
   Value c1_64;
 };
 
-class LowerMatrixSelectRewrite : public OpRewritePattern<graphblas::MatrixSelectOp> {
+class LowerMatrixSelectRewrite
+    : public OpRewritePattern<graphblas::MatrixSelectOp> {
 public:
   using OpRewritePattern<graphblas::MatrixSelectOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::MatrixSelectOp op, PatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(graphblas::MatrixSelectOp op,
+                                PatternRewriter &rewriter) const override {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
 
@@ -497,15 +522,19 @@ public:
 
     // Get sparse tensor info
     Value nrow = rewriter.create<graphblas::NumRowsOp>(loc, input);
-    Value Ap = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, input, c1);
-    Value Aj = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, input, c1);
-    Value Ax = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, input);
+    Value Ap = rewriter.create<sparse_tensor::ToPointersOp>(
+        loc, memref1DI64Type, input, c1);
+    Value Aj = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type,
+                                                           input, c1);
+    Value Ax = rewriter.create<sparse_tensor::ToValuesOp>(
+        loc, memref1DValueType, input);
 
     int thunkIndex = 0;
-    
-    SmallVector<MatrixSelectOutputWriter*, 3> outputs;
+
+    SmallVector<MatrixSelectOutputWriter *, 3> outputs;
     for (Attribute selectorAttr : selectors) {
-      StringRef selector = selectorAttr.dyn_cast_or_null<StringAttr>().getValue();
+      StringRef selector =
+          selectorAttr.dyn_cast_or_null<StringAttr>().getValue();
 
       llvm::Optional<Value> thunk;
       if (supportedThunkNeedingSelectors.contains(selector)) {
@@ -513,8 +542,9 @@ public:
       } else {
         thunk = llvm::None;
       }
-      
-      MatrixSelectOutputWriter *output = new MatrixSelectOutputWriter(selector, thunk);
+
+      MatrixSelectOutputWriter *output =
+          new MatrixSelectOutputWriter(selector, thunk);
       outputs.push_back(output);
 
       output->createConstants(rewriter, loc);
@@ -528,14 +558,14 @@ public:
     rewriter.setInsertionPointToStart(outerLoop.getBody());
     Value row_plus1 = rewriter.create<mlir::AddIOp>(loc, row, c1);
 
-    for (MatrixSelectOutputWriter* output : outputs)
-    {
+    for (MatrixSelectOutputWriter *output : outputs) {
       output->createUpdateCurrCount(rewriter, loc, row, row_plus1);
     }
 
     Value j_start_64 = rewriter.create<memref::LoadOp>(loc, Ap, row);
     Value j_end_64 = rewriter.create<memref::LoadOp>(loc, Ap, row_plus1);
-    Value j_start = rewriter.create<mlir::IndexCastOp>(loc, j_start_64, indexType);
+    Value j_start =
+        rewriter.create<mlir::IndexCastOp>(loc, j_start_64, indexType);
     Value j_end = rewriter.create<mlir::IndexCastOp>(loc, j_end_64, indexType);
 
     scf::ForOp innerLoop = rewriter.create<scf::ForOp>(loc, j_start, j_end, c1);
@@ -547,16 +577,16 @@ public:
     Value col = rewriter.create<mlir::IndexCastOp>(loc, col_64, indexType);
     Value val = rewriter.create<memref::LoadOp>(loc, Ax, jj);
 
-    for (MatrixSelectOutputWriter* output : outputs)
-    {
-      output->createTestAndStore(rewriter, loc, row, col, val, row_plus1, col_64);
+    for (MatrixSelectOutputWriter *output : outputs) {
+      output->createTestAndStore(rewriter, loc, row, col, val, row_plus1,
+                                 col_64);
     }
 
     rewriter.setInsertionPointAfter(outerLoop);
 
     // trim excess values
     SmallVector<Value, 3> outputTensors;
-    for (MatrixSelectOutputWriter* output : outputs) {
+    for (MatrixSelectOutputWriter *output : outputs) {
       output->createTrimValues(rewriter, loc, module);
       outputTensors.push_back(output->tensor);
     }
@@ -570,69 +600,76 @@ public:
   };
 };
 
-class LowerMatrixReduceToVectorRewrite : public OpRewritePattern<graphblas::MatrixReduceToVectorOp>
-{
+class LowerMatrixReduceToVectorRewrite
+    : public OpRewritePattern<graphblas::MatrixReduceToVectorOp> {
 public:
   using OpRewritePattern<graphblas::MatrixReduceToVectorOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::MatrixReduceToVectorOp op, PatternRewriter &rewriter) const override
-  {
+  LogicalResult matchAndRewrite(graphblas::MatrixReduceToVectorOp op,
+                                PatternRewriter &rewriter) const override {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
-    
+
     Value matrix = op.input();
     StringRef aggregator = op.aggregator();
     int axis = op.axis();
-    
-    RankedTensorType matrixType = op.input().getType().dyn_cast<RankedTensorType>();
+
+    RankedTensorType matrixType =
+        op.input().getType().dyn_cast<RankedTensorType>();
     Type elementType = matrixType.getElementType();
     ArrayRef<int64_t> matrixShape = matrixType.getShape();
 
     bool matrixTypeIsCSR = typeIsCSR(matrixType);
     if ((axis == 0 && matrixTypeIsCSR) || (axis == 1 && !matrixTypeIsCSR)) {
       // TODO consider moving this out to its own rewrite pattern
-      
-      MLIRContext* context = op.getContext();
-      
-      RankedTensorType newMatrixType = matrixTypeIsCSR ?
-        getCSCTensorType(context, matrixShape, elementType) :
-        getCSRTensorType(context, matrixShape, elementType);
+
+      MLIRContext *context = op.getContext();
+
+      RankedTensorType newMatrixType =
+          matrixTypeIsCSR ? getCSCTensorType(context, matrixShape, elementType)
+                          : getCSRTensorType(context, matrixShape, elementType);
       graphblas::ConvertLayoutOp newConvertLayoutOp =
-        rewriter.create<graphblas::ConvertLayoutOp>(loc, newMatrixType, matrix);
+          rewriter.create<graphblas::ConvertLayoutOp>(loc, newMatrixType,
+                                                      matrix);
       Value newLayoutInputTensor = newConvertLayoutOp.getResult();
       Type originalVectorType = op->getResultTypes()[0];
       graphblas::MatrixReduceToVectorOp newReduceOp =
-        rewriter.create<graphblas::MatrixReduceToVectorOp>(loc, originalVectorType, newLayoutInputTensor, aggregator, axis);
-      
+          rewriter.create<graphblas::MatrixReduceToVectorOp>(
+              loc, originalVectorType, newLayoutInputTensor, aggregator, axis);
+
       rewriter.replaceOp(op, newReduceOp.getResult());
-      
+
       return success();
     }
 
     if (matrixShape[0] != -1 || matrixShape[1] != -1) {
       // TODO consider moving this out to its own rewrite pattern
 
-      // TODO this casting doesn't actually safely lower down to the LLVM dialect
-      // since it doesn't survive the --sparse-tensor-conversion pass
-      
-      MLIRContext* context = op.getContext();
-      
+      // TODO this casting doesn't actually safely lower down to the LLVM
+      // dialect since it doesn't survive the --sparse-tensor-conversion pass
+
+      MLIRContext *context = op.getContext();
+
       static const ArrayRef<int64_t> newMatrixShape = {-1, -1};
-      RankedTensorType newMatrixType = matrixTypeIsCSR ?
-        getCSRTensorType(context, newMatrixShape, elementType) :
-        getCSCTensorType(context, newMatrixShape, elementType);
-      
-      Value castMatrix = rewriter.create<tensor::CastOp>(loc, newMatrixType, matrix);
+      RankedTensorType newMatrixType =
+          matrixTypeIsCSR
+              ? getCSRTensorType(context, newMatrixShape, elementType)
+              : getCSCTensorType(context, newMatrixShape, elementType);
+
+      Value castMatrix =
+          rewriter.create<tensor::CastOp>(loc, newMatrixType, matrix);
 
       static const ArrayRef<int64_t> newVectorShape = {-1};
-      Type resultVectorType = getCompressedVectorType(context, newVectorShape, elementType);
-      Value resultVector =
-	rewriter.create<graphblas::MatrixReduceToVectorOp>(loc, resultVectorType, castMatrix, aggregator, axis);
-      
+      Type resultVectorType =
+          getCompressedVectorType(context, newVectorShape, elementType);
+      Value resultVector = rewriter.create<graphblas::MatrixReduceToVectorOp>(
+          loc, resultVectorType, castMatrix, aggregator, axis);
+
       Type originalVectorType = op->getResultTypes()[0];
-      Value castVector = rewriter.create<tensor::CastOp>(loc, originalVectorType, resultVector);
-      
+      Value castVector = rewriter.create<tensor::CastOp>(
+          loc, originalVectorType, resultVector);
+
       rewriter.replaceOp(op, castVector);
-      
+
       return success();
     }
 
@@ -641,115 +678,151 @@ public:
 
     Type memref1DValueType = MemRefType::get({-1}, elementType);
     MemRefType memref1DI64Type = MemRefType::get({-1}, int64Type);
-    
+
     sparse_tensor::SparseTensorEncodingAttr sparseEncoding =
-      sparse_tensor::getSparseTensorEncoding(matrixType);
+        sparse_tensor::getSparseTensorEncoding(matrixType);
     unsigned pointerBitWidth = sparseEncoding.getPointerBitWidth();
     Type pointerType = rewriter.getIntegerType(pointerBitWidth);
     Type memref1DPointerType = MemRefType::get({-1}, pointerType);
-    
+
     Value c0_elementType =
-      llvm::TypeSwitch<Type, Value>(elementType)
-      .Case<IntegerType>([&](IntegerType type)
-			 { return rewriter.create<ConstantOp>(loc, rewriter.getIntegerAttr(elementType, 0)); })
-      .Case<FloatType>([&](FloatType type)
-		       { return rewriter.create<ConstantOp>(loc, rewriter.getFloatAttr(elementType, 0.0)); });
+        llvm::TypeSwitch<Type, Value>(elementType)
+            .Case<IntegerType>([&](IntegerType type) {
+              return rewriter.create<ConstantOp>(
+                  loc, rewriter.getIntegerAttr(elementType, 0));
+            })
+            .Case<FloatType>([&](FloatType type) {
+              return rewriter.create<ConstantOp>(
+                  loc, rewriter.getFloatAttr(elementType, 0.0));
+            });
     Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
     Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
     Value c2 = rewriter.create<ConstantIndexOp>(loc, 2);
 
     Value nrows = rewriter.create<tensor::DimOp>(loc, matrix, c0);
-    
-    Value matrixPointers =
-      rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DPointerType, matrix, c1);
-    
-    Value matrixValues = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, matrix);
+
+    Value matrixPointers = rewriter.create<sparse_tensor::ToPointersOp>(
+        loc, memref1DPointerType, matrix, c1);
+
+    Value matrixValues = rewriter.create<sparse_tensor::ToValuesOp>(
+        loc, memref1DValueType, matrix);
 
     int64_t outputLength = (axis == 1) ? matrixShape[0] : matrixShape[1];
     ArrayRef<int64_t> outputShape = {outputLength};
     Value output = callEmpty(rewriter, module, loc, matrix, outputShape);
 
     callResizeDim(rewriter, module, loc, output, c0, nrows);
-    
-    scf::ForOp nnzLoop = rewriter.create<scf::ForOp>(loc, c0, nrows, c1, ValueRange{c0});
+
+    scf::ForOp nnzLoop =
+        rewriter.create<scf::ForOp>(loc, c0, nrows, c1, ValueRange{c0});
     {
       rewriter.setInsertionPointToStart(nnzLoop.getBody());
       Value numNonEmptyRows = nnzLoop.getLoopBody().getArgument(1);
       Value matrixRowIndex = nnzLoop.getInductionVar();
-      Value nextMatrixRowIndex = rewriter.create<AddIOp>(loc, matrixRowIndex, c1).getResult();
-      Value firstPtr64 = rewriter.create<memref::LoadOp>(loc, matrixPointers, matrixRowIndex);
-      Value secondPtr64 = rewriter.create<memref::LoadOp>(loc, matrixPointers, nextMatrixRowIndex);
-      Value rowIsEmpty = rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, firstPtr64, secondPtr64);
-      scf::IfOp ifRowIsEmptyBlock = rewriter.create<scf::IfOp>(loc, TypeRange{indexType}, rowIsEmpty, true);
+      Value nextMatrixRowIndex =
+          rewriter.create<AddIOp>(loc, matrixRowIndex, c1).getResult();
+      Value firstPtr64 =
+          rewriter.create<memref::LoadOp>(loc, matrixPointers, matrixRowIndex);
+      Value secondPtr64 = rewriter.create<memref::LoadOp>(loc, matrixPointers,
+                                                          nextMatrixRowIndex);
+      Value rowIsEmpty = rewriter.create<CmpIOp>(loc, CmpIPredicate::eq,
+                                                 firstPtr64, secondPtr64);
+      scf::IfOp ifRowIsEmptyBlock = rewriter.create<scf::IfOp>(
+          loc, TypeRange{indexType}, rowIsEmpty, true);
       rewriter.setInsertionPointToStart(ifRowIsEmptyBlock.thenBlock());
       rewriter.create<scf::YieldOp>(loc, ValueRange{numNonEmptyRows});
       rewriter.setInsertionPointToStart(ifRowIsEmptyBlock.elseBlock());
-      Value incrementedNumNonEmptyRows = rewriter.create<AddIOp>(loc, numNonEmptyRows, c1).getResult();
-      rewriter.create<scf::YieldOp>(loc, ValueRange{incrementedNumNonEmptyRows});
+      Value incrementedNumNonEmptyRows =
+          rewriter.create<AddIOp>(loc, numNonEmptyRows, c1).getResult();
+      rewriter.create<scf::YieldOp>(loc,
+                                    ValueRange{incrementedNumNonEmptyRows});
       rewriter.setInsertionPointAfter(ifRowIsEmptyBlock);
       Value updatedNumNonEmptyRows = ifRowIsEmptyBlock.getResult(0);
       rewriter.create<scf::YieldOp>(loc, ValueRange{updatedNumNonEmptyRows});
       rewriter.setInsertionPointAfter(nnzLoop);
     }
     Value outputNNZ = nnzLoop.getResult(0);
-    
+
     callResizePointers(rewriter, module, loc, output, c0, c2);
     callResizeIndex(rewriter, module, loc, output, c0, outputNNZ);
     callResizeValues(rewriter, module, loc, output, outputNNZ);
-    
-    Value outputPointers =
-      rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DPointerType, output, c0);
-    Value outputNNZ_i64 = rewriter.create<IndexCastOp>(loc, outputNNZ, int64Type);
+
+    Value outputPointers = rewriter.create<sparse_tensor::ToPointersOp>(
+        loc, memref1DPointerType, output, c0);
+    Value outputNNZ_i64 =
+        rewriter.create<IndexCastOp>(loc, outputNNZ, int64Type);
     rewriter.create<memref::StoreOp>(loc, outputNNZ_i64, outputPointers, c1);
 
-    Value outputIndices = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, output, c0);
-    Value outputValues = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, output);
-    
-    scf::ForOp reduceLoop = rewriter.create<scf::ForOp>(loc, c0, nrows, c1, ValueRange{c0});
+    Value outputIndices = rewriter.create<sparse_tensor::ToIndicesOp>(
+        loc, memref1DI64Type, output, c0);
+    Value outputValues = rewriter.create<sparse_tensor::ToValuesOp>(
+        loc, memref1DValueType, output);
+
+    scf::ForOp reduceLoop =
+        rewriter.create<scf::ForOp>(loc, c0, nrows, c1, ValueRange{c0});
     {
       rewriter.setInsertionPointToStart(reduceLoop.getBody());
       Value outputValuesPosition = reduceLoop.getLoopBody().getArgument(1);
       Value rowIndex = reduceLoop.getInductionVar();
-      Value ptr64 = rewriter.create<memref::LoadOp>(loc, matrixPointers, rowIndex);
-      Value nextRowIndex = rewriter.create<AddIOp>(loc, rowIndex, c1).getResult();
-      Value nextPtr64 = rewriter.create<memref::LoadOp>(loc, matrixPointers, nextRowIndex);
-      Value rowIsNonEmpty = rewriter.create<CmpIOp>(loc, CmpIPredicate::ne, ptr64, nextPtr64);
-      scf::IfOp ifRowIsNonEmptyBlock = rewriter.create<scf::IfOp>(loc, TypeRange{indexType}, rowIsNonEmpty, true);
+      Value ptr64 =
+          rewriter.create<memref::LoadOp>(loc, matrixPointers, rowIndex);
+      Value nextRowIndex =
+          rewriter.create<AddIOp>(loc, rowIndex, c1).getResult();
+      Value nextPtr64 =
+          rewriter.create<memref::LoadOp>(loc, matrixPointers, nextRowIndex);
+      Value rowIsNonEmpty =
+          rewriter.create<CmpIOp>(loc, CmpIPredicate::ne, ptr64, nextPtr64);
+      scf::IfOp ifRowIsNonEmptyBlock = rewriter.create<scf::IfOp>(
+          loc, TypeRange{indexType}, rowIsNonEmpty, true);
       {
-	rewriter.setInsertionPointToStart(ifRowIsNonEmptyBlock.thenBlock());
-	{
-	  Value ptr = rewriter.create<IndexCastOp>(loc, ptr64, indexType);
-	  Value nextPtr = rewriter.create<IndexCastOp>(loc, nextPtr64, indexType);
-	  scf::ForOp rowSumLoop = rewriter.create<scf::ForOp>(loc, ptr, nextPtr, c1, ValueRange{c0_elementType});
-	  {
-	    rewriter.setInsertionPointToStart(rowSumLoop.getBody());
-	    Value currentSum = rowSumLoop.getLoopBody().getArgument(1);
-	    Value currentPtr = rowSumLoop.getInductionVar();
-	    Value rowValue = rewriter.create<memref::LoadOp>(loc, matrixValues, currentPtr);
-	    Value updatedSum = llvm::TypeSwitch<Type, Value>(elementType)
-	      .Case<IntegerType>([&](IntegerType type)
-				 { return rewriter.create<AddIOp>(loc, rowValue, currentSum).getResult(); })
-	      .Case<FloatType>([&](FloatType type)
-			       { return rewriter.create<AddFOp>(loc, rowValue, currentSum).getResult(); });
-	    rewriter.create<scf::YieldOp>(loc, ValueRange{updatedSum});
-	    rewriter.setInsertionPointAfter(rowSumLoop);
-	  }
-	  Value rowSum = rowSumLoop.getResult(0);
-	  rewriter.create<memref::StoreOp>(loc, rowSum, outputValues, outputValuesPosition);
-	  Value rowIndex64 = rewriter.create<IndexCastOp>(loc, rowIndex, int64Type);
-	  rewriter.create<memref::StoreOp>(loc, rowIndex64, outputIndices, outputValuesPosition);
-	  Value updatedOutputValuesPosition = rewriter.create<AddIOp>(loc, outputValuesPosition, c1).getResult();
-	  rewriter.create<scf::YieldOp>(loc, ValueRange{updatedOutputValuesPosition});
-	}
-	
-	rewriter.setInsertionPointToStart(ifRowIsNonEmptyBlock.elseBlock());
-	{
-	  rewriter.create<scf::YieldOp>(loc, ValueRange{outputValuesPosition});
-	}
-	
-	rewriter.setInsertionPointAfter(ifRowIsNonEmptyBlock);
+        rewriter.setInsertionPointToStart(ifRowIsNonEmptyBlock.thenBlock());
+        {
+          Value ptr = rewriter.create<IndexCastOp>(loc, ptr64, indexType);
+          Value nextPtr =
+              rewriter.create<IndexCastOp>(loc, nextPtr64, indexType);
+          scf::ForOp rowSumLoop = rewriter.create<scf::ForOp>(
+              loc, ptr, nextPtr, c1, ValueRange{c0_elementType});
+          {
+            rewriter.setInsertionPointToStart(rowSumLoop.getBody());
+            Value currentSum = rowSumLoop.getLoopBody().getArgument(1);
+            Value currentPtr = rowSumLoop.getInductionVar();
+            Value rowValue =
+                rewriter.create<memref::LoadOp>(loc, matrixValues, currentPtr);
+            Value updatedSum =
+                llvm::TypeSwitch<Type, Value>(elementType)
+                    .Case<IntegerType>([&](IntegerType type) {
+                      return rewriter.create<AddIOp>(loc, rowValue, currentSum)
+                          .getResult();
+                    })
+                    .Case<FloatType>([&](FloatType type) {
+                      return rewriter.create<AddFOp>(loc, rowValue, currentSum)
+                          .getResult();
+                    });
+            rewriter.create<scf::YieldOp>(loc, ValueRange{updatedSum});
+            rewriter.setInsertionPointAfter(rowSumLoop);
+          }
+          Value rowSum = rowSumLoop.getResult(0);
+          rewriter.create<memref::StoreOp>(loc, rowSum, outputValues,
+                                           outputValuesPosition);
+          Value rowIndex64 =
+              rewriter.create<IndexCastOp>(loc, rowIndex, int64Type);
+          rewriter.create<memref::StoreOp>(loc, rowIndex64, outputIndices,
+                                           outputValuesPosition);
+          Value updatedOutputValuesPosition =
+              rewriter.create<AddIOp>(loc, outputValuesPosition, c1)
+                  .getResult();
+          rewriter.create<scf::YieldOp>(
+              loc, ValueRange{updatedOutputValuesPosition});
+        }
+
+        rewriter.setInsertionPointToStart(ifRowIsNonEmptyBlock.elseBlock());
+        {
+          rewriter.create<scf::YieldOp>(loc, ValueRange{outputValuesPosition});
+        }
+
+        rewriter.setInsertionPointAfter(ifRowIsNonEmptyBlock);
       }
-      
+
       Value nextOutputValuesPosition = ifRowIsNonEmptyBlock.getResult(0);
       rewriter.create<scf::YieldOp>(loc, ValueRange{nextOutputValuesPosition});
 
@@ -757,55 +830,68 @@ public:
     }
 
     rewriter.replaceOp(op, output);
-    
+
     return success();
   };
 };
 
-class LowerMatrixReduceToScalarRewrite : public OpRewritePattern<graphblas::MatrixReduceToScalarOp>
-{
+class LowerMatrixReduceToScalarRewrite
+    : public OpRewritePattern<graphblas::MatrixReduceToScalarOp> {
 public:
   using OpRewritePattern<graphblas::MatrixReduceToScalarOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::MatrixReduceToScalarOp op, PatternRewriter &rewriter) const override
-  {
+  LogicalResult matchAndRewrite(graphblas::MatrixReduceToScalarOp op,
+                                PatternRewriter &rewriter) const override {
     Value input = op.input();
     StringRef aggregator = op.aggregator();
     Location loc = op->getLoc();
 
-    RankedTensorType operandType = op.input().getType().dyn_cast<RankedTensorType>();
+    RankedTensorType operandType =
+        op.input().getType().dyn_cast<RankedTensorType>();
     Type valueType = operandType.getElementType();
 
     // New op
-    graphblas::MatrixReduceToScalarGenericOp newReduceOp = rewriter.create<graphblas::MatrixReduceToScalarGenericOp>(
-        loc, op->getResultTypes(), input, 2);
+    graphblas::MatrixReduceToScalarGenericOp newReduceOp =
+        rewriter.create<graphblas::MatrixReduceToScalarGenericOp>(
+            loc, op->getResultTypes(), input, 2);
 
-    if (aggregator == "plus")
-    {
+    if (aggregator == "plus") {
       // Insert agg identity block
       Region &aggIdentityRegion = newReduceOp.getRegion(0);
-      /*Block *aggIdentityBlock = */ rewriter.createBlock(&aggIdentityRegion, {}, {});
+      /*Block *aggIdentityBlock = */ rewriter.createBlock(&aggIdentityRegion,
+                                                          {}, {});
 
-      Value aggIdentity = llvm::TypeSwitch<Type, Value>(valueType)
-                              .Case<IntegerType>([&](IntegerType type)
-                                                 { return rewriter.create<ConstantIntOp>(loc, 0, type.getWidth()); })
-                              .Case<FloatType>([&](FloatType type)
-                                               { return rewriter.create<ConstantFloatOp>(loc, APFloat(0.0), type); });
-      rewriter.create<graphblas::YieldOp>(loc, graphblas::YieldKind::AGG_IDENTITY, aggIdentity);
+      Value aggIdentity =
+          llvm::TypeSwitch<Type, Value>(valueType)
+              .Case<IntegerType>([&](IntegerType type) {
+                return rewriter.create<ConstantIntOp>(loc, 0, type.getWidth());
+              })
+              .Case<FloatType>([&](FloatType type) {
+                return rewriter.create<ConstantFloatOp>(loc, APFloat(0.0),
+                                                        type);
+              });
+      rewriter.create<graphblas::YieldOp>(
+          loc, graphblas::YieldKind::AGG_IDENTITY, aggIdentity);
 
       // Insert agg block
       Region &aggRegion = newReduceOp.getRegion(1);
-      Block *aggBlock = rewriter.createBlock(&aggRegion, {}, {valueType, valueType});
+      Block *aggBlock =
+          rewriter.createBlock(&aggRegion, {}, {valueType, valueType});
       Value lhs = aggBlock->getArgument(0);
       Value rhs = aggBlock->getArgument(1);
 
-      Value aggResult = llvm::TypeSwitch<Type, Value>(valueType)
-                        .Case<IntegerType>([&](IntegerType type)
-                                           { return rewriter.create<AddIOp>(loc, lhs, rhs).getResult(); })
-                        .Case<FloatType>([&](FloatType type)
-                                         { return rewriter.create<AddFOp>(loc, lhs, rhs).getResult(); });
-      rewriter.create<graphblas::YieldOp>(loc, graphblas::YieldKind::AGG, aggResult);
+      Value aggResult =
+          llvm::TypeSwitch<Type, Value>(valueType)
+              .Case<IntegerType>([&](IntegerType type) {
+                return rewriter.create<AddIOp>(loc, lhs, rhs).getResult();
+              })
+              .Case<FloatType>([&](FloatType type) {
+                return rewriter.create<AddFOp>(loc, lhs, rhs).getResult();
+              });
+      rewriter.create<graphblas::YieldOp>(loc, graphblas::YieldKind::AGG,
+                                          aggResult);
     } else {
-      return op.emitError("\"" + aggregator + "\" is not a supported aggregator.");
+      return op.emitError("\"" + aggregator +
+                          "\" is not a supported aggregator.");
     }
 
     rewriter.replaceOp(op, newReduceOp.getResult());
@@ -814,31 +900,39 @@ public:
   };
 };
 
-class LowerMatrixReduceToScalarGenericRewrite : public OpRewritePattern<graphblas::MatrixReduceToScalarGenericOp> {
+class LowerMatrixReduceToScalarGenericRewrite
+    : public OpRewritePattern<graphblas::MatrixReduceToScalarGenericOp> {
 public:
-  using OpRewritePattern<graphblas::MatrixReduceToScalarGenericOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::MatrixReduceToScalarGenericOp op, PatternRewriter &rewriter) const override {
+  using OpRewritePattern<
+      graphblas::MatrixReduceToScalarGenericOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(graphblas::MatrixReduceToScalarGenericOp op,
+                                PatternRewriter &rewriter) const override {
     Value input = op.input();
     Location loc = op->getLoc();
 
-    RankedTensorType operandType = op.input().getType().dyn_cast<RankedTensorType>();
+    RankedTensorType operandType =
+        op.input().getType().dyn_cast<RankedTensorType>();
     Type valueType = operandType.getElementType();
-    Type int64Type = rewriter.getIntegerType(64); // TODO should we get this from the sparse encoding?
+    Type int64Type = rewriter.getIntegerType(
+        64); // TODO should we get this from the sparse encoding?
     Type indexType = rewriter.getIndexType();
 
     // Required blocks
     RegionRange extensions = op.extensions();
     ExtensionBlocks extBlocks;
-    std::set<graphblas::YieldKind> required = {graphblas::YieldKind::AGG_IDENTITY, graphblas::YieldKind::AGG};
-    LogicalResult extractResult = extBlocks.extractBlocks(op, extensions, required, {});
+    std::set<graphblas::YieldKind> required = {
+        graphblas::YieldKind::AGG_IDENTITY, graphblas::YieldKind::AGG};
+    LogicalResult extractResult =
+        extBlocks.extractBlocks(op, extensions, required, {});
 
-    if (extractResult.failed())
-    {
+    if (extractResult.failed()) {
       return extractResult;
     }
 
     // insert agg identity
-    graphblas::YieldOp aggIdentityYield = llvm::dyn_cast_or_null<graphblas::YieldOp>(extBlocks.aggIdentity->getTerminator());
+    graphblas::YieldOp aggIdentityYield =
+        llvm::dyn_cast_or_null<graphblas::YieldOp>(
+            extBlocks.aggIdentity->getTerminator());
     rewriter.mergeBlocks(extBlocks.aggIdentity, rewriter.getBlock(), {});
     Value c0Accumulator = aggIdentityYield.values().front();
     rewriter.eraseOp(aggIdentityYield);
@@ -852,17 +946,24 @@ public:
     MemRefType memref1DValueType = MemRefType::get({-1}, valueType);
 
     Value nrows = rewriter.create<graphblas::NumRowsOp>(loc, input);
-    sparse_tensor::ToPointersOp inputPtrs = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, input, c1);
-    sparse_tensor::ToValuesOp inputValues = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, input);
-    memref::LoadOp nnz64 = rewriter.create<memref::LoadOp>(loc, inputPtrs, nrows);
+    sparse_tensor::ToPointersOp inputPtrs =
+        rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type,
+                                                     input, c1);
+    sparse_tensor::ToValuesOp inputValues =
+        rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType,
+                                                   input);
+    memref::LoadOp nnz64 =
+        rewriter.create<memref::LoadOp>(loc, inputPtrs, nrows);
     IndexCastOp nnz = rewriter.create<IndexCastOp>(loc, nnz64, indexType);
 
     // begin loop
-    scf::ParallelOp valueLoop = rewriter.create<scf::ParallelOp>(loc, c0, nnz.getResult(), c1, c0Accumulator);
+    scf::ParallelOp valueLoop = rewriter.create<scf::ParallelOp>(
+        loc, c0, nnz.getResult(), c1, c0Accumulator);
     ValueRange valueLoopIdx = valueLoop.getInductionVars();
 
     rewriter.setInsertionPointToStart(valueLoop.getBody());
-    memref::LoadOp y = rewriter.create<memref::LoadOp>(loc, inputValues, valueLoopIdx);
+    memref::LoadOp y =
+        rewriter.create<memref::LoadOp>(loc, inputValues, valueLoopIdx);
 
     scf::ReduceOp reducer = rewriter.create<scf::ReduceOp>(loc, y);
     BlockArgument lhs = reducer.getRegion().getArgument(0);
@@ -870,7 +971,8 @@ public:
 
     rewriter.setInsertionPointToStart(&reducer.getRegion().front());
 
-    graphblas::YieldOp aggYield = llvm::dyn_cast_or_null<graphblas::YieldOp>(extBlocks.agg->getTerminator());
+    graphblas::YieldOp aggYield = llvm::dyn_cast_or_null<graphblas::YieldOp>(
+        extBlocks.agg->getTerminator());
     rewriter.mergeBlocks(extBlocks.agg, rewriter.getBlock(), {lhs, rhs});
     Value result = aggYield.values().front();
     rewriter.eraseOp(aggYield);
@@ -885,38 +987,47 @@ public:
   };
 };
 
-class LowerMatrixApplyRewrite : public OpRewritePattern<graphblas::MatrixApplyOp> {
+class LowerMatrixApplyRewrite
+    : public OpRewritePattern<graphblas::MatrixApplyOp> {
 public:
   using OpRewritePattern<graphblas::MatrixApplyOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::MatrixApplyOp op, PatternRewriter &rewriter) const override {
-    ModuleOp module = op->getParentOfType<ModuleOp>(); /* ignore unused variable for debugging */ (void)module;
+  LogicalResult matchAndRewrite(graphblas::MatrixApplyOp op,
+                                PatternRewriter &rewriter) const override {
+    ModuleOp module = op->getParentOfType<ModuleOp>(); /* ignore unused variable
+                                                          for debugging */
+    (void)module;
     Location loc = op->getLoc();
 
-    Type valueType = op.input().getType().dyn_cast<RankedTensorType>().getElementType();
+    Type valueType =
+        op.input().getType().dyn_cast<RankedTensorType>().getElementType();
 
     Value input = op.input();
     Value thunk = op.thunk();
     StringRef apply_operator = op.apply_operator();
 
     // New op
-    graphblas::MatrixApplyGenericOp newApplyOp = rewriter.create<graphblas::MatrixApplyGenericOp>(
-        loc, op->getResultTypes(), input, 1);
+    graphblas::MatrixApplyGenericOp newApplyOp =
+        rewriter.create<graphblas::MatrixApplyGenericOp>(
+            loc, op->getResultTypes(), input, 1);
 
     // Insert transformOut block
     Region &transformOutRegion = newApplyOp.getRegion(0);
-    Block *transformOutBlock = rewriter.createBlock(&transformOutRegion, {}, {valueType});
+    Block *transformOutBlock =
+        rewriter.createBlock(&transformOutRegion, {}, {valueType});
 
     Value transformResult;
-    if (apply_operator == "min")
-    {
+    if (apply_operator == "min") {
       Value val = transformOutBlock->getArgument(0);
-      Value cmp = rewriter.create<mlir::CmpFOp>(loc, mlir::CmpFPredicate::OLT, val, thunk);
+      Value cmp = rewriter.create<mlir::CmpFOp>(loc, mlir::CmpFPredicate::OLT,
+                                                val, thunk);
       transformResult = rewriter.create<mlir::SelectOp>(loc, cmp, val, thunk);
     } else {
-      return op.emitError("\"" + apply_operator + "\" is not a supported apply_operator.");
+      return op.emitError("\"" + apply_operator +
+                          "\" is not a supported apply_operator.");
     };
 
-    rewriter.create<graphblas::YieldOp>(loc, graphblas::YieldKind::TRANSFORM_OUT, transformResult);
+    rewriter.create<graphblas::YieldOp>(
+        loc, graphblas::YieldKind::TRANSFORM_OUT, transformResult);
 
     rewriter.replaceOp(op, newApplyOp.getResult());
 
@@ -924,16 +1035,17 @@ public:
   };
 };
 
-class LowerMatrixApplyGenericRewrite : public OpRewritePattern<graphblas::MatrixApplyGenericOp>
-{
+class LowerMatrixApplyGenericRewrite
+    : public OpRewritePattern<graphblas::MatrixApplyGenericOp> {
 public:
   using OpRewritePattern<graphblas::MatrixApplyGenericOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::MatrixApplyGenericOp op, PatternRewriter &rewriter) const override
-  {
+  LogicalResult matchAndRewrite(graphblas::MatrixApplyGenericOp op,
+                                PatternRewriter &rewriter) const override {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
 
-    Type valueType = op.input().getType().dyn_cast<RankedTensorType>().getElementType();
+    Type valueType =
+        op.input().getType().dyn_cast<RankedTensorType>().getElementType();
     Type memref1DValueType = MemRefType::get({-1}, valueType);
 
     Value inputTensor = op.input();
@@ -941,11 +1053,12 @@ public:
     // Required blocks
     RegionRange extensions = op.extensions();
     ExtensionBlocks extBlocks;
-    std::set<graphblas::YieldKind> required = {graphblas::YieldKind::TRANSFORM_OUT};
-    LogicalResult extractResult = extBlocks.extractBlocks(op, extensions, required, {});
+    std::set<graphblas::YieldKind> required = {
+        graphblas::YieldKind::TRANSFORM_OUT};
+    LogicalResult extractResult =
+        extBlocks.extractBlocks(op, extensions, required, {});
 
-    if (extractResult.failed())
-    {
+    if (extractResult.failed()) {
       return extractResult;
     }
 
@@ -955,23 +1068,29 @@ public:
 
     // Get sparse tensor info
     Value output = rewriter.create<graphblas::DupOp>(loc, inputTensor);
-    Value inputValues = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, inputTensor);
-    Value outputValues = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, output);
+    Value inputValues = rewriter.create<sparse_tensor::ToValuesOp>(
+        loc, memref1DValueType, inputTensor);
+    Value outputValues = rewriter.create<sparse_tensor::ToValuesOp>(
+        loc, memref1DValueType, output);
 
     Value nnz = rewriter.create<graphblas::NumValsOp>(loc, inputTensor);
 
     // Loop over values
-    scf::ParallelOp valueLoop = rewriter.create<scf::ParallelOp>(loc, c0, nnz, c1);
+    scf::ParallelOp valueLoop =
+        rewriter.create<scf::ParallelOp>(loc, c0, nnz, c1);
     ValueRange valueLoopIdx = valueLoop.getInductionVars();
 
     rewriter.setInsertionPointToStart(valueLoop.getBody());
     Value val = rewriter.create<memref::LoadOp>(loc, inputValues, valueLoopIdx);
 
-    // scf::ParallelOp automatically gets an empty scf.yield at the end which we need to insert before
+    // scf::ParallelOp automatically gets an empty scf.yield at the end which we
+    // need to insert before
     Operation *scfYield = valueLoop.getBody()->getTerminator();
 
     // insert transformOut block
-    graphblas::YieldOp transformOutYield = llvm::dyn_cast_or_null<graphblas::YieldOp>(extBlocks.transformOut->getTerminator());
+    graphblas::YieldOp transformOutYield =
+        llvm::dyn_cast_or_null<graphblas::YieldOp>(
+            extBlocks.transformOut->getTerminator());
 
     rewriter.mergeBlockBefore(extBlocks.transformOut, scfYield, {val});
     Value result = transformOutYield.values().front();
@@ -991,11 +1110,15 @@ public:
   };
 };
 
-class LowerMatrixMultiplyRewrite : public OpRewritePattern<graphblas::MatrixMultiplyOp> {
+class LowerMatrixMultiplyRewrite
+    : public OpRewritePattern<graphblas::MatrixMultiplyOp> {
 public:
   using OpRewritePattern<graphblas::MatrixMultiplyOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::MatrixMultiplyOp op, PatternRewriter &rewriter) const override {
-    ModuleOp module = op->getParentOfType<ModuleOp>(); /* ignore unused variable for debugging */ (void)module;
+  LogicalResult matchAndRewrite(graphblas::MatrixMultiplyOp op,
+                                PatternRewriter &rewriter) const override {
+    ModuleOp module = op->getParentOfType<ModuleOp>(); /* ignore unused variable
+                                                          for debugging */
+    (void)module;
     Location loc = op->getLoc();
 
     // Inputs
@@ -1004,15 +1127,17 @@ public:
 
     // Types
     // Can't use result here because it might be a scalar (vector-vector)
-    Type valueType = op.a().getType().dyn_cast<RankedTensorType>().getElementType();
+    Type valueType =
+        op.a().getType().dyn_cast<RankedTensorType>().getElementType();
 
     // New op
     ArrayRef<NamedAttribute> attributes;
-    graphblas::MatrixMultiplyGenericOp newMultOp = rewriter.create<graphblas::MatrixMultiplyGenericOp>(
-      loc, op->getResultTypes(), operands, attributes, 3);
+    graphblas::MatrixMultiplyGenericOp newMultOp =
+        rewriter.create<graphblas::MatrixMultiplyGenericOp>(
+            loc, op->getResultTypes(), operands, attributes, 3);
 
-    if(failed(populateSemiringRegions(rewriter, loc, semiring, valueType, 
-                                      newMultOp.getRegions().slice(0, 3))))
+    if (failed(populateSemiringRegions(rewriter, loc, semiring, valueType,
+                                       newMultOp.getRegions().slice(0, 3))))
       return failure();
 
     rewriter.setInsertionPointAfter(newMultOp);
@@ -1023,20 +1148,22 @@ public:
   };
 };
 
-class LowerMatrixMultiplyGenericRewrite : public OpRewritePattern<graphblas::MatrixMultiplyGenericOp> {
+class LowerMatrixMultiplyGenericRewrite
+    : public OpRewritePattern<graphblas::MatrixMultiplyGenericOp> {
 public:
   using OpRewritePattern<graphblas::MatrixMultiplyGenericOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::MatrixMultiplyGenericOp op, PatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(graphblas::MatrixMultiplyGenericOp op,
+                                PatternRewriter &rewriter) const override {
     // Required blocks
     RegionRange extensions = op.extensions();
     ExtensionBlocks extBlocks;
     std::set<graphblas::YieldKind> required = {
-        graphblas::YieldKind::ADD_IDENTITY,
-        graphblas::YieldKind::ADD,
-        graphblas::YieldKind::MULT
-    };
-    std::set<graphblas::YieldKind> optional = {graphblas::YieldKind::TRANSFORM_OUT};
-    LogicalResult extractResult = extBlocks.extractBlocks(op, extensions, required, optional);
+        graphblas::YieldKind::ADD_IDENTITY, graphblas::YieldKind::ADD,
+        graphblas::YieldKind::MULT};
+    std::set<graphblas::YieldKind> optional = {
+        graphblas::YieldKind::TRANSFORM_OUT};
+    LogicalResult extractResult =
+        extBlocks.extractBlocks(op, extensions, required, optional);
 
     if (extractResult.failed()) {
       return extractResult;
@@ -1060,7 +1187,10 @@ public:
   };
 
 private:
-  LogicalResult rewriteMatrixMatrixMultiplication(graphblas::MatrixMultiplyGenericOp op, PatternRewriter &rewriter, ExtensionBlocks extBlocks) const {
+  LogicalResult
+  rewriteMatrixMatrixMultiplication(graphblas::MatrixMultiplyGenericOp op,
+                                    PatternRewriter &rewriter,
+                                    ExtensionBlocks extBlocks) const {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
 
@@ -1072,7 +1202,8 @@ private:
     // Types
     Type indexType = rewriter.getIndexType();
     Type int64Type = rewriter.getIntegerType(64);
-    Type valueType = op.getResult().getType().dyn_cast<RankedTensorType>().getElementType();
+    Type valueType =
+        op.getResult().getType().dyn_cast<RankedTensorType>().getElementType();
 
     MemRefType memref1DI64Type = MemRefType::get({-1}, int64Type);
     MemRefType memref1DValueType = MemRefType::get({-1}, valueType);
@@ -1084,7 +1215,8 @@ private:
 
     Value nrow = rewriter.create<graphblas::NumRowsOp>(loc, A);
     Value ncol = rewriter.create<graphblas::NumColsOp>(loc, B);
-    Value nk = rewriter.create<graphblas::NumColsOp>(loc, A); // guaranteed equal to B.rows
+    Value nk = rewriter.create<graphblas::NumColsOp>(
+        loc, A); // guaranteed equal to B.rows
     Value nrow_plus_one = rewriter.create<AddIOp>(loc, nrow, c1);
 
     Value C = callEmptyLike(rewriter, module, loc, A);
@@ -1093,34 +1225,46 @@ private:
     callResizePointers(rewriter, module, loc, C, c1, nrow_plus_one);
     C = convertToExternalCSR(rewriter, module, loc, C);
 
-    Value Ap = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, A, c1);
-    Value Aj = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, A, c1);
-    Value Ax = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, A);
-    Value Bp = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, B, c1);
-    Value Bi = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, B, c1);
-    Value Bx = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, B);
-    Value Cp = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, C, c1);
+    Value Ap = rewriter.create<sparse_tensor::ToPointersOp>(
+        loc, memref1DI64Type, A, c1);
+    Value Aj = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type,
+                                                           A, c1);
+    Value Ax =
+        rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, A);
+    Value Bp = rewriter.create<sparse_tensor::ToPointersOp>(
+        loc, memref1DI64Type, B, c1);
+    Value Bi = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type,
+                                                           B, c1);
+    Value Bx =
+        rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, B);
+    Value Cp = rewriter.create<sparse_tensor::ToPointersOp>(
+        loc, memref1DI64Type, C, c1);
     Value Mp, Mj;
-    if (mask)
-    {
-        Mp = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, mask, c1);
-        Mj = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, mask, c1);
+    if (mask) {
+      Mp = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type,
+                                                        mask, c1);
+      Mj = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type,
+                                                       mask, c1);
     }
 
     // 1st pass
     //   Compute the number of nonzero entries per row.
     //   Store results in Cp
-    //   The rows in A are the fixed elements, while the columns of B are the iteration element
-    scf::ParallelOp rowLoop1 = rewriter.create<scf::ParallelOp>(loc, c0, nrow, c1);
+    //   The rows in A are the fixed elements, while the columns of B are the
+    //   iteration element
+    scf::ParallelOp rowLoop1 =
+        rewriter.create<scf::ParallelOp>(loc, c0, nrow, c1);
     Value row = rowLoop1.getInductionVars()[0];
     rewriter.setInsertionPointToStart(rowLoop1.getBody());
 
     Value colStart64 = rewriter.create<memref::LoadOp>(loc, Ap, row);
     Value rowPlus1 = rewriter.create<AddIOp>(loc, row, c1);
     Value colEnd64 = rewriter.create<memref::LoadOp>(loc, Ap, rowPlus1);
-    Value cmpColSame = rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, colStart64, colEnd64);
+    Value cmpColSame =
+        rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, colStart64, colEnd64);
 
-    scf::IfOp ifBlock_rowTotal = rewriter.create<scf::IfOp>(loc, int64Type, cmpColSame, true);
+    scf::IfOp ifBlock_rowTotal =
+        rewriter.create<scf::IfOp>(loc, int64Type, cmpColSame, true);
     // if cmpColSame
     rewriter.setInsertionPointToStart(ifBlock_rowTotal.thenBlock());
     rewriter.create<scf::YieldOp>(loc, ci0);
@@ -1133,11 +1277,14 @@ private:
     if (mask) {
       Value mcolStart64 = rewriter.create<memref::LoadOp>(loc, Mp, row);
       Value mcolEnd64 = rewriter.create<memref::LoadOp>(loc, Mp, rowPlus1);
-      Value mcolStart = rewriter.create<IndexCastOp>(loc, mcolStart64, indexType);
+      Value mcolStart =
+          rewriter.create<IndexCastOp>(loc, mcolStart64, indexType);
       Value mcolEnd = rewriter.create<IndexCastOp>(loc, mcolEnd64, indexType);
-      total = computeNumOverlaps(rewriter, nk, Aj, colStart, colEnd, Bp, Bi, Mj, mcolStart, mcolEnd, valueType);
+      total = computeNumOverlaps(rewriter, nk, Aj, colStart, colEnd, Bp, Bi, Mj,
+                                 mcolStart, mcolEnd, valueType);
     } else {
-      total = computeNumOverlaps(rewriter, nk, Aj, colStart, colEnd, Bp, Bi, nullptr, c0, ncol, valueType);
+      total = computeNumOverlaps(rewriter, nk, Aj, colStart, colEnd, Bp, Bi,
+                                 nullptr, c0, ncol, valueType);
     }
     rewriter.create<scf::YieldOp>(loc, total);
 
@@ -1152,7 +1299,8 @@ private:
     // 2nd pass
     //   Compute the cumsum of values in Cp to build the final Cp
     //   Then resize C's indices and values
-    //   The rows in A are the fixed elements, while the columns of B are the iteration element
+    //   The rows in A are the fixed elements, while the columns of B are the
+    //   iteration element
     scf::ForOp rowLoop2 = rewriter.create<scf::ForOp>(loc, c0, nrow, c1);
     Value cs_i = rowLoop2.getInductionVar();
     rewriter.setInsertionPointToStart(rowLoop2.getBody());
@@ -1170,22 +1318,27 @@ private:
     callResizeIndex(rewriter, module, loc, C, c1, nnz);
     callResizeValues(rewriter, module, loc, C, nnz);
     C = convertToExternalCSR(rewriter, module, loc, C);
-    Value Cj = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, C, c1);
-    Value Cx = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, C);
+    Value Cj = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type,
+                                                           C, c1);
+    Value Cx =
+        rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, C);
 
     // 3rd pass
     //   In parallel over the rows,
     //   compute the nonzero columns and associated values.
     //   Store in Cj and Cx
-    scf::ParallelOp rowLoop3 = rewriter.create<scf::ParallelOp>(loc, c0, nrow, c1);
+    scf::ParallelOp rowLoop3 =
+        rewriter.create<scf::ParallelOp>(loc, c0, nrow, c1);
     row = rowLoop3.getInductionVars()[0];
     rewriter.setInsertionPointToStart(rowLoop3.getBody());
 
     rowPlus1 = rewriter.create<AddIOp>(loc, row, c1);
     Value cpStart64 = rewriter.create<memref::LoadOp>(loc, Cp, row);
     Value cpEnd64 = rewriter.create<memref::LoadOp>(loc, Cp, rowPlus1);
-    Value cmp_cpDifferent = rewriter.create<CmpIOp>(loc, CmpIPredicate::ne, cpStart64, cpEnd64);
-    scf::IfOp ifBlock_cmpDiff = rewriter.create<scf::IfOp>(loc, cmp_cpDifferent);
+    Value cmp_cpDifferent =
+        rewriter.create<CmpIOp>(loc, CmpIPredicate::ne, cpStart64, cpEnd64);
+    scf::IfOp ifBlock_cmpDiff =
+        rewriter.create<scf::IfOp>(loc, cmp_cpDifferent);
     rewriter.setInsertionPointToStart(ifBlock_cmpDiff.thenBlock());
 
     Value baseIndex64 = rewriter.create<memref::LoadOp>(loc, Cp, row);
@@ -1199,11 +1352,16 @@ private:
     if (mask) {
       Value mcolStart64 = rewriter.create<memref::LoadOp>(loc, Mp, row);
       Value mcolEnd64 = rewriter.create<memref::LoadOp>(loc, Mp, rowPlus1);
-      Value mcolStart = rewriter.create<IndexCastOp>(loc, mcolStart64, indexType);
+      Value mcolStart =
+          rewriter.create<IndexCastOp>(loc, mcolStart64, indexType);
       Value mcolEnd = rewriter.create<IndexCastOp>(loc, mcolEnd64, indexType);
-      computeInnerProduct(rewriter, nk, Aj, Ax, colStart, colEnd, Bp, Bi, Bx, Mj, mcolStart, mcolEnd, valueType, extBlocks, Cj, Cx, baseIndex);
+      computeInnerProduct(rewriter, nk, Aj, Ax, colStart, colEnd, Bp, Bi, Bx,
+                          Mj, mcolStart, mcolEnd, valueType, extBlocks, Cj, Cx,
+                          baseIndex);
     } else {
-      computeInnerProduct(rewriter, nk, Aj, Ax, colStart, colEnd, Bp, Bi, Bx, nullptr, c0, ncol, valueType, extBlocks, Cj, Cx, baseIndex);
+      computeInnerProduct(rewriter, nk, Aj, Ax, colStart, colEnd, Bp, Bi, Bx,
+                          nullptr, c0, ncol, valueType, extBlocks, Cj, Cx,
+                          baseIndex);
     }
 
     // end if cmpDiff
@@ -1219,7 +1377,10 @@ private:
     return success();
   }
 
-  LogicalResult rewriteMatrixVectorMultiplication(graphblas::MatrixMultiplyGenericOp op, PatternRewriter &rewriter, ExtensionBlocks extBlocks) const {
+  LogicalResult
+  rewriteMatrixVectorMultiplication(graphblas::MatrixMultiplyGenericOp op,
+                                    PatternRewriter &rewriter,
+                                    ExtensionBlocks extBlocks) const {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
 
@@ -1231,7 +1392,8 @@ private:
     // Types
     Type indexType = rewriter.getIndexType();
     Type int64Type = rewriter.getIntegerType(64);
-    Type valueType = op.getResult().getType().dyn_cast<RankedTensorType>().getElementType();
+    Type valueType =
+        op.getResult().getType().dyn_cast<RankedTensorType>().getElementType();
 
     MemRefType memref1DI64Type = MemRefType::get({-1}, int64Type);
     MemRefType memref1DValueType = MemRefType::get({-1}, valueType);
@@ -1244,40 +1406,52 @@ private:
 
     Value size = rewriter.create<graphblas::NumRowsOp>(loc, A);
     Value nk = rewriter.create<graphblas::SizeOp>(loc, B);
-    // TODO: how do I check nk == nk_check and raise an exception if they don't match?
-    // Value nk_check = rewriter.create<graphblas::NumColsOp>(loc, A);
+    // TODO: how do I check nk == nk_check and raise an exception if they don't
+    // match? Value nk_check = rewriter.create<graphblas::NumColsOp>(loc, A);
 
     Value C = callEmptyLike(rewriter, module, loc, B);
     callResizeDim(rewriter, module, loc, C, c0, size);
     callResizePointers(rewriter, module, loc, C, c0, c2);
 
-    Value Ap = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, A, c1);
-    Value Aj = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, A, c1);
-    Value Ax = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, A);
-    Value Bp = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, B, c0);
-    Value Bi = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, B, c0);
-    Value Bx = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, B);
-    Value Cp = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, C, c0);
+    Value Ap = rewriter.create<sparse_tensor::ToPointersOp>(
+        loc, memref1DI64Type, A, c1);
+    Value Aj = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type,
+                                                           A, c1);
+    Value Ax =
+        rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, A);
+    Value Bp = rewriter.create<sparse_tensor::ToPointersOp>(
+        loc, memref1DI64Type, B, c0);
+    Value Bi = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type,
+                                                           B, c0);
+    Value Bx =
+        rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, B);
+    Value Cp = rewriter.create<sparse_tensor::ToPointersOp>(
+        loc, memref1DI64Type, C, c0);
     Value Mp, Mi, maskStart, maskEnd;
-    if (mask)
-    {
-        Mp = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, mask, c0);
-        Mi = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, mask, c0);
-        Value maskStart64 = rewriter.create<memref::LoadOp>(loc, Mp, c0);
-        Value maskEnd64 = rewriter.create<memref::LoadOp>(loc, Mp, c1);
-        maskStart = rewriter.create<IndexCastOp>(loc, maskStart64, indexType);
-        maskEnd = rewriter.create<IndexCastOp>(loc, maskEnd64, indexType);
+    if (mask) {
+      Mp = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type,
+                                                        mask, c0);
+      Mi = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type,
+                                                       mask, c0);
+      Value maskStart64 = rewriter.create<memref::LoadOp>(loc, Mp, c0);
+      Value maskEnd64 = rewriter.create<memref::LoadOp>(loc, Mp, c1);
+      maskStart = rewriter.create<IndexCastOp>(loc, maskStart64, indexType);
+      maskEnd = rewriter.create<IndexCastOp>(loc, maskEnd64, indexType);
     }
 
     // 1st pass
     //   Compute the number of nonzero entries in the result
     //   Store results in Cp
-    //   The vector B is the fixed element, while the rows of A are the iteration element
+    //   The vector B is the fixed element, while the rows of A are the
+    //   iteration element
     Value fixedIndexEnd64 = rewriter.create<memref::LoadOp>(loc, Bp, c1);
-    Value fixedIndexEnd = rewriter.create<IndexCastOp>(loc, fixedIndexEnd64, indexType);
-    Value cmpColSame = rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, c0, fixedIndexEnd);
+    Value fixedIndexEnd =
+        rewriter.create<IndexCastOp>(loc, fixedIndexEnd64, indexType);
+    Value cmpColSame =
+        rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, c0, fixedIndexEnd);
 
-    scf::IfOp ifBlock_rowTotal = rewriter.create<scf::IfOp>(loc, int64Type, cmpColSame, true);
+    scf::IfOp ifBlock_rowTotal =
+        rewriter.create<scf::IfOp>(loc, int64Type, cmpColSame, true);
     // if cmpColSame
     rewriter.setInsertionPointToStart(ifBlock_rowTotal.thenBlock());
     rewriter.create<scf::YieldOp>(loc, ci0);
@@ -1286,9 +1460,11 @@ private:
     rewriter.setInsertionPointToStart(ifBlock_rowTotal.elseBlock());
     Value total;
     if (mask) {
-      total = computeNumOverlaps(rewriter, nk, Bi, c0, fixedIndexEnd, Ap, Aj, Mi, maskStart, maskEnd, valueType);
+      total = computeNumOverlaps(rewriter, nk, Bi, c0, fixedIndexEnd, Ap, Aj,
+                                 Mi, maskStart, maskEnd, valueType);
     } else {
-      total = computeNumOverlaps(rewriter, nk, Bi, c0, fixedIndexEnd, Ap, Aj, nullptr, c0, size, valueType);
+      total = computeNumOverlaps(rewriter, nk, Bi, c0, fixedIndexEnd, Ap, Aj,
+                                 nullptr, c0, size, valueType);
     }
     rewriter.create<scf::YieldOp>(loc, total);
 
@@ -1300,21 +1476,29 @@ private:
 
     callResizeIndex(rewriter, module, loc, C, c0, nnz);
     callResizeValues(rewriter, module, loc, C, nnz);
-    Value Ci = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, C, c0);
-    Value Cx = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, C);
+    Value Ci = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type,
+                                                           C, c0);
+    Value Cx =
+        rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, C);
 
     // 2nd pass
     //   Compute the nonzero values.
     //   Store in Ci and Cx
-    //   The vector B is the fixed element, while the rows of A are the iteration element
-    Value cmp_cpDifferent = rewriter.create<CmpIOp>(loc, CmpIPredicate::ne, c0, nnz);
-    scf::IfOp ifBlock_cmpDiff = rewriter.create<scf::IfOp>(loc, cmp_cpDifferent);
+    //   The vector B is the fixed element, while the rows of A are the
+    //   iteration element
+    Value cmp_cpDifferent =
+        rewriter.create<CmpIOp>(loc, CmpIPredicate::ne, c0, nnz);
+    scf::IfOp ifBlock_cmpDiff =
+        rewriter.create<scf::IfOp>(loc, cmp_cpDifferent);
     rewriter.setInsertionPointToStart(ifBlock_cmpDiff.thenBlock());
 
     if (mask) {
-      computeInnerProduct(rewriter, nk, Bi, Bx, c0, fixedIndexEnd, Ap, Aj, Ax, Mi, maskStart, maskEnd, valueType, extBlocks, Ci, Cx, c0);
+      computeInnerProduct(rewriter, nk, Bi, Bx, c0, fixedIndexEnd, Ap, Aj, Ax,
+                          Mi, maskStart, maskEnd, valueType, extBlocks, Ci, Cx,
+                          c0);
     } else {
-      computeInnerProduct(rewriter, nk, Bi, Bx, c0, fixedIndexEnd, Ap, Aj, Ax, nullptr, c0, size, valueType, extBlocks, Ci, Cx, c0);
+      computeInnerProduct(rewriter, nk, Bi, Bx, c0, fixedIndexEnd, Ap, Aj, Ax,
+                          nullptr, c0, size, valueType, extBlocks, Ci, Cx, c0);
     }
 
     // end if cmpDiff
@@ -1327,7 +1511,10 @@ private:
     return success();
   }
 
-  LogicalResult rewriteVectorMatrixMultiplication(graphblas::MatrixMultiplyGenericOp op, PatternRewriter &rewriter, ExtensionBlocks extBlocks) const {
+  LogicalResult
+  rewriteVectorMatrixMultiplication(graphblas::MatrixMultiplyGenericOp op,
+                                    PatternRewriter &rewriter,
+                                    ExtensionBlocks extBlocks) const {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
 
@@ -1339,7 +1526,8 @@ private:
     // Types
     Type indexType = rewriter.getIndexType();
     Type int64Type = rewriter.getIntegerType(64);
-    Type valueType = op.getResult().getType().dyn_cast<RankedTensorType>().getElementType();
+    Type valueType =
+        op.getResult().getType().dyn_cast<RankedTensorType>().getElementType();
 
     MemRefType memref1DI64Type = MemRefType::get({-1}, int64Type);
     MemRefType memref1DValueType = MemRefType::get({-1}, valueType);
@@ -1351,39 +1539,52 @@ private:
     Value ci0 = rewriter.create<ConstantIntOp>(loc, 0, int64Type);
 
     Value size = rewriter.create<graphblas::NumColsOp>(loc, B);
-    Value nk = rewriter.create<graphblas::SizeOp>(loc, A); // guaranteed equal to B.rows
+    Value nk = rewriter.create<graphblas::SizeOp>(
+        loc, A); // guaranteed equal to B.rows
 
     Value C = callEmptyLike(rewriter, module, loc, A);
     callResizeDim(rewriter, module, loc, C, c0, size);
     callResizePointers(rewriter, module, loc, C, c0, c2);
 
-    Value Ap = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, A, c0);
-    Value Ai = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, A, c0);
-    Value Ax = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, A);
-    Value Bp = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, B, c1);
-    Value Bi = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, B, c1);
-    Value Bx = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, B);
-    Value Cp = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, C, c0);
+    Value Ap = rewriter.create<sparse_tensor::ToPointersOp>(
+        loc, memref1DI64Type, A, c0);
+    Value Ai = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type,
+                                                           A, c0);
+    Value Ax =
+        rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, A);
+    Value Bp = rewriter.create<sparse_tensor::ToPointersOp>(
+        loc, memref1DI64Type, B, c1);
+    Value Bi = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type,
+                                                           B, c1);
+    Value Bx =
+        rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, B);
+    Value Cp = rewriter.create<sparse_tensor::ToPointersOp>(
+        loc, memref1DI64Type, C, c0);
     Value Mp, Mi, maskStart, maskEnd;
-    if (mask)
-    {
-        Mp = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, mask, c0);
-        Mi = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, mask, c0);
-        Value maskStart64 = rewriter.create<memref::LoadOp>(loc, Mp, c0);
-        Value maskEnd64 = rewriter.create<memref::LoadOp>(loc, Mp, c1);
-        maskStart = rewriter.create<IndexCastOp>(loc, maskStart64, indexType);
-        maskEnd = rewriter.create<IndexCastOp>(loc, maskEnd64, indexType);
+    if (mask) {
+      Mp = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type,
+                                                        mask, c0);
+      Mi = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type,
+                                                       mask, c0);
+      Value maskStart64 = rewriter.create<memref::LoadOp>(loc, Mp, c0);
+      Value maskEnd64 = rewriter.create<memref::LoadOp>(loc, Mp, c1);
+      maskStart = rewriter.create<IndexCastOp>(loc, maskStart64, indexType);
+      maskEnd = rewriter.create<IndexCastOp>(loc, maskEnd64, indexType);
     }
 
     // 1st pass
     //   Compute the number of nonzero entries in the result
     //   Store results in Cp
-    //   The vector A is the fixed element, while the columns of B are the iteration element
+    //   The vector A is the fixed element, while the columns of B are the
+    //   iteration element
     Value fixedIndexEnd64 = rewriter.create<memref::LoadOp>(loc, Ap, c1);
-    Value fixedIndexEnd = rewriter.create<IndexCastOp>(loc, fixedIndexEnd64, indexType);
-    Value cmpColSame = rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, c0, fixedIndexEnd);
+    Value fixedIndexEnd =
+        rewriter.create<IndexCastOp>(loc, fixedIndexEnd64, indexType);
+    Value cmpColSame =
+        rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, c0, fixedIndexEnd);
 
-    scf::IfOp ifBlock_rowTotal = rewriter.create<scf::IfOp>(loc, int64Type, cmpColSame, true);
+    scf::IfOp ifBlock_rowTotal =
+        rewriter.create<scf::IfOp>(loc, int64Type, cmpColSame, true);
     // if cmpColSame
     rewriter.setInsertionPointToStart(ifBlock_rowTotal.thenBlock());
     rewriter.create<scf::YieldOp>(loc, ci0);
@@ -1392,9 +1593,11 @@ private:
     rewriter.setInsertionPointToStart(ifBlock_rowTotal.elseBlock());
     Value total;
     if (mask) {
-      total = computeNumOverlaps(rewriter, nk, Ai, c0, fixedIndexEnd, Bp, Bi, Mi, maskStart, maskEnd, valueType);
+      total = computeNumOverlaps(rewriter, nk, Ai, c0, fixedIndexEnd, Bp, Bi,
+                                 Mi, maskStart, maskEnd, valueType);
     } else {
-      total = computeNumOverlaps(rewriter, nk, Ai, c0, fixedIndexEnd, Bp, Bi, nullptr, c0, size, valueType);
+      total = computeNumOverlaps(rewriter, nk, Ai, c0, fixedIndexEnd, Bp, Bi,
+                                 nullptr, c0, size, valueType);
     }
     rewriter.create<scf::YieldOp>(loc, total);
 
@@ -1406,21 +1609,29 @@ private:
 
     callResizeIndex(rewriter, module, loc, C, c0, nnz);
     callResizeValues(rewriter, module, loc, C, nnz);
-    Value Ci = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, C, c0);
-    Value Cx = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, C);
+    Value Ci = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type,
+                                                           C, c0);
+    Value Cx =
+        rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, C);
 
     // 2nd pass
     //   Compute the nonzero values.
     //   Store in Ci and Cx
-    //   The vector A is the fixed element, while the columns of B are the iteration element
-    Value cmp_cpDifferent = rewriter.create<CmpIOp>(loc, CmpIPredicate::ne, c0, nnz);
-    scf::IfOp ifBlock_cmpDiff = rewriter.create<scf::IfOp>(loc, cmp_cpDifferent);
+    //   The vector A is the fixed element, while the columns of B are the
+    //   iteration element
+    Value cmp_cpDifferent =
+        rewriter.create<CmpIOp>(loc, CmpIPredicate::ne, c0, nnz);
+    scf::IfOp ifBlock_cmpDiff =
+        rewriter.create<scf::IfOp>(loc, cmp_cpDifferent);
     rewriter.setInsertionPointToStart(ifBlock_cmpDiff.thenBlock());
 
     if (mask) {
-      computeInnerProduct(rewriter, nk, Ai, Ax, c0, fixedIndexEnd, Bp, Bi, Bx, Mi, maskStart, maskEnd, valueType, extBlocks, Ci, Cx, c0);
+      computeInnerProduct(rewriter, nk, Ai, Ax, c0, fixedIndexEnd, Bp, Bi, Bx,
+                          Mi, maskStart, maskEnd, valueType, extBlocks, Ci, Cx,
+                          c0);
     } else {
-      computeInnerProduct(rewriter, nk, Ai, Ax, c0, fixedIndexEnd, Bp, Bi, Bx, nullptr, c0, size, valueType, extBlocks, Ci, Cx, c0);
+      computeInnerProduct(rewriter, nk, Ai, Ax, c0, fixedIndexEnd, Bp, Bi, Bx,
+                          nullptr, c0, size, valueType, extBlocks, Ci, Cx, c0);
     }
 
     // end if cmpDiff
@@ -1433,7 +1644,10 @@ private:
     return success();
   }
 
-  LogicalResult rewriteVectorVectorMultiplication(graphblas::MatrixMultiplyGenericOp op, PatternRewriter &rewriter, ExtensionBlocks extBlocks) const {
+  LogicalResult
+  rewriteVectorVectorMultiplication(graphblas::MatrixMultiplyGenericOp op,
+                                    PatternRewriter &rewriter,
+                                    ExtensionBlocks extBlocks) const {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
 
@@ -1457,28 +1671,41 @@ private:
     Value size = rewriter.create<graphblas::SizeOp>(loc, A);
 
     Value C = callEmptyLike(rewriter, module, loc, A);
-    callResizeDim(rewriter, module, loc, C, c0, c1);  // exactly one entry because this is a vector representing a scalar
+    callResizeDim(
+        rewriter, module, loc, C, c0,
+        c1); // exactly one entry because this is a vector representing a scalar
     callResizePointers(rewriter, module, loc, C, c0, c2);
     callResizeIndex(rewriter, module, loc, C, c0, c1);
     callResizeValues(rewriter, module, loc, C, c1);
 
-    Value Ap = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, A, c0);
-    Value Ai = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, A, c0);
-    Value Ax = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, A);
-    Value Bp = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, B, c0);
-    Value Bi = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, B, c0);
-    Value Bx = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, B);
-    Value Ci = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, C, c0);
-    Value Cx = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, C);
+    Value Ap = rewriter.create<sparse_tensor::ToPointersOp>(
+        loc, memref1DI64Type, A, c0);
+    Value Ai = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type,
+                                                           A, c0);
+    Value Ax =
+        rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, A);
+    Value Bp = rewriter.create<sparse_tensor::ToPointersOp>(
+        loc, memref1DI64Type, B, c0);
+    Value Bi = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type,
+                                                           B, c0);
+    Value Bx =
+        rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, B);
+    Value Ci = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type,
+                                                           C, c0);
+    Value Cx =
+        rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, C);
 
     // Single pass
     //   Compute the nonzero values.
     //   Store in Ci and Cx (single-element vector representing a scalar)
-    //   The vector A is the fixed element, while the vector B is treated as the iteration element
+    //   The vector A is the fixed element, while the vector B is treated as the
+    //   iteration element
     Value fixedIndexEnd64 = rewriter.create<memref::LoadOp>(loc, Ap, c1);
-    Value fixedIndexEnd = rewriter.create<IndexCastOp>(loc, fixedIndexEnd64, indexType);
+    Value fixedIndexEnd =
+        rewriter.create<IndexCastOp>(loc, fixedIndexEnd64, indexType);
 
-    computeInnerProduct(rewriter, size, Ai, Ax, c0, fixedIndexEnd, Bp, Bi, Bx, nullptr, c0, c1, valueType, extBlocks, Ci, Cx, c0);
+    computeInnerProduct(rewriter, size, Ai, Ax, c0, fixedIndexEnd, Bp, Bi, Bx,
+                        nullptr, c0, c1, valueType, extBlocks, Ci, Cx, c0);
 
     // extract scalar from C
     Value cScalar = rewriter.create<memref::LoadOp>(loc, Cx, c0);
@@ -1491,11 +1718,18 @@ private:
   }
 };
 
-class LowerMatrixMultiplyReduceToScalarGenericRewrite : public OpRewritePattern<graphblas::MatrixMultiplyReduceToScalarGenericOp> {
+class LowerMatrixMultiplyReduceToScalarGenericRewrite
+    : public OpRewritePattern<
+          graphblas::MatrixMultiplyReduceToScalarGenericOp> {
 public:
-  using OpRewritePattern<graphblas::MatrixMultiplyReduceToScalarGenericOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::MatrixMultiplyReduceToScalarGenericOp op, PatternRewriter &rewriter) const override {
-    ModuleOp module = op->getParentOfType<ModuleOp>(); /* ignore unused variable for debugging */ (void) module;
+  using OpRewritePattern<
+      graphblas::MatrixMultiplyReduceToScalarGenericOp>::OpRewritePattern;
+  LogicalResult
+  matchAndRewrite(graphblas::MatrixMultiplyReduceToScalarGenericOp op,
+                  PatternRewriter &rewriter) const override {
+    ModuleOp module = op->getParentOfType<ModuleOp>(); /* ignore unused variable
+                                                          for debugging */
+    (void)module;
     Location loc = op->getLoc();
 
     // Inputs
@@ -1507,16 +1741,14 @@ public:
     RegionRange extensions = op.extensions();
     ExtensionBlocks extBlocks;
     std::set<graphblas::YieldKind> required = {
-        graphblas::YieldKind::ADD_IDENTITY,
-        graphblas::YieldKind::ADD,
-        graphblas::YieldKind::MULT,
-        graphblas::YieldKind::AGG_IDENTITY,
+        graphblas::YieldKind::ADD_IDENTITY, graphblas::YieldKind::ADD,
+        graphblas::YieldKind::MULT, graphblas::YieldKind::AGG_IDENTITY,
         graphblas::YieldKind::AGG};
     std::set<graphblas::YieldKind> optional = {};
-    LogicalResult extractResult = extBlocks.extractBlocks(op, extensions, required, optional);
+    LogicalResult extractResult =
+        extBlocks.extractBlocks(op, extensions, required, optional);
 
-    if (extractResult.failed())
-    {
+    if (extractResult.failed()) {
       return extractResult;
     }
 
@@ -1534,42 +1766,59 @@ public:
     Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
     Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
     // TODO: make cf0 value dependent on the aggregator
-    Value cf0 = llvm::TypeSwitch<Type, Value>(valueType)
-        .Case<IntegerType>([&](IntegerType type) { return rewriter.create<ConstantIntOp>(loc, 0, type.getWidth()); })
-        .Case<FloatType>([&](FloatType type) { return rewriter.create<ConstantFloatOp>(loc, APFloat(0.0), type); });
+    Value cf0 =
+        llvm::TypeSwitch<Type, Value>(valueType)
+            .Case<IntegerType>([&](IntegerType type) {
+              return rewriter.create<ConstantIntOp>(loc, 0, type.getWidth());
+            })
+            .Case<FloatType>([&](FloatType type) {
+              return rewriter.create<ConstantFloatOp>(loc, APFloat(0.0), type);
+            });
     Value ctrue = rewriter.create<ConstantIntOp>(loc, 1, boolType);
     Value cfalse = rewriter.create<ConstantIntOp>(loc, 0, boolType);
 
     // Get sparse tensor info
-    Value Ap = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, A, c1);
-    Value Aj = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, A, c1);
-    Value Ax = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, A);
-    Value Bp = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, B, c1);
-    Value Bi = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, B, c1);
-    Value Bx = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, B);
+    Value Ap = rewriter.create<sparse_tensor::ToPointersOp>(
+        loc, memref1DI64Type, A, c1);
+    Value Aj = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type,
+                                                           A, c1);
+    Value Ax =
+        rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, A);
+    Value Bp = rewriter.create<sparse_tensor::ToPointersOp>(
+        loc, memref1DI64Type, B, c1);
+    Value Bi = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type,
+                                                           B, c1);
+    Value Bx =
+        rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, B);
 
     Value nrow = rewriter.create<graphblas::NumRowsOp>(loc, A);
     Value ncol = rewriter.create<graphblas::NumColsOp>(loc, B);
-    Value nk = rewriter.create<graphblas::NumColsOp>(loc, A); // guaranteed equal to B.rows
+    Value nk = rewriter.create<graphblas::NumColsOp>(
+        loc, A); // guaranteed equal to B.rows
 
     Value Mp, Mj;
     if (mask) {
-        Mp = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, mask, c1);
-        Mj = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, mask, c1);
+      Mp = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type,
+                                                        mask, c1);
+      Mj = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type,
+                                                       mask, c1);
     }
 
     // In parallel over the rows and columns,
     //   compute the nonzero values and accumulate
-    scf::ParallelOp rowLoop = rewriter.create<scf::ParallelOp>(loc, c0, nrow, c1, cf0);
+    scf::ParallelOp rowLoop =
+        rewriter.create<scf::ParallelOp>(loc, c0, nrow, c1, cf0);
     Value row = rowLoop.getInductionVars()[0];
     rewriter.setInsertionPointToStart(rowLoop.getBody());
 
     Value rowPlus1 = rewriter.create<AddIOp>(loc, row, c1);
     Value apStart64 = rewriter.create<memref::LoadOp>(loc, Ap, row);
     Value apEnd64 = rewriter.create<memref::LoadOp>(loc, Ap, rowPlus1);
-    Value cmp_cpSame = rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, apStart64, apEnd64);
+    Value cmp_cpSame =
+        rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, apStart64, apEnd64);
 
-    scf::IfOp ifBlock_cmpSame = rewriter.create<scf::IfOp>(loc, valueType, cmp_cpSame, true);
+    scf::IfOp ifBlock_cmpSame =
+        rewriter.create<scf::IfOp>(loc, valueType, cmp_cpSame, true);
     // if cmpSame
     rewriter.setInsertionPointToStart(ifBlock_cmpSame.thenBlock());
     rewriter.create<scf::YieldOp>(loc, cf0);
@@ -1584,7 +1833,8 @@ public:
     Value kvec_i1 = rewriter.create<memref::AllocOp>(loc, memref1DBoolType, nk);
     rewriter.create<linalg::FillOp>(loc, cfalse, kvec_i1);
 
-    scf::ParallelOp colLoop1 = rewriter.create<scf::ParallelOp>(loc, colStart, colEnd, c1);
+    scf::ParallelOp colLoop1 =
+        rewriter.create<scf::ParallelOp>(loc, colStart, colEnd, c1);
     Value jj = colLoop1.getInductionVars()[0];
     rewriter.setInsertionPointToStart(colLoop1.getBody());
     Value col64 = rewriter.create<memref::LoadOp>(loc, Aj, jj);
@@ -1599,21 +1849,23 @@ public:
     // Loop thru all columns of B; accumulate values
     scf::ParallelOp colLoop2;
     if (mask) {
-        Value mcolStart64 = rewriter.create<memref::LoadOp>(loc, Mp, row);
-        Value mcolEnd64 = rewriter.create<memref::LoadOp>(loc, Mp, rowPlus1);
-        Value mcolStart = rewriter.create<IndexCastOp>(loc, mcolStart64, indexType);
-        Value mcolEnd = rewriter.create<IndexCastOp>(loc, mcolEnd64, indexType);
+      Value mcolStart64 = rewriter.create<memref::LoadOp>(loc, Mp, row);
+      Value mcolEnd64 = rewriter.create<memref::LoadOp>(loc, Mp, rowPlus1);
+      Value mcolStart =
+          rewriter.create<IndexCastOp>(loc, mcolStart64, indexType);
+      Value mcolEnd = rewriter.create<IndexCastOp>(loc, mcolEnd64, indexType);
 
-        colLoop2 = rewriter.create<scf::ParallelOp>(loc, mcolStart, mcolEnd, c1, cf0);
-        Value mm = colLoop2.getInductionVars()[0];
-        rewriter.setInsertionPointToStart(colLoop2.getBody());
-        col64 = rewriter.create<memref::LoadOp>(loc, Mj, mm);
-        col = rewriter.create<IndexCastOp>(loc, col64, indexType);
+      colLoop2 =
+          rewriter.create<scf::ParallelOp>(loc, mcolStart, mcolEnd, c1, cf0);
+      Value mm = colLoop2.getInductionVars()[0];
+      rewriter.setInsertionPointToStart(colLoop2.getBody());
+      col64 = rewriter.create<memref::LoadOp>(loc, Mj, mm);
+      col = rewriter.create<IndexCastOp>(loc, col64, indexType);
     } else {
-        colLoop2 = rewriter.create<scf::ParallelOp>(loc, c0, ncol, c1, cf0);
-        col = colLoop2.getInductionVars()[0];
-        rewriter.setInsertionPointToStart(colLoop2.getBody());
-        col64 = rewriter.create<IndexCastOp>(loc, col, int64Type);
+      colLoop2 = rewriter.create<scf::ParallelOp>(loc, c0, ncol, c1, cf0);
+      col = colLoop2.getInductionVars()[0];
+      rewriter.setInsertionPointToStart(colLoop2.getBody());
+      col64 = rewriter.create<IndexCastOp>(loc, col, int64Type);
     }
 
     Value colPlus1 = rewriter.create<AddIOp>(loc, col, c1);
@@ -1623,12 +1875,15 @@ public:
     Value iEnd = rewriter.create<IndexCastOp>(loc, iEnd64, indexType);
 
     // insert add identity block
-    graphblas::YieldOp addIdentityYield = llvm::dyn_cast_or_null<graphblas::YieldOp>(extBlocks.addIdentity->getTerminator());
+    graphblas::YieldOp addIdentityYield =
+        llvm::dyn_cast_or_null<graphblas::YieldOp>(
+            extBlocks.addIdentity->getTerminator());
     rewriter.mergeBlocks(extBlocks.addIdentity, rewriter.getBlock(), {});
     Value addIdentity = addIdentityYield.values().front();
     rewriter.eraseOp(addIdentityYield);
 
-    scf::ForOp kLoop = rewriter.create<scf::ForOp>(loc, iStart, iEnd, c1, addIdentity);
+    scf::ForOp kLoop =
+        rewriter.create<scf::ForOp>(loc, iStart, iEnd, c1, addIdentity);
     Value ii = kLoop.getInductionVar();
     Value curr = kLoop.getLoopBody().getArgument(1);
     rewriter.setInsertionPointToStart(kLoop.getBody());
@@ -1636,7 +1891,8 @@ public:
     Value kk64 = rewriter.create<memref::LoadOp>(loc, Bi, ii);
     Value kk = rewriter.create<IndexCastOp>(loc, kk64, indexType);
     Value cmpPair = rewriter.create<memref::LoadOp>(loc, kvec_i1, kk);
-    scf::IfOp ifBlock_cmpPair = rewriter.create<scf::IfOp>(loc, valueType, cmpPair, true);
+    scf::IfOp ifBlock_cmpPair =
+        rewriter.create<scf::IfOp>(loc, valueType, cmpPair, true);
     // if cmpPair
     rewriter.setInsertionPointToStart(ifBlock_cmpPair.thenBlock());
 
@@ -1644,16 +1900,19 @@ public:
     Value bVal = rewriter.create<memref::LoadOp>(loc, Bx, ii);
 
     // insert multiply operation block
-    graphblas::YieldOp multYield = llvm::dyn_cast_or_null<graphblas::YieldOp>(extBlocks.mult->getTerminator());
+    graphblas::YieldOp multYield = llvm::dyn_cast_or_null<graphblas::YieldOp>(
+        extBlocks.mult->getTerminator());
     Value multResult = multYield.values().front();
     rewriter.eraseOp(multYield);
     rewriter.mergeBlocks(extBlocks.mult, rewriter.getBlock(), {aVal, bVal});
 
     // insert add operation block
-    graphblas::YieldOp addYield = llvm::dyn_cast_or_null<graphblas::YieldOp>(extBlocks.add->getTerminator());
+    graphblas::YieldOp addYield = llvm::dyn_cast_or_null<graphblas::YieldOp>(
+        extBlocks.add->getTerminator());
     Value addResult = addYield.values().front();
     rewriter.eraseOp(addYield);
-    rewriter.mergeBlocks(extBlocks.add, rewriter.getBlock(), {curr, multResult});
+    rewriter.mergeBlocks(extBlocks.add, rewriter.getBlock(),
+                         {curr, multResult});
 
     rewriter.create<scf::YieldOp>(loc, addResult);
 
@@ -1679,13 +1938,14 @@ public:
 
     rewriter.setInsertionPointToStart(&colReducer.getRegion().front());
 
-
     Region *aggRegion = extBlocks.agg->getParent();
     BlockAndValueMapping mapper;
-    // Clone blocks into front of region to displace existing entry block, which will be removed
-    // by canonicalization later
-    aggRegion->cloneInto(&colReducer.getRegion(), colReducer.getRegion().begin(), mapper);
-    graphblas::YieldOp colYield = llvm::dyn_cast_or_null<graphblas::YieldOp>(colReducer.getRegion().front().getTerminator());
+    // Clone blocks into front of region to displace existing entry block, which
+    // will be removed by canonicalization later
+    aggRegion->cloneInto(&colReducer.getRegion(),
+                         colReducer.getRegion().begin(), mapper);
+    graphblas::YieldOp colYield = llvm::dyn_cast_or_null<graphblas::YieldOp>(
+        colReducer.getRegion().front().getTerminator());
     Value colAggResult = colYield.values().front();
     rewriter.setInsertionPointAfter(colYield);
     rewriter.create<scf::ReduceReturnOp>(loc, colAggResult);
@@ -1712,10 +1972,12 @@ public:
 
     rewriter.setInsertionPointToStart(&rowReducer.getRegion().front());
 
-    graphblas::YieldOp yield = llvm::dyn_cast_or_null<graphblas::YieldOp>(extBlocks.agg->getTerminator());
+    graphblas::YieldOp yield = llvm::dyn_cast_or_null<graphblas::YieldOp>(
+        extBlocks.agg->getTerminator());
     Value aggResult = yield.values().front();
 
-    // we can safely merge this agg block now, since the previous agg instance was cloned above
+    // we can safely merge this agg block now, since the previous agg instance
+    // was cloned above
     rewriter.mergeBlocks(extBlocks.agg, rewriter.getBlock(), {lhs, rhs});
     rewriter.create<scf::ReduceReturnOp>(loc, aggResult);
     rewriter.eraseOp(yield);
@@ -1734,7 +1996,8 @@ public:
 class LowerUnionRewrite : public OpRewritePattern<graphblas::UnionOp> {
 public:
   using OpRewritePattern<graphblas::UnionOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::UnionOp op, PatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(graphblas::UnionOp op,
+                                PatternRewriter &rewriter) const override {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
 
@@ -1746,12 +2009,13 @@ public:
     // Types
     RankedTensorType aType = a.getType().dyn_cast<RankedTensorType>();
 
-    unsigned rank = aType.getRank();  // ranks guaranteed to be equal
+    unsigned rank = aType.getRank(); // ranks guaranteed to be equal
 
     Value output;
     if (rank == 2) {
       Value outputX = callEmptyLike(rewriter, module, loc, a);
-      computeMatrixElementWise(rewriter, module, a, b, outputX, unionOperator, /* intersect */ false);
+      computeMatrixElementWise(rewriter, module, a, b, outputX, unionOperator,
+                               /* intersect */ false);
       // Convert to same ordering as inputs
       if (typeIsCSR(aType)) {
         output = convertToExternalCSR(rewriter, module, loc, outputX);
@@ -1760,7 +2024,8 @@ public:
       }
     } else {
       output = callEmptyLike(rewriter, module, loc, a);
-      computeVectorElementWise(rewriter, module, a, b, output, unionOperator, /* intersect */ false);
+      computeVectorElementWise(rewriter, module, a, b, output, unionOperator,
+                               /* intersect */ false);
     }
 
     rewriter.replaceOp(op, output);
@@ -1774,7 +2039,8 @@ public:
 class LowerIntersectRewrite : public OpRewritePattern<graphblas::IntersectOp> {
 public:
   using OpRewritePattern<graphblas::IntersectOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::IntersectOp op, PatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(graphblas::IntersectOp op,
+                                PatternRewriter &rewriter) const override {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
 
@@ -1786,12 +2052,13 @@ public:
     // Types
     RankedTensorType aType = a.getType().dyn_cast<RankedTensorType>();
 
-    unsigned rank = aType.getRank();  // ranks guaranteed to be equal
+    unsigned rank = aType.getRank(); // ranks guaranteed to be equal
 
     Value output;
     if (rank == 2) {
       Value outputX = callEmptyLike(rewriter, module, loc, a);
-      computeMatrixElementWise(rewriter, module, a, b, outputX, intersectOperator, /* intersect */ true);
+      computeMatrixElementWise(rewriter, module, a, b, outputX,
+                               intersectOperator, /* intersect */ true);
       // Convert to same ordering as inputs
       if (typeIsCSR(aType)) {
         output = convertToExternalCSR(rewriter, module, loc, outputX);
@@ -1800,7 +2067,8 @@ public:
       }
     } else {
       output = callEmptyLike(rewriter, module, loc, a);
-      computeVectorElementWise(rewriter, module, a, b, output, intersectOperator, /* intersect */ true);
+      computeVectorElementWise(rewriter, module, a, b, output,
+                               intersectOperator, /* intersect */ true);
     }
 
     rewriter.replaceOp(op, output);
@@ -1814,7 +2082,8 @@ public:
 class LowerUpdateRewrite : public OpRewritePattern<graphblas::UpdateOp> {
 public:
   using OpRewritePattern<graphblas::UpdateOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::UpdateOp op, PatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(graphblas::UpdateOp op,
+                                PatternRewriter &rewriter) const override {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
     Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
@@ -1822,7 +2091,8 @@ public:
     // Inputs
     Value input = op.input();
     Value output = op.output();
-    llvm::Optional<llvm::StringRef> accumulateOperator = op.accumulate_operator();
+    llvm::Optional<llvm::StringRef> accumulateOperator =
+        op.accumulate_operator();
     std::string accumulateString;
     if (accumulateOperator) {
       accumulateString = accumulateOperator->str();
@@ -1833,22 +2103,25 @@ public:
     // Types
     RankedTensorType outputType = output.getType().dyn_cast<RankedTensorType>();
 
-    unsigned rank = outputType.getRank();  // ranks guaranteed to be equal
+    unsigned rank = outputType.getRank(); // ranks guaranteed to be equal
 
     if (rank == 2) {
       if (accumulateOperator) {
         if (mask) {
           if (replace) {
             // input -> output(mask) { accumulate, replace }
-            return op.emitError("Update with mask+accumulate+replace is not supported yet");
+            return op.emitError(
+                "Update with mask+accumulate+replace is not supported yet");
           } else {
             // input -> output(mask) { accumulate }
-            return op.emitError("Update with mask+accumulate is not supported yet");
+            return op.emitError(
+                "Update with mask+accumulate is not supported yet");
           }
         } else {
           // input -> output { accumulate, replace? }
           Value temp = callDupTensor(rewriter, module, loc, output);
-          computeMatrixElementWise(rewriter, module, input, temp, output, accumulateString, /* intersect */ false);
+          computeMatrixElementWise(rewriter, module, input, temp, output,
+                                   accumulateString, /* intersect */ false);
           callDelSparseTensor(rewriter, module, loc, temp);
         }
       } else {
@@ -1856,16 +2129,20 @@ public:
           if (replace) {
             // input -> output(mask) { replace }
             // Inefficient; caller should apply mask when input is created
-            return op.emitError("Update with mask+replace is not supported yet");
+            return op.emitError(
+                "Update with mask+replace is not supported yet");
           } else {
             // input -> output(mask)
             // Merges input into output
-            return op.emitError("Update with mask and no accumulator is not supported yet");
+            return op.emitError(
+                "Update with mask and no accumulator is not supported yet");
           }
         } else {
           // input -> output { replace? }
-          // Sort of pointless; caller should simply use input or call graphblas.dup if they want a copy
-          return op.emitError("Update with no accumulator or mask is not supported yet");
+          // Sort of pointless; caller should simply use input or call
+          // graphblas.dup if they want a copy
+          return op.emitError(
+              "Update with no accumulator or mask is not supported yet");
         }
       }
     } else {
@@ -1874,15 +2151,18 @@ public:
         if (mask) {
           if (replace) {
             // input -> output(mask) { accumulate, replace }
-            return op.emitError("Update with mask+accumulate+replace is not supported yet");
+            return op.emitError(
+                "Update with mask+accumulate+replace is not supported yet");
           } else {
             // input -> output(mask) { accumulate }
-            return op.emitError("Update with mask+accumulate is not supported yet");
+            return op.emitError(
+                "Update with mask+accumulate is not supported yet");
           }
         } else {
           // input -> output { accumulate, replace? }
           Value temp = callDupTensor(rewriter, module, loc, output);
-          computeVectorElementWise(rewriter, module, input, temp, output, accumulateString, /* intersect */ false);
+          computeVectorElementWise(rewriter, module, input, temp, output,
+                                   accumulateString, /* intersect */ false);
           callDelSparseTensor(rewriter, module, loc, temp);
         }
       } else {
@@ -1890,16 +2170,20 @@ public:
           if (replace) {
             // input -> output(mask) { replace }
             // Inefficient; caller should apply mask when input is created
-            return op.emitError("Update with mask+replace is not supported yet");
+            return op.emitError(
+                "Update with mask+replace is not supported yet");
           } else {
             // input -> output(mask)
             // Merges input into output
-            return op.emitError("Update with mask and no accumulator is not supported yet");
+            return op.emitError(
+                "Update with mask and no accumulator is not supported yet");
           }
         } else {
           // input -> output { replace? }
-          // Sort of pointless; caller should simply use input or call graphblas.dup if they want a copy
-          return op.emitError("Update with no accumulator or mask is not supported yet");
+          // Sort of pointless; caller should simply use input or call
+          // graphblas.dup if they want a copy
+          return op.emitError(
+              "Update with no accumulator or mask is not supported yet");
         }
       }
     }
@@ -1914,7 +2198,8 @@ public:
 class LowerEqualRewrite : public OpRewritePattern<graphblas::EqualOp> {
 public:
   using OpRewritePattern<graphblas::EqualOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::EqualOp op, PatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(graphblas::EqualOp op,
+                                PatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
 
     // Inputs
@@ -1935,7 +2220,7 @@ public:
     Value cfalse = rewriter.create<ConstantIntOp>(loc, 0, boolType);
     Value ctrue = rewriter.create<ConstantIntOp>(loc, 1, boolType);
 
-    unsigned rank = aType.getRank();  // ranks guaranteed to be equal
+    unsigned rank = aType.getRank(); // ranks guaranteed to be equal
 
     Value dimIndex;
     Value cmpShape;
@@ -1946,8 +2231,10 @@ public:
       Value bNrows = rewriter.create<graphblas::NumRowsOp>(loc, B);
       Value aNcols = rewriter.create<graphblas::NumColsOp>(loc, A);
       Value bNcols = rewriter.create<graphblas::NumColsOp>(loc, B);
-      Value cmpNrows = rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, aNrows, bNrows);
-      Value cmpNcols = rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, aNcols, bNcols);
+      Value cmpNrows =
+          rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, aNrows, bNrows);
+      Value cmpNcols =
+          rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, aNcols, bNcols);
       cmpShape = rewriter.create<AndOp>(loc, cmpNrows, cmpNcols);
     } else {
       // Vector check
@@ -1958,7 +2245,8 @@ public:
       cmpShape = rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, aSize, bSize);
     }
 
-    scf::IfOp ifOuter = rewriter.create<scf::IfOp>(loc, boolType, cmpShape, true);
+    scf::IfOp ifOuter =
+        rewriter.create<scf::IfOp>(loc, boolType, cmpShape, true);
     // if cmpSize
     rewriter.setInsertionPointToStart(ifOuter.thenBlock());
 
@@ -1971,12 +2259,17 @@ public:
     rewriter.setInsertionPointToStart(ifNnz.thenBlock());
 
     // Check index positions and values
-    Value Ai = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, A, dimIndex);
-    Value Bi = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, B, dimIndex);
-    Value Ax = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, A);
-    Value Bx = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, B);
+    Value Ai = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type,
+                                                           A, dimIndex);
+    Value Bi = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type,
+                                                           B, dimIndex);
+    Value Ax =
+        rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, A);
+    Value Bx =
+        rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, B);
 
-    scf::ParallelOp indexLoop = rewriter.create<scf::ParallelOp>(loc, c0, aNnz, c1, ctrue);
+    scf::ParallelOp indexLoop =
+        rewriter.create<scf::ParallelOp>(loc, c0, aNnz, c1, ctrue);
     Value loopIdx = indexLoop.getInductionVars()[0];
     rewriter.setInsertionPointToStart(indexLoop.getBody());
 
@@ -1984,10 +2277,17 @@ public:
     Value bIndex = rewriter.create<memref::LoadOp>(loc, Bi, loopIdx);
     Value aValue = rewriter.create<memref::LoadOp>(loc, Ax, loopIdx);
     Value bValue = rewriter.create<memref::LoadOp>(loc, Bx, loopIdx);
-    Value cmpIndex = rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, aIndex, bIndex);
+    Value cmpIndex =
+        rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, aIndex, bIndex);
     Value cmpValue = llvm::TypeSwitch<Type, Value>(valueType)
-      .Case<IntegerType>([&](IntegerType type) { return rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, aValue, bValue); })
-      .Case<FloatType>([&](FloatType type) { return rewriter.create<CmpFOp>(loc, CmpFPredicate::OEQ, aValue, bValue); });
+                         .Case<IntegerType>([&](IntegerType type) {
+                           return rewriter.create<CmpIOp>(
+                               loc, CmpIPredicate::eq, aValue, bValue);
+                         })
+                         .Case<FloatType>([&](FloatType type) {
+                           return rewriter.create<CmpFOp>(
+                               loc, CmpFPredicate::OEQ, aValue, bValue);
+                         });
     Value cmpCombined = rewriter.create<AndOp>(loc, cmpIndex, cmpValue);
 
     scf::ReduceOp reducer = rewriter.create<scf::ReduceOp>(loc, cmpCombined);
@@ -2021,11 +2321,14 @@ public:
   };
 };
 
-class LowerVectorArgMinMaxOpRewrite : public OpRewritePattern<graphblas::VectorArgMinMaxOp> {
+class LowerVectorArgMinMaxOpRewrite
+    : public OpRewritePattern<graphblas::VectorArgMinMaxOp> {
 public:
   using OpRewritePattern<graphblas::VectorArgMinMaxOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::VectorArgMinMaxOp op, PatternRewriter &rewriter) const override {
-    // TODO we get seg faults if given a size 0 vector or a sparse vector with no non-zero values.
+  LogicalResult matchAndRewrite(graphblas::VectorArgMinMaxOp op,
+                                PatternRewriter &rewriter) const override {
+    // TODO we get seg faults if given a size 0 vector or a sparse vector with
+    // no non-zero values.
     Location loc = op->getLoc();
 
     Value input = op.vec();
@@ -2037,66 +2340,85 @@ public:
     Type int64Type = rewriter.getIntegerType(64);
     Type memref1DI64Type = MemRefType::get({-1}, int64Type);
 
-    Value pointers = rewriter.create<sparse_tensor::ToPointersOp>(loc, memref1DI64Type, input, c0);
+    Value pointers = rewriter.create<sparse_tensor::ToPointersOp>(
+        loc, memref1DI64Type, input, c0);
     Value endPosition64 = rewriter.create<memref::LoadOp>(loc, pointers, c1);
-    Value endPosition = rewriter.create<IndexCastOp>(loc, endPosition64, indexType);
+    Value endPosition =
+        rewriter.create<IndexCastOp>(loc, endPosition64, indexType);
 
     Type inputElementType = inputType.getElementType();
     Type memref1DValueType = MemRefType::get({-1}, inputElementType);
-    Value values = rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, input);
+    Value values = rewriter.create<sparse_tensor::ToValuesOp>(
+        loc, memref1DValueType, input);
 
     Value initialExtremum = rewriter.create<memref::LoadOp>(loc, values, c0);
 
-    scf::ForOp loop = rewriter.create<scf::ForOp>(loc, c1, endPosition, c1, ValueRange{initialExtremum, c0});
+    scf::ForOp loop = rewriter.create<scf::ForOp>(
+        loc, c1, endPosition, c1, ValueRange{initialExtremum, c0});
     Value currentValuePosition = loop.getInductionVar();
     Value currentExtremum = loop.getLoopBody().getArgument(1);
     Value currentExtremumPosition = loop.getLoopBody().getArgument(2);
     rewriter.setInsertionPointToStart(loop.getBody());
 
-    Value currentValue = rewriter.create<memref::LoadOp>(loc, values, currentValuePosition);
+    Value currentValue =
+        rewriter.create<memref::LoadOp>(loc, values, currentValuePosition);
     bool useMinimum = op.minmax().str() == "min";
-    Value replace = llvm::TypeSwitch<Type, Value>(inputElementType)
-      .Case<IntegerType>([&](IntegerType type) {
-			   return rewriter.create<CmpIOp>(loc, useMinimum ? CmpIPredicate::slt : CmpIPredicate::sgt, currentValue, currentExtremum);
-			 })
-      .Case<FloatType>([&](FloatType type) {
-			 return rewriter.create<CmpFOp>(loc, useMinimum ? CmpFPredicate::OLT : CmpFPredicate::OGT, currentValue, currentExtremum);
-		       });
+    Value replace =
+        llvm::TypeSwitch<Type, Value>(inputElementType)
+            .Case<IntegerType>([&](IntegerType type) {
+              return rewriter.create<CmpIOp>(
+                  loc, useMinimum ? CmpIPredicate::slt : CmpIPredicate::sgt,
+                  currentValue, currentExtremum);
+            })
+            .Case<FloatType>([&](FloatType type) {
+              return rewriter.create<CmpFOp>(
+                  loc, useMinimum ? CmpFPredicate::OLT : CmpFPredicate::OGT,
+                  currentValue, currentExtremum);
+            });
 
-    scf::IfOp ifBlock = rewriter.create<scf::IfOp>(loc, TypeRange{inputElementType, indexType}, replace, true);
+    scf::IfOp ifBlock = rewriter.create<scf::IfOp>(
+        loc, TypeRange{inputElementType, indexType}, replace, true);
     rewriter.setInsertionPointToStart(ifBlock.thenBlock());
-    rewriter.create<scf::YieldOp>(loc, ValueRange{currentValue, currentValuePosition});
+    rewriter.create<scf::YieldOp>(
+        loc, ValueRange{currentValue, currentValuePosition});
     rewriter.setInsertionPointToStart(ifBlock.elseBlock());
-    rewriter.create<scf::YieldOp>(loc, ValueRange{currentExtremum, currentExtremumPosition});
+    rewriter.create<scf::YieldOp>(
+        loc, ValueRange{currentExtremum, currentExtremumPosition});
     rewriter.setInsertionPointAfter(ifBlock);
 
     Value nextExtremum = ifBlock.getResult(0);
     Value nextExtremumPosition = ifBlock.getResult(1);
-    rewriter.create<scf::YieldOp>(loc, ValueRange{nextExtremum, nextExtremumPosition});
+    rewriter.create<scf::YieldOp>(
+        loc, ValueRange{nextExtremum, nextExtremumPosition});
 
     rewriter.setInsertionPointAfter(loop);
 
     Value finalExtremumPosition = loop.getResult(1);
-    Value indices = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type, input, c0);
-    Value argExtremum64 = rewriter.create<memref::LoadOp>(loc, indices, finalExtremumPosition);
-    Value argExtremum = rewriter.create<IndexCastOp>(loc, argExtremum64, indexType);
+    Value indices = rewriter.create<sparse_tensor::ToIndicesOp>(
+        loc, memref1DI64Type, input, c0);
+    Value argExtremum64 =
+        rewriter.create<memref::LoadOp>(loc, indices, finalExtremumPosition);
+    Value argExtremum =
+        rewriter.create<IndexCastOp>(loc, argExtremum64, indexType);
     rewriter.replaceOp(op, argExtremum);
 
     return success();
   };
 };
 
-class LowerVectorArgMinOpRewrite : public OpRewritePattern<graphblas::VectorArgMinOp> {
+class LowerVectorArgMinOpRewrite
+    : public OpRewritePattern<graphblas::VectorArgMinOp> {
 public:
   using OpRewritePattern<graphblas::VectorArgMinOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::VectorArgMinOp op, PatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(graphblas::VectorArgMinOp op,
+                                PatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
 
     Value inputTensor = op.vec();
     Type outputType = op->getResultTypes()[0];
 
-    Value newVectorArgMinMaxOp =
-      rewriter.create<graphblas::VectorArgMinMaxOp>(loc, outputType, inputTensor, "min");
+    Value newVectorArgMinMaxOp = rewriter.create<graphblas::VectorArgMinMaxOp>(
+        loc, outputType, inputTensor, "min");
 
     rewriter.replaceOp(op, newVectorArgMinMaxOp);
 
@@ -2104,17 +2426,19 @@ public:
   };
 };
 
-class LowerVectorArgMaxOpRewrite : public OpRewritePattern<graphblas::VectorArgMaxOp> {
+class LowerVectorArgMaxOpRewrite
+    : public OpRewritePattern<graphblas::VectorArgMaxOp> {
 public:
   using OpRewritePattern<graphblas::VectorArgMaxOp>::OpRewritePattern;
-  LogicalResult matchAndRewrite(graphblas::VectorArgMaxOp op, PatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(graphblas::VectorArgMaxOp op,
+                                PatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
 
     Value inputTensor = op.vec();
     Type outputType = op->getResultTypes()[0];
 
-    Value newVectorArgMinMaxOp =
-      rewriter.create<graphblas::VectorArgMinMaxOp>(loc, outputType, inputTensor, "max");
+    Value newVectorArgMinMaxOp = rewriter.create<graphblas::VectorArgMinMaxOp>(
+        loc, outputType, inputTensor, "max");
 
     rewriter.replaceOp(op, newVectorArgMinMaxOp);
 
@@ -2133,35 +2457,23 @@ public:
 };
 
 void populateGraphBLASLoweringPatterns(RewritePatternSet &patterns) {
-  patterns.add<
-      LowerMatrixSelectRewrite,
-      LowerMatrixReduceToVectorRewrite,
-      LowerMatrixReduceToScalarRewrite,
-      LowerMatrixReduceToScalarGenericRewrite,
-      LowerMatrixMultiplyRewrite,
-      LowerConvertLayoutRewrite,
-      LowerTransposeRewrite,
-      LowerMatrixApplyRewrite,
-      LowerMatrixApplyGenericRewrite,
-      LowerMatrixMultiplyReduceToScalarGenericRewrite,
-      LowerMatrixMultiplyGenericRewrite,
-      LowerUnionRewrite,
-      LowerIntersectRewrite,
-      LowerUpdateRewrite,
-      LowerEqualRewrite,
-      LowerVectorArgMinMaxOpRewrite,
-      LowerVectorArgMinOpRewrite,
-      LowerVectorArgMaxOpRewrite,
-      LowerCommentRewrite,
-      LowerSizeRewrite,
-      LowerNumRowsRewrite,
-      LowerNumColsRewrite,
-      LowerNumValsRewrite,
-      LowerDupRewrite
-    >(patterns.getContext());
+  patterns
+      .add<LowerMatrixSelectRewrite, LowerMatrixReduceToVectorRewrite,
+           LowerMatrixReduceToScalarRewrite,
+           LowerMatrixReduceToScalarGenericRewrite, LowerMatrixMultiplyRewrite,
+           LowerConvertLayoutRewrite, LowerTransposeRewrite,
+           LowerMatrixApplyRewrite, LowerMatrixApplyGenericRewrite,
+           LowerMatrixMultiplyReduceToScalarGenericRewrite,
+           LowerMatrixMultiplyGenericRewrite, LowerUnionRewrite,
+           LowerIntersectRewrite, LowerUpdateRewrite, LowerEqualRewrite,
+           LowerVectorArgMinMaxOpRewrite, LowerVectorArgMinOpRewrite,
+           LowerVectorArgMaxOpRewrite, LowerCommentRewrite, LowerSizeRewrite,
+           LowerNumRowsRewrite, LowerNumColsRewrite, LowerNumValsRewrite,
+           LowerDupRewrite>(patterns.getContext());
 }
 
-struct GraphBLASLoweringPass : public GraphBLASLoweringBase<GraphBLASLoweringPass> {
+struct GraphBLASLoweringPass
+    : public GraphBLASLoweringBase<GraphBLASLoweringPass> {
   void runOnOperation() override {
     MLIRContext *ctx = &getContext();
     RewritePatternSet patterns(ctx);
@@ -2172,19 +2484,14 @@ struct GraphBLASLoweringPass : public GraphBLASLoweringBase<GraphBLASLoweringPas
   }
 };
 
-void populateGraphBLASStructuralizePatterns(RewritePatternSet &patterns)
-{
-  patterns.add<
-      LowerMatrixMultiplyRewrite,
-      LowerMatrixApplyRewrite,
-      LowerMatrixReduceToScalarRewrite
-      >(patterns.getContext());
+void populateGraphBLASStructuralizePatterns(RewritePatternSet &patterns) {
+  patterns.add<LowerMatrixMultiplyRewrite, LowerMatrixApplyRewrite,
+               LowerMatrixReduceToScalarRewrite>(patterns.getContext());
 }
 
-struct GraphBLASStructuralizePass : public GraphBLASStructuralizeBase<GraphBLASStructuralizePass>
-{
-  void runOnOperation() override
-  {
+struct GraphBLASStructuralizePass
+    : public GraphBLASStructuralizeBase<GraphBLASStructuralizePass> {
+  void runOnOperation() override {
     MLIRContext *ctx = &getContext();
     RewritePatternSet patterns(ctx);
     ConversionTarget target(*ctx);
@@ -2198,7 +2505,7 @@ std::unique_ptr<OperationPass<ModuleOp>> mlir::createGraphBLASLoweringPass() {
   return std::make_unique<GraphBLASLoweringPass>();
 }
 
-std::unique_ptr<OperationPass<ModuleOp>> mlir::createGraphBLASStructuralizePass()
-{
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::createGraphBLASStructuralizePass() {
   return std::make_unique<GraphBLASStructuralizePass>();
 }

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASUtils.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASUtils.cpp
@@ -1,12 +1,12 @@
+#include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include "mlir/Dialect/StandardOps/IR/Ops.h"
-#include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "llvm/ADT/TypeSwitch.h"
-#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/None.h"
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 #include "GraphBLAS/GraphBLASOps.h"
 #include "GraphBLAS/GraphBLASUtils.h"
@@ -17,32 +17,34 @@ using namespace mlir::sparse_tensor;
 
 bool typeIsCSX(Type inputType) {
   sparse_tensor::SparseTensorEncodingAttr inputSparseEncoding =
-    sparse_tensor::getSparseTensorEncoding(inputType);
+      sparse_tensor::getSparseTensorEncoding(inputType);
 
   if (!inputSparseEncoding)
     return false;
-  
+
   AffineMap inputDimOrdering = inputSparseEncoding.getDimOrdering();
-  if (inputDimOrdering) 
+  if (inputDimOrdering)
     return false;
-  
-  llvm::ArrayRef<SparseTensorEncodingAttr::DimLevelType> dlt = inputSparseEncoding.getDimLevelType();
+
+  llvm::ArrayRef<SparseTensorEncodingAttr::DimLevelType> dlt =
+      inputSparseEncoding.getDimLevelType();
   if (dlt.size() != 2)
     return false;
-  
+
   return true;
 }
 
 bool typeIsCSR(Type inputType) {
 
   sparse_tensor::SparseTensorEncodingAttr inputSparseEncoding =
-    sparse_tensor::getSparseTensorEncoding(inputType);
-  
+      sparse_tensor::getSparseTensorEncoding(inputType);
+
   if (!inputSparseEncoding)
     return false;
-  
+
   AffineMap inputDimOrdering = inputSparseEncoding.getDimOrdering();
-  if (!inputDimOrdering) // if inputDimOrdering.map != nullptr ; i.e. if the dimOrdering exists
+  if (!inputDimOrdering) // if inputDimOrdering.map != nullptr ; i.e. if the
+                         // dimOrdering exists
     return false;
   if (inputDimOrdering.getNumDims() != 2) {
     return false;
@@ -52,12 +54,15 @@ bool typeIsCSR(Type inputType) {
     if (inputDimOrdering0 != 0 || inputDimOrdering1 != 1)
       return false;
   }
-  llvm::ArrayRef<SparseTensorEncodingAttr::DimLevelType> dlt = inputSparseEncoding.getDimLevelType();
+  llvm::ArrayRef<SparseTensorEncodingAttr::DimLevelType> dlt =
+      inputSparseEncoding.getDimLevelType();
   if (dlt.size() != 2) {
     return false;
   } else {
-    if (dlt[0] != sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Dense
-        || dlt[1] != sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Compressed)
+    if (dlt[0] !=
+            sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Dense ||
+        dlt[1] !=
+            sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Compressed)
       return false;
   }
 
@@ -66,13 +71,14 @@ bool typeIsCSR(Type inputType) {
 
 bool typeIsCSC(Type inputType) {
   sparse_tensor::SparseTensorEncodingAttr inputSparseEncoding =
-    sparse_tensor::getSparseTensorEncoding(inputType);
-  
+      sparse_tensor::getSparseTensorEncoding(inputType);
+
   if (!inputSparseEncoding)
     return false;
-  
+
   AffineMap inputDimOrdering = inputSparseEncoding.getDimOrdering();
-  if (!inputDimOrdering) // if inputDimOrdering.map != nullptr ; i.e. if the dimOrdering exists
+  if (!inputDimOrdering) // if inputDimOrdering.map != nullptr ; i.e. if the
+                         // dimOrdering exists
     return false;
   if (inputDimOrdering.getNumDims() != 2) {
     return false;
@@ -82,21 +88,23 @@ bool typeIsCSC(Type inputType) {
     if (inputDimOrdering0 != 1 || inputDimOrdering1 != 0)
       return false;
   }
-  
-  llvm::ArrayRef<SparseTensorEncodingAttr::DimLevelType> dlt = inputSparseEncoding.getDimLevelType();
+
+  llvm::ArrayRef<SparseTensorEncodingAttr::DimLevelType> dlt =
+      inputSparseEncoding.getDimLevelType();
   if (dlt.size() != 2) {
     return false;
   } else {
-    if (dlt[0] != sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Dense
-        || dlt[1] != sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Compressed)
+    if (dlt[0] !=
+            sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Dense ||
+        dlt[1] !=
+            sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Compressed)
       return false;
   }
-  
+
   return true;
 }
 
-int64_t getRank(Type inputType)
-{
+int64_t getRank(Type inputType) {
   mlir::sparse_tensor::SparseTensorEncodingAttr sparseEncoding =
       mlir::sparse_tensor::getSparseTensorEncoding(inputType);
   if (!sparseEncoding)
@@ -106,130 +114,131 @@ int64_t getRank(Type inputType)
   return inputTensorType.getRank();
 }
 
-int64_t getRank(Value inputValue)
-{
+int64_t getRank(Value inputValue) {
   Type inputType = inputValue.getType();
   return getRank(inputType);
 }
 
 // make Compressed Vector type
-RankedTensorType getCompressedVectorType(MLIRContext *context, ArrayRef<int64_t> shape, Type valueType)
-{
-    SmallVector<sparse_tensor::SparseTensorEncodingAttr::DimLevelType, 1> dlt;
-    dlt.push_back(sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Compressed);
-    unsigned ptr = 64;
-    unsigned ind = 64;
-    AffineMap map = {};
+RankedTensorType getCompressedVectorType(MLIRContext *context,
+                                         ArrayRef<int64_t> shape,
+                                         Type valueType) {
+  SmallVector<sparse_tensor::SparseTensorEncodingAttr::DimLevelType, 1> dlt;
+  dlt.push_back(
+      sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Compressed);
+  unsigned ptr = 64;
+  unsigned ind = 64;
+  AffineMap map = {};
 
-    RankedTensorType rtt = RankedTensorType::get(
-        shape,
-        valueType,
-        sparse_tensor::SparseTensorEncodingAttr::get(context, dlt, map, ptr, ind));
+  RankedTensorType rtt =
+      RankedTensorType::get(shape, valueType,
+                            sparse_tensor::SparseTensorEncodingAttr::get(
+                                context, dlt, map, ptr, ind));
 
-    return rtt;
+  return rtt;
 }
 
 // make CSX tensor type
-RankedTensorType getCSXTensorType(MLIRContext *context, ArrayRef<int64_t> shape, Type valueType)
-{
-    SmallVector<sparse_tensor::SparseTensorEncodingAttr::DimLevelType, 2> dlt;
-    dlt.push_back(sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Dense);
-    dlt.push_back(sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Compressed);
-    unsigned ptr = 64;
-    unsigned ind = 64;
-    AffineMap map = {};
-    
-    RankedTensorType rtt = RankedTensorType::get(
-        shape,
-        valueType,
-        sparse_tensor::SparseTensorEncodingAttr::get(context, dlt, map, ptr, ind));
-    
-    return rtt;
+RankedTensorType getCSXTensorType(MLIRContext *context, ArrayRef<int64_t> shape,
+                                  Type valueType) {
+  SmallVector<sparse_tensor::SparseTensorEncodingAttr::DimLevelType, 2> dlt;
+  dlt.push_back(sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Dense);
+  dlt.push_back(
+      sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Compressed);
+  unsigned ptr = 64;
+  unsigned ind = 64;
+  AffineMap map = {};
+
+  RankedTensorType rtt =
+      RankedTensorType::get(shape, valueType,
+                            sparse_tensor::SparseTensorEncodingAttr::get(
+                                context, dlt, map, ptr, ind));
+
+  return rtt;
 }
 
 // make CSR tensor type
-RankedTensorType getCSRTensorType(MLIRContext *context, ArrayRef<int64_t> shape, Type valueType)
-{
-    SmallVector<sparse_tensor::SparseTensorEncodingAttr::DimLevelType, 2> dlt;
-    dlt.push_back(sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Dense);
-    dlt.push_back(sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Compressed);
-    unsigned ptr = 64;
-    unsigned ind = 64;
-    AffineMap map = AffineMap::getMultiDimIdentityMap(2, context);
+RankedTensorType getCSRTensorType(MLIRContext *context, ArrayRef<int64_t> shape,
+                                  Type valueType) {
+  SmallVector<sparse_tensor::SparseTensorEncodingAttr::DimLevelType, 2> dlt;
+  dlt.push_back(sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Dense);
+  dlt.push_back(
+      sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Compressed);
+  unsigned ptr = 64;
+  unsigned ind = 64;
+  AffineMap map = AffineMap::getMultiDimIdentityMap(2, context);
 
-    RankedTensorType rtt = RankedTensorType::get(
-        shape,
-        valueType,
-        sparse_tensor::SparseTensorEncodingAttr::get(context, dlt, map, ptr, ind));
+  RankedTensorType rtt =
+      RankedTensorType::get(shape, valueType,
+                            sparse_tensor::SparseTensorEncodingAttr::get(
+                                context, dlt, map, ptr, ind));
 
-    return rtt;
+  return rtt;
 }
 
 // make CSC tensor type
-RankedTensorType getCSCTensorType(MLIRContext *context, ArrayRef<int64_t> shape, Type valueType)
-{
-    SmallVector<sparse_tensor::SparseTensorEncodingAttr::DimLevelType, 2> dlt;
-    dlt.push_back(sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Dense);
-    dlt.push_back(sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Compressed);
-    unsigned ptr = 64;
-    unsigned ind = 64;
-    AffineMap map = AffineMap::getPermutationMap(ArrayRef<unsigned>{1, 0}, context);
+RankedTensorType getCSCTensorType(MLIRContext *context, ArrayRef<int64_t> shape,
+                                  Type valueType) {
+  SmallVector<sparse_tensor::SparseTensorEncodingAttr::DimLevelType, 2> dlt;
+  dlt.push_back(sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Dense);
+  dlt.push_back(
+      sparse_tensor::SparseTensorEncodingAttr::DimLevelType::Compressed);
+  unsigned ptr = 64;
+  unsigned ind = 64;
+  AffineMap map =
+      AffineMap::getPermutationMap(ArrayRef<unsigned>{1, 0}, context);
 
-    RankedTensorType rtt = RankedTensorType::get(
-        shape,
-        valueType,
-        sparse_tensor::SparseTensorEncodingAttr::get(context, dlt, map, ptr, ind));
+  RankedTensorType rtt =
+      RankedTensorType::get(shape, valueType,
+                            sparse_tensor::SparseTensorEncodingAttr::get(
+                                context, dlt, map, ptr, ind));
 
-    return rtt;
+  return rtt;
 }
 
 /// Returns function reference (first hit also inserts into module).
-// from: llvm/llvm-project/mlir/lib/Dialect/SparseTensor/Transforms/SparseTensorConversion.cpp
-static FlatSymbolRefAttr getFunc(ModuleOp &mod, Location &loc, StringRef name, TypeRange result,
-                                 TypeRange operands)
-{
-    MLIRContext *context = mod.getContext();
-    FuncOp func = mod.lookupSymbol<FuncOp>(name);
-    if (!func)
-    {
-        OpBuilder moduleBuilder(mod.getBodyRegion());
-        moduleBuilder
-            .create<FuncOp>(loc, name,
-                            FunctionType::get(context, operands, result))
-            .setPrivate();
-    }
-    return SymbolRefAttr::get(context, name);
+// from:
+// llvm/llvm-project/mlir/lib/Dialect/SparseTensor/Transforms/SparseTensorConversion.cpp
+static FlatSymbolRefAttr getFunc(ModuleOp &mod, Location &loc, StringRef name,
+                                 TypeRange result, TypeRange operands) {
+  MLIRContext *context = mod.getContext();
+  FuncOp func = mod.lookupSymbol<FuncOp>(name);
+  if (!func) {
+    OpBuilder moduleBuilder(mod.getBodyRegion());
+    moduleBuilder
+        .create<FuncOp>(loc, name, FunctionType::get(context, operands, result))
+        .setPrivate();
+  }
+  return SymbolRefAttr::get(context, name);
 }
 
-Value convertToExternalCSX(OpBuilder &builder, ModuleOp &mod, Location loc, Value input)
-{
+Value convertToExternalCSX(OpBuilder &builder, ModuleOp &mod, Location loc,
+                           Value input) {
   MLIRContext *context = mod.getContext();
   RankedTensorType inputType = input.getType().dyn_cast<RankedTensorType>();
   if (typeIsCSX(inputType))
     return input;
-  
+
   llvm::ArrayRef<int64_t> inputShape = inputType.getShape();
   Type inputTensorValueType = inputType.getElementType();
-  RankedTensorType csxType = getCSXTensorType(context, inputShape, inputTensorValueType);
+  RankedTensorType csxType =
+      getCSXTensorType(context, inputShape, inputTensorValueType);
   FlatSymbolRefAttr castFuncSymbol;
   if (typeIsCSC(inputType))
     castFuncSymbol = getFunc(mod, loc, "cast_csc_to_csx", csxType, inputType);
   else if (typeIsCSR(inputType))
     castFuncSymbol = getFunc(mod, loc, "cast_csr_to_csx", csxType, inputType);
-  else 
+  else
     assert(false && "Unexpected tensor type.");
-  CallOp castCallOp = builder.create<CallOp>(loc,
-                                             castFuncSymbol,
-                                             csxType,
-                                             llvm::ArrayRef<Value>({input})
-                                             );
+  CallOp castCallOp = builder.create<CallOp>(loc, castFuncSymbol, csxType,
+                                             llvm::ArrayRef<Value>({input}));
 
   Value result = castCallOp->getResult(0);
   return result;
 }
 
-Value convertToExternalCSR(OpBuilder &builder, ModuleOp &mod, Location loc, Value input)
-{
+Value convertToExternalCSR(OpBuilder &builder, ModuleOp &mod, Location loc,
+                           Value input) {
   // Cast the tensor to the CSR type that our external functions expect
   // since these are passed via opaque pointer (ultimately) to these functions
   // this is OK.
@@ -242,24 +251,23 @@ Value convertToExternalCSR(OpBuilder &builder, ModuleOp &mod, Location loc, Valu
     input = convertToExternalCSX(builder, mod, loc, input);
     inputType = input.getType().dyn_cast<RankedTensorType>();
   }
-  
+
   // all external calls are currently for unknown size float64 tensors
   llvm::ArrayRef<int64_t> inputShape = inputType.getShape();
   Type inputTensorValueType = inputType.getElementType();
-  RankedTensorType csrType = getCSRTensorType(context, inputShape, inputTensorValueType); 
-  FlatSymbolRefAttr castFuncSymbol = getFunc(mod, loc, "cast_csx_to_csr", csrType, inputType);
-  CallOp castCallOp = builder.create<CallOp>(loc,
-                                             castFuncSymbol,
-                                             csrType,
-                                             llvm::ArrayRef<Value>({input})
-                                             );
+  RankedTensorType csrType =
+      getCSRTensorType(context, inputShape, inputTensorValueType);
+  FlatSymbolRefAttr castFuncSymbol =
+      getFunc(mod, loc, "cast_csx_to_csr", csrType, inputType);
+  CallOp castCallOp = builder.create<CallOp>(loc, castFuncSymbol, csrType,
+                                             llvm::ArrayRef<Value>({input}));
 
   Value result = castCallOp->getResult(0);
   return result;
 }
 
-Value convertToExternalCSC(OpBuilder &builder, ModuleOp &mod, Location loc, Value input)
-{
+Value convertToExternalCSC(OpBuilder &builder, ModuleOp &mod, Location loc,
+                           Value input) {
   MLIRContext *context = mod.getContext();
   RankedTensorType inputType = input.getType().dyn_cast<RankedTensorType>();
   if (typeIsCSC(inputType))
@@ -269,66 +277,65 @@ Value convertToExternalCSC(OpBuilder &builder, ModuleOp &mod, Location loc, Valu
     input = convertToExternalCSX(builder, mod, loc, input);
     inputType = input.getType().dyn_cast<RankedTensorType>();
   }
-  
+
   llvm::ArrayRef<int64_t> inputShape = inputType.getShape();
   Type inputTensorValueType = inputType.getElementType();
-  RankedTensorType cscType = getCSCTensorType(context, inputShape, inputTensorValueType); 
-  FlatSymbolRefAttr castFuncSymbol = getFunc(mod, loc, "cast_csx_to_csc", cscType, inputType);
-  CallOp castCallOp = builder.create<CallOp>(loc,
-                                             castFuncSymbol,
-                                             cscType,
-                                             llvm::ArrayRef<Value>({input})
-                                             );
+  RankedTensorType cscType =
+      getCSCTensorType(context, inputShape, inputTensorValueType);
+  FlatSymbolRefAttr castFuncSymbol =
+      getFunc(mod, loc, "cast_csx_to_csc", cscType, inputType);
+  CallOp castCallOp = builder.create<CallOp>(loc, castFuncSymbol, cscType,
+                                             llvm::ArrayRef<Value>({input}));
 
   Value result = castCallOp->getResult(0);
   return result;
 }
 
-void callDelSparseTensor(OpBuilder &builder, ModuleOp &mod, Location loc, Value tensor) {
-  RankedTensorType inputTensorType = tensor.getType().dyn_cast<RankedTensorType>();
+void callDelSparseTensor(OpBuilder &builder, ModuleOp &mod, Location loc,
+                         Value tensor) {
+  RankedTensorType inputTensorType =
+      tensor.getType().dyn_cast<RankedTensorType>();
   int64_t rank = inputTensorType.getRank();
 
   std::string funcName;
-  if (rank == 2)
-  {
+  if (rank == 2) {
     tensor = convertToExternalCSX(builder, mod, loc, tensor);
     funcName = "delSparseMatrix";
-  }
-  else
-  {
+  } else {
     funcName = "delSparseVector";
   }
   Type tensorType = tensor.getType();
 
-  FlatSymbolRefAttr func = getFunc(mod, loc, funcName, ArrayRef<Type>({}), tensorType);
+  FlatSymbolRefAttr func =
+      getFunc(mod, loc, funcName, ArrayRef<Type>({}), tensorType);
   builder.create<mlir::CallOp>(loc, func, TypeRange(), tensor);
   return;
 }
 
-mlir::Value callEmptyLike(OpBuilder &builder, ModuleOp &mod, Location loc, Value tensor) {
-  RankedTensorType inputTensorType = tensor.getType().dyn_cast<RankedTensorType>();
+mlir::Value callEmptyLike(OpBuilder &builder, ModuleOp &mod, Location loc,
+                          Value tensor) {
+  RankedTensorType inputTensorType =
+      tensor.getType().dyn_cast<RankedTensorType>();
   int64_t rank = inputTensorType.getRank();
 
   std::string funcName;
-  if (rank == 2)
-  {
+  if (rank == 2) {
     tensor = convertToExternalCSX(builder, mod, loc, tensor);
     funcName = "matrix_empty_like";
-  }
-  else
-  {
+  } else {
     funcName = "vector_empty_like";
   }
   Type tensorType = tensor.getType();
 
   FlatSymbolRefAttr func = getFunc(mod, loc, funcName, tensorType, tensorType);
-  mlir::CallOp callOpResult = builder.create<mlir::CallOp>(loc, func, tensorType, tensor);
+  mlir::CallOp callOpResult =
+      builder.create<mlir::CallOp>(loc, func, tensorType, tensor);
   Value result = callOpResult->getResult(0);
   return result;
 }
 
-mlir::Value callEmpty(OpBuilder &builder, ModuleOp &mod, Location loc, Value inputTensor,
-		      ArrayRef<int64_t> resultShape) {
+mlir::Value callEmpty(OpBuilder &builder, ModuleOp &mod, Location loc,
+                      Value inputTensor, ArrayRef<int64_t> resultShape) {
   Type inputType = inputTensor.getType();
   RankedTensorType inputTensorType = inputType.dyn_cast<RankedTensorType>();
   int64_t inputTensorRank = inputTensorType.getRank();
@@ -336,7 +343,7 @@ mlir::Value callEmpty(OpBuilder &builder, ModuleOp &mod, Location loc, Value inp
     inputTensor = convertToExternalCSX(builder, mod, loc, inputTensor);
     inputType = inputTensor.getType();
   }
-  
+
   int64_t ndims = resultShape.size();
   std::string funcName;
   if (ndims == 2) {
@@ -344,152 +351,151 @@ mlir::Value callEmpty(OpBuilder &builder, ModuleOp &mod, Location loc, Value inp
   } else {
     funcName = "vector_empty";
   }
-  
+
   MLIRContext *context = mod.getContext();
   Type indexType = builder.getIndexType();
-  
+
   Type elementType = inputTensorType.getElementType();
-  Type outputTensorType = getCompressedVectorType(context, resultShape, elementType);
-  
-  FlatSymbolRefAttr func = getFunc(mod, loc, funcName, TypeRange{outputTensorType},
-				   TypeRange{inputType, indexType});
+  Type outputTensorType =
+      getCompressedVectorType(context, resultShape, elementType);
+
+  FlatSymbolRefAttr func =
+      getFunc(mod, loc, funcName, TypeRange{outputTensorType},
+              TypeRange{inputType, indexType});
 
   Value c_ndims = builder.create<ConstantIndexOp>(loc, ndims);
-  mlir::CallOp callOpResult =
-    builder.create<mlir::CallOp>(loc, func, outputTensorType, ArrayRef<Value>({inputTensor, c_ndims}));
-    
+  mlir::CallOp callOpResult = builder.create<mlir::CallOp>(
+      loc, func, outputTensorType, ArrayRef<Value>({inputTensor, c_ndims}));
+
   Value result = callOpResult->getResult(0);
 
   return result;
 }
 
-mlir::Value callDupTensor(OpBuilder &builder, ModuleOp &mod, Location loc, Value tensor) {
-  RankedTensorType inputTensorType = tensor.getType().dyn_cast<RankedTensorType>();
+mlir::Value callDupTensor(OpBuilder &builder, ModuleOp &mod, Location loc,
+                          Value tensor) {
+  RankedTensorType inputTensorType =
+      tensor.getType().dyn_cast<RankedTensorType>();
   int64_t rank = inputTensorType.getRank();
 
   std::string funcName;
-  if (rank == 2)
-  {
+  if (rank == 2) {
     tensor = convertToExternalCSX(builder, mod, loc, tensor);
     funcName = "dup_matrix";
-  }
-  else
-  {
+  } else {
     funcName = "dup_vector";
   }
   Type tensorType = tensor.getType();
 
   FlatSymbolRefAttr func = getFunc(mod, loc, funcName, tensorType, tensorType);
-    mlir::CallOp callOpResult = builder.create<mlir::CallOp>(loc, func, tensorType, tensor);
-    Value result = callOpResult->getResult(0);
-    return result;
-  
+  mlir::CallOp callOpResult =
+      builder.create<mlir::CallOp>(loc, func, tensorType, tensor);
+  Value result = callOpResult->getResult(0);
+  return result;
 }
 
 mlir::CallOp callResizeDim(OpBuilder &builder, ModuleOp &mod, Location loc,
-                           Value tensor, Value d, Value size)
-{
-  RankedTensorType inputTensorType = tensor.getType().dyn_cast<RankedTensorType>();
+                           Value tensor, Value d, Value size) {
+  RankedTensorType inputTensorType =
+      tensor.getType().dyn_cast<RankedTensorType>();
   int64_t rank = inputTensorType.getRank();
 
   std::string funcName;
-  if (rank == 2)
-  {
+  if (rank == 2) {
     tensor = convertToExternalCSX(builder, mod, loc, tensor);
     funcName = "matrix_resize_dim";
-  }
-  else
-  {
+  } else {
     funcName = "vector_resize_dim";
   }
   Type tensorType = tensor.getType();
 
   Type indexType = builder.getIndexType();
-  FlatSymbolRefAttr func = getFunc(mod, loc, funcName, TypeRange(), {tensorType, indexType, indexType});
-  mlir::CallOp result = builder.create<mlir::CallOp>(loc, func, TypeRange(), ArrayRef<Value>({tensor, d, size}));
+  FlatSymbolRefAttr func = getFunc(mod, loc, funcName, TypeRange(),
+                                   {tensorType, indexType, indexType});
+  mlir::CallOp result = builder.create<mlir::CallOp>(
+      loc, func, TypeRange(), ArrayRef<Value>({tensor, d, size}));
 
   return result;
 }
 
 mlir::CallOp callResizePointers(OpBuilder &builder, ModuleOp &mod, Location loc,
-                                Value tensor, Value d, Value size)
-{
-  RankedTensorType inputTensorType = tensor.getType().dyn_cast<RankedTensorType>();
+                                Value tensor, Value d, Value size) {
+  RankedTensorType inputTensorType =
+      tensor.getType().dyn_cast<RankedTensorType>();
   int64_t rank = inputTensorType.getRank();
 
   std::string funcName;
-  if (rank == 2)
-  {
+  if (rank == 2) {
     tensor = convertToExternalCSX(builder, mod, loc, tensor);
     funcName = "matrix_resize_pointers";
-  }
-  else
-  {
+  } else {
     funcName = "vector_resize_pointers";
   }
   Type tensorType = tensor.getType();
 
   Type indexType = builder.getIndexType();
-  FlatSymbolRefAttr func = getFunc(mod, loc, funcName, TypeRange(), {tensorType, indexType, indexType});
-  mlir::CallOp result = builder.create<mlir::CallOp>(loc, func, TypeRange(), ArrayRef<Value>({tensor, d, size}));
+  FlatSymbolRefAttr func = getFunc(mod, loc, funcName, TypeRange(),
+                                   {tensorType, indexType, indexType});
+  mlir::CallOp result = builder.create<mlir::CallOp>(
+      loc, func, TypeRange(), ArrayRef<Value>({tensor, d, size}));
 
   return result;
 }
 
 mlir::CallOp callResizeIndex(OpBuilder &builder, ModuleOp &mod, Location loc,
-                             Value tensor, Value d, Value size)
-{
-  RankedTensorType inputTensorType = tensor.getType().dyn_cast<RankedTensorType>();
+                             Value tensor, Value d, Value size) {
+  RankedTensorType inputTensorType =
+      tensor.getType().dyn_cast<RankedTensorType>();
   int64_t rank = inputTensorType.getRank();
 
   std::string funcName;
-  if (rank == 2)
-  {
+  if (rank == 2) {
     tensor = convertToExternalCSX(builder, mod, loc, tensor);
     funcName = "matrix_resize_index";
-  }
-  else
-  {
+  } else {
     funcName = "vector_resize_index";
   }
   Type tensorType = tensor.getType();
 
   Type indexType = builder.getIndexType();
-  FlatSymbolRefAttr func = getFunc(mod, loc, funcName, TypeRange(), {tensorType, indexType, indexType});
-  mlir::CallOp result = builder.create<mlir::CallOp>(loc, func, TypeRange(), ArrayRef<Value>({tensor, d, size}));
+  FlatSymbolRefAttr func = getFunc(mod, loc, funcName, TypeRange(),
+                                   {tensorType, indexType, indexType});
+  mlir::CallOp result = builder.create<mlir::CallOp>(
+      loc, func, TypeRange(), ArrayRef<Value>({tensor, d, size}));
 
   return result;
 }
 
 mlir::CallOp callResizeValues(OpBuilder &builder, ModuleOp &mod, Location loc,
-                              Value tensor, Value size)
-{
-  RankedTensorType inputTensorType = tensor.getType().dyn_cast<RankedTensorType>();
+                              Value tensor, Value size) {
+  RankedTensorType inputTensorType =
+      tensor.getType().dyn_cast<RankedTensorType>();
   int64_t rank = inputTensorType.getRank();
 
   std::string funcName;
-  if (rank == 2)
-  {
+  if (rank == 2) {
     tensor = convertToExternalCSX(builder, mod, loc, tensor);
     funcName = "matrix_resize_values";
-  }
-  else
-  {
+  } else {
     funcName = "vector_resize_values";
   }
   Type tensorType = tensor.getType();
 
   Type indexType = builder.getIndexType();
-  FlatSymbolRefAttr func = getFunc(mod, loc, funcName, TypeRange(), {tensorType, indexType});
-  mlir::CallOp result = builder.create<mlir::CallOp>(loc, func, TypeRange(), ArrayRef<Value>({tensor, size}));
+  FlatSymbolRefAttr func =
+      getFunc(mod, loc, funcName, TypeRange(), {tensorType, indexType});
+  mlir::CallOp result = builder.create<mlir::CallOp>(
+      loc, func, TypeRange(), ArrayRef<Value>({tensor, size}));
 
   return result;
 }
 
-void cleanupIntermediateTensor(OpBuilder &builder, ModuleOp &mod, Location loc, Value tensor) {
+void cleanupIntermediateTensor(OpBuilder &builder, ModuleOp &mod, Location loc,
+                               Value tensor) {
   // Clean up sparse tensor unless it is returned by the function
-  Block * outputBlock = tensor.getParentBlock();
-  ReturnOp lastStatement = llvm::dyn_cast_or_null<ReturnOp>(outputBlock->getTerminator());
+  Block *outputBlock = tensor.getParentBlock();
+  ReturnOp lastStatement =
+      llvm::dyn_cast_or_null<ReturnOp>(outputBlock->getTerminator());
   bool toDelete = true;
   if (lastStatement != nullptr) {
     for (Value result : lastStatement->getOperands()) {
@@ -505,31 +511,31 @@ void cleanupIntermediateTensor(OpBuilder &builder, ModuleOp &mod, Location loc, 
   }
 }
 
-LogicalResult ExtensionBlocks::extractBlocks(Operation *op, RegionRange &regions,
-                                             const std::set<graphblas::YieldKind> &required,
-                                             const std::set<graphblas::YieldKind> &optional)
-{
+LogicalResult
+ExtensionBlocks::extractBlocks(Operation *op, RegionRange &regions,
+                               const std::set<graphblas::YieldKind> &required,
+                               const std::set<graphblas::YieldKind> &optional) {
   std::set<graphblas::YieldKind> allowed(required);
   allowed.insert(optional.begin(), optional.end());
   std::set<graphblas::YieldKind> seen;
 
-  for (Region *ext : regions)
-  {
+  for (Region *ext : regions) {
     Block &block = ext->front();
-    graphblas::YieldOp yield = llvm::dyn_cast_or_null<graphblas::YieldOp>(block.getTerminator());
-    if (yield == nullptr)
-    {
+    graphblas::YieldOp yield =
+        llvm::dyn_cast_or_null<graphblas::YieldOp>(block.getTerminator());
+    if (yield == nullptr) {
       // must have graphblas.yield as terminator
-      return op->emitError("extension blocks must have a graphblas.yield terminator");
+      return op->emitError(
+          "extension blocks must have a graphblas.yield terminator");
     }
 
     graphblas::YieldKind kind = yield.kind();
     if (allowed.count(kind) == 0) {
-      return op->emitError("extension block " + stringifyYieldKind(kind) + " not allowed for this op");
+      return op->emitError("extension block " + stringifyYieldKind(kind) +
+                           " not allowed for this op");
     }
 
-    switch (kind)
-    {
+    switch (kind) {
     case graphblas::YieldKind::TRANSFORM_IN_A:
       this->transformInA = &block;
       break;
@@ -571,7 +577,8 @@ LogicalResult ExtensionBlocks::extractBlocks(Operation *op, RegionRange &regions
 
   for (auto requiredKind : required) {
     if (seen.count(requiredKind) != 1) {
-      return op->emitError("required extension block " + stringifyYieldKind(requiredKind) + " not found");
+      return op->emitError("required extension block " +
+                           stringifyYieldKind(requiredKind) + " not found");
     }
   }
 
@@ -580,36 +587,45 @@ LogicalResult ExtensionBlocks::extractBlocks(Operation *op, RegionRange &regions
 
 LogicalResult populateSemiringAdd(OpBuilder &builder, Location loc,
                                   StringRef addName, Type valueType,
-                                  RegionRange regions)
-{
-  // This function must match the options supported by GraphBLASOps.cpp::checkSemiringAdd()
+                                  RegionRange regions) {
+  // This function must match the options supported by
+  // GraphBLASOps.cpp::checkSemiringAdd()
 
   // Insert additive identity
   Region *addIdentityRegion = regions[0];
   Value addIdentity;
   /*Block *addIdentityBlock = */ builder.createBlock(addIdentityRegion, {}, {});
-  if (addName == "plus" || addName == "any")
-  {
+  if (addName == "plus" || addName == "any") {
     // Add identity
-    addIdentity = llvm::TypeSwitch<Type, Value>(valueType)
-                      .Case<IntegerType>([&](IntegerType type)
-                                         { return builder.create<ConstantIntOp>(loc, 0, type.getWidth()); })
-                      .Case<FloatType>([&](FloatType type)
-                                       { return builder.create<ConstantFloatOp>(loc, APFloat(0.0), type); });
+    addIdentity =
+        llvm::TypeSwitch<Type, Value>(valueType)
+            .Case<IntegerType>([&](IntegerType type) {
+              return builder.create<ConstantIntOp>(loc, 0, type.getWidth());
+            })
+            .Case<FloatType>([&](FloatType type) {
+              return builder.create<ConstantFloatOp>(loc, APFloat(0.0), type);
+            });
+  } else if (addName == "min") {
+    addIdentity =
+        llvm::TypeSwitch<Type, Value>(valueType)
+            .Case<IntegerType>([&](IntegerType type) {
+              return builder.create<ConstantOp>(
+                  loc,
+                  builder.getIntegerAttr(
+                      valueType, APInt::getSignedMaxValue(type.getWidth())));
+            })
+            .Case<FloatType>([&](FloatType type) {
+              return builder.create<ConstantOp>(
+                  loc, builder.getFloatAttr(
+                           valueType, APFloat::getLargest(
+                                          type.getFloatSemantics(), false)));
+            });
+  } else {
+    return addIdentityRegion->getParentOp()->emitError(
+        "\"" + addName + "\" is not a supported semiring add.");
   }
-  else if (addName == "min")
-  {
-    addIdentity = llvm::TypeSwitch<Type, Value>(valueType)
-                      .Case<IntegerType>([&](IntegerType type)
-                                         { return builder.create<ConstantOp>(loc, builder.getIntegerAttr(valueType, APInt::getSignedMaxValue(type.getWidth()))); })
-                      .Case<FloatType>([&](FloatType type)
-                                       { return builder.create<ConstantOp>(loc, builder.getFloatAttr(valueType, APFloat::getLargest(type.getFloatSemantics(), false))); });
-  }
-  else
-  {
-    return addIdentityRegion->getParentOp()->emitError("\"" + addName + "\" is not a supported semiring add.");
-  }
-  builder.create<graphblas::YieldOp>(loc, graphblas::YieldKind::ADD_IDENTITY, addIdentity);
+  builder.create<graphblas::YieldOp>(loc, graphblas::YieldKind::ADD_IDENTITY,
+                                     addIdentity);
 
   // Insert additive operation
   Region *addRegion = regions[1];
@@ -617,33 +633,34 @@ LogicalResult populateSemiringAdd(OpBuilder &builder, Location loc,
   Value addBlockArg0 = addBlock->getArgument(0);
   Value addBlockArg1 = addBlock->getArgument(1);
   Value addResult;
-  if (addName == "plus")
-  {
+  if (addName == "plus") {
     // Insert add operation
-    addResult = llvm::TypeSwitch<Type, Value>(valueType)
-                    .Case<IntegerType>([&](IntegerType type)
-                                       { return builder.create<AddIOp>(loc, addBlockArg0, addBlockArg1); })
-                    .Case<FloatType>([&](FloatType type)
-                                     { return builder.create<AddFOp>(loc, addBlockArg0, addBlockArg1); });
-  }
-  else if (addName == "min")
-  {
+    addResult =
+        llvm::TypeSwitch<Type, Value>(valueType)
+            .Case<IntegerType>([&](IntegerType type) {
+              return builder.create<AddIOp>(loc, addBlockArg0, addBlockArg1);
+            })
+            .Case<FloatType>([&](FloatType type) {
+              return builder.create<AddFOp>(loc, addBlockArg0, addBlockArg1);
+            });
+  } else if (addName == "min") {
     Value cmp = llvm::TypeSwitch<Type, Value>(valueType)
-                    .Case<IntegerType>([&](IntegerType type)
-                                       { return builder.create<CmpIOp>(loc, CmpIPredicate::slt, addBlockArg0, addBlockArg1); })
-                    .Case<FloatType>([&](FloatType type)
-                                     { return builder.create<CmpFOp>(loc, CmpFPredicate::OLT, addBlockArg0, addBlockArg1); });
+                    .Case<IntegerType>([&](IntegerType type) {
+                      return builder.create<CmpIOp>(loc, CmpIPredicate::slt,
+                                                    addBlockArg0, addBlockArg1);
+                    })
+                    .Case<FloatType>([&](FloatType type) {
+                      return builder.create<CmpFOp>(loc, CmpFPredicate::OLT,
+                                                    addBlockArg0, addBlockArg1);
+                    });
     addResult = builder.create<SelectOp>(loc, cmp, addBlockArg0, addBlockArg1);
-  }
-  else if (addName == "any")
-  {
+  } else if (addName == "any") {
     // Same as "second" for multiplicative op?
     // https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/master/GraphBLAS/Source/Template/GB_binop_factory.c#L243-L244
     addResult = addBlockArg1;
-  }
-  else
-  {
-    return addRegion->getParentOp()->emitError("\"" + addName + "\" is not a supported semiring add.");
+  } else {
+    return addRegion->getParentOp()->emitError(
+        "\"" + addName + "\" is not a supported semiring add.");
   }
   builder.create<graphblas::YieldOp>(loc, graphblas::YieldKind::ADD, addResult);
 
@@ -651,74 +668,73 @@ LogicalResult populateSemiringAdd(OpBuilder &builder, Location loc,
 }
 
 LogicalResult populateSemiringMultiply(OpBuilder &builder, Location loc,
-                                      StringRef multiplyName, Type valueType,
-                                      RegionRange regions)
-{
-  // This function must match the options supported by GraphBLASOps.cpp::checkSemiringMultiply()
+                                       StringRef multiplyName, Type valueType,
+                                       RegionRange regions) {
+  // This function must match the options supported by
+  // GraphBLASOps.cpp::checkSemiringMultiply()
 
   // Insert multiplicative operation
   Region *multRegion = regions[0];
-  Block *multBlock = builder.createBlock(multRegion, {}, {valueType, valueType});
+  Block *multBlock =
+      builder.createBlock(multRegion, {}, {valueType, valueType});
   Value multBlockArg0 = multBlock->getArgument(0);
   Value multBlockArg1 = multBlock->getArgument(1);
   Value multResult;
 
-  if (multiplyName == "pair")
-  {
-    multResult = llvm::TypeSwitch<Type, Value>(valueType)
-                     .Case<IntegerType>([&](IntegerType type)
-                                        { return builder.create<ConstantIntOp>(loc, 1, type.getWidth()); })
-                     .Case<FloatType>([&](FloatType type)
-                                      { return builder.create<ConstantFloatOp>(loc, APFloat(1.0), type); });
-  }
-  else if (multiplyName == "times")
-  {
-    multResult = llvm::TypeSwitch<Type, Value>(valueType)
-                     .Case<IntegerType>([&](IntegerType type)
-                                        { return builder.create<MulIOp>(loc, multBlockArg0, multBlockArg1); })
-                     .Case<FloatType>([&](FloatType type)
-                                      { return builder.create<MulFOp>(loc, multBlockArg0, multBlockArg1); });
-  }
-  else if (multiplyName == "plus")
-  {
-    multResult = llvm::TypeSwitch<Type, Value>(valueType)
-                     .Case<IntegerType>([&](IntegerType type)
-                                        { return builder.create<AddIOp>(loc, multBlockArg0, multBlockArg1); })
-                     .Case<FloatType>([&](FloatType type)
-                                      { return builder.create<AddFOp>(loc, multBlockArg0, multBlockArg1); });
-  }
-  else if (multiplyName == "first")
-  {
+  if (multiplyName == "pair") {
+    multResult =
+        llvm::TypeSwitch<Type, Value>(valueType)
+            .Case<IntegerType>([&](IntegerType type) {
+              return builder.create<ConstantIntOp>(loc, 1, type.getWidth());
+            })
+            .Case<FloatType>([&](FloatType type) {
+              return builder.create<ConstantFloatOp>(loc, APFloat(1.0), type);
+            });
+  } else if (multiplyName == "times") {
+    multResult =
+        llvm::TypeSwitch<Type, Value>(valueType)
+            .Case<IntegerType>([&](IntegerType type) {
+              return builder.create<MulIOp>(loc, multBlockArg0, multBlockArg1);
+            })
+            .Case<FloatType>([&](FloatType type) {
+              return builder.create<MulFOp>(loc, multBlockArg0, multBlockArg1);
+            });
+  } else if (multiplyName == "plus") {
+    multResult =
+        llvm::TypeSwitch<Type, Value>(valueType)
+            .Case<IntegerType>([&](IntegerType type) {
+              return builder.create<AddIOp>(loc, multBlockArg0, multBlockArg1);
+            })
+            .Case<FloatType>([&](FloatType type) {
+              return builder.create<AddFOp>(loc, multBlockArg0, multBlockArg1);
+            });
+  } else if (multiplyName == "first") {
     multResult = multBlockArg0;
-  }
-  else if (multiplyName == "second")
-  {
+  } else if (multiplyName == "second") {
     multResult = multBlockArg1;
+  } else {
+    return multRegion->getParentOp()->emitError(
+        "\"" + multiplyName + "\" is not a supported semiring multiply.");
   }
-  else
-  {
-    return multRegion->getParentOp()->emitError("\"" + multiplyName + "\" is not a supported semiring multiply.");
-  }
-  builder.create<graphblas::YieldOp>(loc, graphblas::YieldKind::MULT, multResult);
+  builder.create<graphblas::YieldOp>(loc, graphblas::YieldKind::MULT,
+                                     multResult);
 
   return success();
 }
 
 LogicalResult populateSemiringRegions(OpBuilder &builder, Location loc,
                                       StringRef semiring, Type valueType,
-                                      RegionRange regions)
-{
+                                      RegionRange regions) {
   auto semiringParts = semiring.split('_');
 
-  if (failed(populateSemiringAdd(builder, loc,
-                                 semiringParts.first, valueType,
+  if (failed(populateSemiringAdd(builder, loc, semiringParts.first, valueType,
                                  regions.slice(0, 2))))
     return failure();
 
-  if (failed(populateSemiringMultiply(builder, loc,
-                                     semiringParts.second, valueType,
-                                     regions.slice(2, 1) /* no multiply identity block currently */)))
+  if (failed(populateSemiringMultiply(
+          builder, loc, semiringParts.second, valueType,
+          regions.slice(2, 1) /* no multiply identity block currently */)))
     return failure();
 
-  return success();                 
+  return success();
 }


### PR DESCRIPTION
Quick manual execution of clang-format (re: #123) to bring the existing C++ into the LLVM style.  We shouldn't use clang-format on SparseUtils.cpp, as we want that to stay as close to upstream as possible, and sparse_utils.cpp, which is generated Cython code.

Going to fast-track this into the repo so future PRs can be based on it.  Automatic clang-format verification will be added to CI in a subsequent PR.