### PR TITLE
Fix mlir_graphblas/src/test/GraphBLAS/invalid_apply.mlir test failures

### DIFF
--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
@@ -328,7 +328,7 @@ def GraphBLAS_ApplyOp : GraphBLAS_Op<"apply", [NoSideEffect]> {
         ```
     }];
 
-    let arguments = (ins GraphBlasMatrixOperand:$input, AnyType:$thunk, StrAttr:$apply_operator);
+    let arguments = (ins GraphBlasMatrixOrVectorOperand:$input, AnyType:$thunk, StrAttr:$apply_operator);
     let results = (outs AnyTensor:$output);
     
     let assemblyFormat = [{


### PR DESCRIPTION
`mlir_graphblas/src/test/GraphBLAS/invalid_apply.mlir` was having some test failures because `graphblas.apply` wasn't accepting vectors. Those tests now pass.