### PR TITLE
Fix segfault in test_ir_reduce_to_vector

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -54,6 +54,7 @@ jobs:
         run: |
           conda install -c conda-forge coveralls
           coveralls --service=github
+        continue-on-error: true
       - name: Conda Build
         run: |
           conda build -c metagraph/label/dev -c conda-forge --python ${{ matrix.pyver }} continuous_integration/conda # temp restriction to use metagraph dev label

--- a/mlir_graphblas/tests/test_mlir_builder.py
+++ b/mlir_graphblas/tests/test_mlir_builder.py
@@ -704,12 +704,12 @@ REDUCE_TO_VECTOR_CASES = [
         "tensor<?xf64, #SparseVec64>",
         id="csr_arbitrary",
     ),
-    # pytest.param(
-    #     "tensor<?x?xf64, #CSC64>",
-    #     "tensor<?xf64, #SparseVec64>",
-    #     "tensor<?xf64, #SparseVec64>",
-    #     id="csc_arbitrary",
-    # ), # TODO make this work
+    pytest.param(
+        "tensor<?x?xf64, #CSC64>",
+        "tensor<?xf64, #SparseVec64>",
+        "tensor<?xf64, #SparseVec64>",
+        id="csc_arbitrary",
+    ),
 ]
 
 
@@ -780,6 +780,12 @@ def test_ir_reduce_to_vector(
         reduced_rows_clamped,
         reduced_columns_clamped,
     ) = reduce_func(input_tensor)
+
+    assert reduced_rows.shape == (5,)
+    assert reduced_columns.shape == (4,)
+    assert reduced_rows_clamped.shape == (5,)
+    assert reduced_columns_clamped.shape == (4,)
+
     reduced_rows = engine.sparse_vec_densify5(reduced_rows)
     reduced_columns = engine.sparse_vec_densify4(reduced_columns)
     reduced_rows_clamped = engine.sparse_vec_densify5(reduced_rows_clamped)


### PR DESCRIPTION
The segfault in `test_ir_reduce_to_vector` was caused by an incorrect dim size. 

Using `engine.sparse_vec_densify4` ignored the dim size of the sparse tensor because it blindly assumed that the size of the input tensor was 4. 

Implementing https://github.com/metagraph-dev/mlir-graphblas/issues/122 will have made us aware of this issue sooner, so that ticket might be more strongly motivated now.