### PR TITLE
Move allowed semiring names to a global near the other globals.

### DIFF
--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
@@ -359,16 +359,18 @@ def GraphBLAS_MatrixMultiplyOp : GraphBLAS_Op<"matrix_multiply", [NoSideEffect]>
     let summary = "matrix multiply operation with an optional structural mask";
     let description = [{
         Performs a matrix multiply according to the given semiring and optional
-        structural mask.  The semiring must be one of "plus_times", "plus_pair", or
-        "plus_plus".  The given sparse tensors must be a matrix (i.e. rank 2) or a
-        vector (i.e. rank 1).  If the first input is a matrix, it must be CSR format.
-        If the second input is a matrix, it must be CSC format.  Matrix times vector
-        will return a vector.  Vector times matrix will return a vector.  Matrix times
-        matrix will return a CSR matrix.  The mask (if provided) must be the same
-        format as the returned object.  This operation also accepts an optional region
-        that specifies element-wise postprocessing to be done on the result of the
-        matrix multiplication.  The region must use `graphblas.yield` to indicate the
-        result of the element-wise postprocessing.
+        structural mask.  The semiring must be a string of the form "<ADD_NAME>_<MUL_NAME>",
+        e.g. "plus_times". The options for "<ADD_NAME>" are "plus", "any", and "min". The
+        options for "<MUL_NAME>" are "pair", "times", "plus", "first", and "second". The
+        given sparse tensors must be a matrix (i.e. rank 2) or a vector (i.e. rank 1).
+        If the first input is a matrix, it must be CSR format. If the second input
+        is a matrix, it must be CSC format.  Matrix times vector will return a vector.
+        Vector times matrix will return a vector.  Matrix times matrix will return
+        a CSR matrix.  The mask (if provided) must be the same format as the returned
+        object.  This operation also accepts an optional region that specifies
+        element-wise postprocessing to be done on the result of the matrix multiplication.
+        The region must use `graphblas.yield` to indicate the result of the element-wise
+        postprocessing.
 
         No Mask Example:
         ```mlir

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
@@ -18,8 +18,13 @@ static const llvm::StringSet<> supportedUnionOperators{"plus", "min", "times"};
 static const llvm::StringSet<> supportedUpdateAccumulateOperators{"plus",
                                                                   "min"};
 
-static const llvm::StringSet<> supportedSemirings{"plus_times", "plus_pair",
-                                                  "plus_plus", "min_plus"};
+// These must match the options supported by
+// GraphBLASUtils.cpp::populateSemiringAdd()
+static const llvm::StringSet<> supportedSemiringAddNames{"plus", "any", "min"};
+// These must match the options supported by
+// GraphBLASUtils.cpp::populateSemiringMultiply()
+static const llvm::StringSet<> supportedSemiringMultiplyNames{
+    "pair", "times", "plus", "first", "second"};
 
 static const llvm::StringSet<> supportedReduceAggregators{"plus"};
 

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOps.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOps.cpp
@@ -113,10 +113,7 @@ static llvm::Optional<std::string> checkCompressedVector(Type inputType,
 }
 
 static llvm::Optional<std::string> checkSemiringAdd(StringRef addName) {
-  // This must match the options supported by
-  // GraphBLASUtils.cpp::populateSemiringAdd()
-  llvm::StringSet<> allowed = {"plus", "any", "min"};
-  if (!allowed.contains(addName))
+  if (!supportedSemiringAddNames.contains(addName))
     return "\"" + addName.str() + "\" is not a supported semiring add.";
   else
     return llvm::None;
@@ -124,10 +121,7 @@ static llvm::Optional<std::string> checkSemiringAdd(StringRef addName) {
 
 static llvm::Optional<std::string>
 checkSemiringMultiply(StringRef multiplyName) {
-  // This must match the options supported by
-  // GraphBLASUtils.cpp::populateSemiringMultiply()
-  llvm::StringSet<> allowed = {"pair", "times", "plus", "first", "second"};
-  if (!allowed.contains(multiplyName))
+  if (!supportedSemiringMultiplyNames.contains(multiplyName))
     return "\"" + multiplyName.str() +
            "\" is not a supported semiring multiply.";
   else

--- a/mlir_graphblas/src/test/GraphBLAS/check_ops.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/check_ops.mlir
@@ -112,6 +112,8 @@ module {
 
 module {
 
+    // COM: TODO as part of https://github.com/metagraph-dev/mlir-graphblas/issues/66 , handle all posssible semirings here.
+
     // CHECK: func @matrix_multiply_plus_times(%[[ARGA:.*]]: [[CSR_TYPE_A:tensor<.*->.*>]], %[[ARGB:.*]]: [[CSC_TYPE_B:tensor<.*->.*>]]) -> [[RETURN_TYPE:tensor<.*->.*>]] {
     func @matrix_multiply_plus_times(%argA: tensor<2x3xi64, #CSR64>, %argB: tensor<3x2xi64, #CSC64>) -> tensor<2x2xi64, #CSR64> {
         // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.matrix_multiply %[[ARGA]], %[[ARGB]] {semiring = "plus_times"} : ([[CSR_TYPE_A]], [[CSC_TYPE_B]]) to [[RETURN_TYPE]]

--- a/mlir_graphblas/src/test/GraphBLAS/structuralize_semirings.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/structuralize_semirings.mlir
@@ -14,6 +14,8 @@
   indexBitWidth = 64
 }>
 
+// COM: TODO as part of https://github.com/metagraph-dev/mlir-graphblas/issues/66 , handle all posssible semirings here.
+
 // additive operations
 
 // CHECK-LABEL:   builtin.func @matrix_multiply_plus_X(


### PR DESCRIPTION
This moves the semiring names used in `mlir_graphblas/src/lib/GraphBLAS/GraphBLASOps.cpp` to `mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h` so that all the globals are in the same place.