### PR TITLE
Additional operators for union and intersect

### DIFF
--- a/mlir_graphblas/engine.py
+++ b/mlir_graphblas/engine.py
@@ -150,12 +150,11 @@ def return_tensor_to_ctypes(
         else:
             pointer_type = "uint64"
             index_type = "uint64"
-        value_type = {
-            "i32": "int32",
-            "i64": "int64",
-            "f32": "float32",
-            "f64": "float64",
-        }[tensor_type.element_type.dump()]
+
+        if isinstance(tensor_type.element_type, mlir.astnodes.IntegerType):
+            value_type = f"int{tensor_type.element_type.width}"
+        else:
+            value_type = f"float{tensor_type.element_type.type.name[1:]}"
 
         def decoder(arg, ptype=pointer_type, itype=index_type, vtype=value_type) -> int:
             ptr = ctypes.cast(arg, ctypes.c_void_p).value

--- a/mlir_graphblas/functions.py
+++ b/mlir_graphblas/functions.py
@@ -236,7 +236,7 @@ class MatrixReduceToScalar(BaseFunction):
 
     _valid_aggregators = {"plus"}
     _agg_aliases = {
-        "plus": "plus",
+        "sum": "plus",
     }
 
     def __init__(self, aggregator="plus"):

--- a/mlir_graphblas/ops.py
+++ b/mlir_graphblas/ops.py
@@ -307,7 +307,7 @@ class GraphBLAS_Transpose(BaseOp):
 class GraphBLAS_Update(BaseOp):
     dialect = "graphblas"
     name = "update"
-    allowed_accumulators = {"plus", "min"}
+    allowed_accumulators = {"plus", "times", "min", "max"}
 
     @classmethod
     def call(cls, irbuilder, input, output, accumulate="plus"):

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
@@ -10,13 +10,13 @@
 #include <set>
 #include <string>
 
-static const llvm::StringSet<> supportedIntersectOperators{"plus", "min",
-                                                           "times"};
+static const llvm::StringSet<> supportedIntersectOperators{"plus", "minus", "times", "div", "min", "max", "first", "second"};
+                                                           //"eq", "ne", "lt", "le", "gt", "ge"};
 
-static const llvm::StringSet<> supportedUnionOperators{"plus", "min", "times"};
+static const llvm::StringSet<> supportedUnionOperators{"plus", "times", "min", "max", "first", "second"};
 
-static const llvm::StringSet<> supportedUpdateAccumulateOperators{"plus",
-                                                                  "min"};
+static const llvm::StringSet<> supportedUpdateAccumulateOperators{"plus", "times",
+                                                                  "min", "max"};
 
 // These must match the options supported by
 // GraphBLASUtils.cpp::populateSemiringAdd()

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
@@ -10,13 +10,15 @@
 #include <set>
 #include <string>
 
-static const llvm::StringSet<> supportedIntersectOperators{"plus", "minus", "times", "div", "min", "max", "first", "second"};
-                                                           //"eq", "ne", "lt", "le", "gt", "ge"};
+static const llvm::StringSet<> supportedIntersectOperators{
+    "plus", "minus", "times", "div", "min", "max", "first", "second"};
+//"eq", "ne", "lt", "le", "gt", "ge"};
 
-static const llvm::StringSet<> supportedUnionOperators{"plus", "times", "min", "max", "first", "second"};
+static const llvm::StringSet<> supportedUnionOperators{
+    "plus", "times", "min", "max", "first", "second"};
 
-static const llvm::StringSet<> supportedUpdateAccumulateOperators{"plus", "times",
-                                                                  "min", "max"};
+static const llvm::StringSet<> supportedUpdateAccumulateOperators{
+    "plus", "times", "min", "max"};
 
 // These must match the options supported by
 // GraphBLASUtils.cpp::populateSemiringAdd()

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASArrayUtils.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASArrayUtils.cpp
@@ -620,20 +620,36 @@ Value computeUnionAggregation(PatternRewriter &rewriter, bool intersect,
   Value aggVal;
   if (agg == "plus") {
     aggVal = llvm::TypeSwitch<Type, Value>(valueType)
-        .Case<IntegerType>([&](IntegerType type) { return rewriter.create<AddIOp>(loc, newValA, newValB); })
-        .Case<FloatType>([&](FloatType type) { return rewriter.create<AddFOp>(loc, newValA, newValB); });
+                 .Case<IntegerType>([&](IntegerType type) {
+                   return rewriter.create<AddIOp>(loc, newValA, newValB);
+                 })
+                 .Case<FloatType>([&](FloatType type) {
+                   return rewriter.create<AddFOp>(loc, newValA, newValB);
+                 });
   } else if (agg == "minus") {
     aggVal = llvm::TypeSwitch<Type, Value>(valueType)
-        .Case<IntegerType>([&](IntegerType type) { return rewriter.create<SubIOp>(loc, newValA, newValB); })
-        .Case<FloatType>([&](FloatType type) { return rewriter.create<SubFOp>(loc, newValA, newValB); });
+                 .Case<IntegerType>([&](IntegerType type) {
+                   return rewriter.create<SubIOp>(loc, newValA, newValB);
+                 })
+                 .Case<FloatType>([&](FloatType type) {
+                   return rewriter.create<SubFOp>(loc, newValA, newValB);
+                 });
   } else if (agg == "times") {
     aggVal = llvm::TypeSwitch<Type, Value>(valueType)
-        .Case<IntegerType>([&](IntegerType type) { return rewriter.create<MulIOp>(loc, newValA, newValB); })
-        .Case<FloatType>([&](FloatType type) { return rewriter.create<MulFOp>(loc, newValA, newValB); });
+                 .Case<IntegerType>([&](IntegerType type) {
+                   return rewriter.create<MulIOp>(loc, newValA, newValB);
+                 })
+                 .Case<FloatType>([&](FloatType type) {
+                   return rewriter.create<MulFOp>(loc, newValA, newValB);
+                 });
   } else if (agg == "div") {
     aggVal = llvm::TypeSwitch<Type, Value>(valueType)
-        .Case<IntegerType>([&](IntegerType type) { return rewriter.create<SignedDivIOp>(loc, newValA, newValB); })
-        .Case<FloatType>([&](FloatType type) { return rewriter.create<DivFOp>(loc, newValA, newValB); });
+                 .Case<IntegerType>([&](IntegerType type) {
+                   return rewriter.create<SignedDivIOp>(loc, newValA, newValB);
+                 })
+                 .Case<FloatType>([&](FloatType type) {
+                   return rewriter.create<DivFOp>(loc, newValA, newValB);
+                 });
   } else if (agg == "min") {
     Value cmp = llvm::TypeSwitch<Type, Value>(valueType)
                     .Case<IntegerType>([&](IntegerType type) {
@@ -647,10 +663,14 @@ Value computeUnionAggregation(PatternRewriter &rewriter, bool intersect,
     aggVal = rewriter.create<SelectOp>(loc, cmp, newValA, newValB);
   } else if (agg == "max") {
     Value cmp = llvm::TypeSwitch<Type, Value>(valueType)
-                    .Case<IntegerType>([&](IntegerType type)
-                                       { return rewriter.create<CmpIOp>(loc, CmpIPredicate::sgt, newValA, newValB); })
-                    .Case<FloatType>([&](FloatType type)
-                                       { return rewriter.create<CmpFOp>(loc, CmpFPredicate::OGT, newValA, newValB); });
+                    .Case<IntegerType>([&](IntegerType type) {
+                      return rewriter.create<CmpIOp>(loc, CmpIPredicate::sgt,
+                                                     newValA, newValB);
+                    })
+                    .Case<FloatType>([&](FloatType type) {
+                      return rewriter.create<CmpFOp>(loc, CmpFPredicate::OGT,
+                                                     newValA, newValB);
+                    });
     aggVal = rewriter.create<SelectOp>(loc, cmp, newValA, newValB);
   } else if (agg == "first") {
     aggVal = newValA;
@@ -658,40 +678,64 @@ Value computeUnionAggregation(PatternRewriter &rewriter, bool intersect,
     aggVal = newValB;
   } else if (agg == "eq") {
     aggVal = llvm::TypeSwitch<Type, Value>(valueType)
-                 .Case<IntegerType>([&](IntegerType type)
-                                    { return rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, newValA, newValB); })
-                 .Case<FloatType>([&](FloatType type)
-                                    { return rewriter.create<CmpFOp>(loc, CmpFPredicate::OEQ, newValA, newValB); });
+                 .Case<IntegerType>([&](IntegerType type) {
+                   return rewriter.create<CmpIOp>(loc, CmpIPredicate::eq,
+                                                  newValA, newValB);
+                 })
+                 .Case<FloatType>([&](FloatType type) {
+                   return rewriter.create<CmpFOp>(loc, CmpFPredicate::OEQ,
+                                                  newValA, newValB);
+                 });
   } else if (agg == "ne") {
     aggVal = llvm::TypeSwitch<Type, Value>(valueType)
-                 .Case<IntegerType>([&](IntegerType type)
-                                    { return rewriter.create<CmpIOp>(loc, CmpIPredicate::ne, newValA, newValB); })
-                 .Case<FloatType>([&](FloatType type)
-                                    { return rewriter.create<CmpFOp>(loc, CmpFPredicate::ONE, newValA, newValB); });
+                 .Case<IntegerType>([&](IntegerType type) {
+                   return rewriter.create<CmpIOp>(loc, CmpIPredicate::ne,
+                                                  newValA, newValB);
+                 })
+                 .Case<FloatType>([&](FloatType type) {
+                   return rewriter.create<CmpFOp>(loc, CmpFPredicate::ONE,
+                                                  newValA, newValB);
+                 });
   } else if (agg == "lt") {
     aggVal = llvm::TypeSwitch<Type, Value>(valueType)
-                 .Case<IntegerType>([&](IntegerType type)
-                                    { return rewriter.create<CmpIOp>(loc, CmpIPredicate::slt, newValA, newValB); })
-                 .Case<FloatType>([&](FloatType type)
-                                    { return rewriter.create<CmpFOp>(loc, CmpFPredicate::OLT, newValA, newValB); });
+                 .Case<IntegerType>([&](IntegerType type) {
+                   return rewriter.create<CmpIOp>(loc, CmpIPredicate::slt,
+                                                  newValA, newValB);
+                 })
+                 .Case<FloatType>([&](FloatType type) {
+                   return rewriter.create<CmpFOp>(loc, CmpFPredicate::OLT,
+                                                  newValA, newValB);
+                 });
   } else if (agg == "le") {
     aggVal = llvm::TypeSwitch<Type, Value>(valueType)
-                 .Case<IntegerType>([&](IntegerType type)
-                                    { return rewriter.create<CmpIOp>(loc, CmpIPredicate::sle, newValA, newValB); })
-                 .Case<FloatType>([&](FloatType type)
-                                    { return rewriter.create<CmpFOp>(loc, CmpFPredicate::OLE, newValA, newValB); });
+                 .Case<IntegerType>([&](IntegerType type) {
+                   return rewriter.create<CmpIOp>(loc, CmpIPredicate::sle,
+                                                  newValA, newValB);
+                 })
+                 .Case<FloatType>([&](FloatType type) {
+                   return rewriter.create<CmpFOp>(loc, CmpFPredicate::OLE,
+                                                  newValA, newValB);
+                 });
   } else if (agg == "gt") {
     aggVal = llvm::TypeSwitch<Type, Value>(valueType)
-                 .Case<IntegerType>([&](IntegerType type)
-                                    { return rewriter.create<CmpIOp>(loc, CmpIPredicate::sgt, newValA, newValB); })
-                 .Case<FloatType>([&](FloatType type)
-                                    { return rewriter.create<CmpFOp>(loc, CmpFPredicate::OGT, newValA, newValB); });
+                 .Case<IntegerType>([&](IntegerType type) {
+                   return rewriter.create<CmpIOp>(loc, CmpIPredicate::sgt,
+                                                  newValA, newValB);
+                 })
+                 .Case<FloatType>([&](FloatType type) {
+                   return rewriter.create<CmpFOp>(loc, CmpFPredicate::OGT,
+                                                  newValA, newValB);
+                 });
   } else if (agg == "ge") {
     aggVal = llvm::TypeSwitch<Type, Value>(valueType)
-                 .Case<IntegerType>([&](IntegerType type)
-                                    { return rewriter.create<CmpIOp>(loc, CmpIPredicate::sge, newValA, newValB); })
-                 .Case<FloatType>([&](FloatType type)
-                                    { return rewriter.create<CmpFOp>(loc, CmpFPredicate::OGE, newValA, newValB); });
+                 .Case<IntegerType>([&](IntegerType type) {
+                   return rewriter.create<CmpIOp>(loc, CmpIPredicate::sge,
+                                                  newValA, newValB);
+                 })
+                 .Case<FloatType>([&](FloatType type) {
+                   return rewriter.create<CmpFOp>(loc, CmpFPredicate::OGE,
+                                                  newValA, newValB);
+                 });
   }
 
   rewriter.create<memref::StoreOp>(loc, aggVal, Ox, posO);

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASArrayUtils.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASArrayUtils.cpp
@@ -620,12 +620,20 @@ Value computeUnionAggregation(PatternRewriter &rewriter, bool intersect,
   Value aggVal;
   if (agg == "plus") {
     aggVal = llvm::TypeSwitch<Type, Value>(valueType)
-                 .Case<IntegerType>([&](IntegerType type) {
-                   return rewriter.create<AddIOp>(loc, newValA, newValB);
-                 })
-                 .Case<FloatType>([&](FloatType type) {
-                   return rewriter.create<AddFOp>(loc, newValA, newValB);
-                 });
+        .Case<IntegerType>([&](IntegerType type) { return rewriter.create<AddIOp>(loc, newValA, newValB); })
+        .Case<FloatType>([&](FloatType type) { return rewriter.create<AddFOp>(loc, newValA, newValB); });
+  } else if (agg == "minus") {
+    aggVal = llvm::TypeSwitch<Type, Value>(valueType)
+        .Case<IntegerType>([&](IntegerType type) { return rewriter.create<SubIOp>(loc, newValA, newValB); })
+        .Case<FloatType>([&](FloatType type) { return rewriter.create<SubFOp>(loc, newValA, newValB); });
+  } else if (agg == "times") {
+    aggVal = llvm::TypeSwitch<Type, Value>(valueType)
+        .Case<IntegerType>([&](IntegerType type) { return rewriter.create<MulIOp>(loc, newValA, newValB); })
+        .Case<FloatType>([&](FloatType type) { return rewriter.create<MulFOp>(loc, newValA, newValB); });
+  } else if (agg == "div") {
+    aggVal = llvm::TypeSwitch<Type, Value>(valueType)
+        .Case<IntegerType>([&](IntegerType type) { return rewriter.create<SignedDivIOp>(loc, newValA, newValB); })
+        .Case<FloatType>([&](FloatType type) { return rewriter.create<DivFOp>(loc, newValA, newValB); });
   } else if (agg == "min") {
     Value cmp = llvm::TypeSwitch<Type, Value>(valueType)
                     .Case<IntegerType>([&](IntegerType type) {
@@ -637,15 +645,55 @@ Value computeUnionAggregation(PatternRewriter &rewriter, bool intersect,
                                                      newValA, newValB);
                     });
     aggVal = rewriter.create<SelectOp>(loc, cmp, newValA, newValB);
-  } else if (agg == "times") {
+  } else if (agg == "max") {
+    Value cmp = llvm::TypeSwitch<Type, Value>(valueType)
+                    .Case<IntegerType>([&](IntegerType type)
+                                       { return rewriter.create<CmpIOp>(loc, CmpIPredicate::sgt, newValA, newValB); })
+                    .Case<FloatType>([&](FloatType type)
+                                       { return rewriter.create<CmpFOp>(loc, CmpFPredicate::OGT, newValA, newValB); });
+    aggVal = rewriter.create<SelectOp>(loc, cmp, newValA, newValB);
+  } else if (agg == "first") {
+    aggVal = newValA;
+  } else if (agg == "second") {
+    aggVal = newValB;
+  } else if (agg == "eq") {
     aggVal = llvm::TypeSwitch<Type, Value>(valueType)
-                 .Case<IntegerType>([&](IntegerType type) {
-                   return rewriter.create<MulIOp>(loc, newValA, newValB);
-                 })
-                 .Case<FloatType>([&](FloatType type) {
-                   return rewriter.create<MulFOp>(loc, newValA, newValB);
-                 });
+                 .Case<IntegerType>([&](IntegerType type)
+                                    { return rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, newValA, newValB); })
+                 .Case<FloatType>([&](FloatType type)
+                                    { return rewriter.create<CmpFOp>(loc, CmpFPredicate::OEQ, newValA, newValB); });
+  } else if (agg == "ne") {
+    aggVal = llvm::TypeSwitch<Type, Value>(valueType)
+                 .Case<IntegerType>([&](IntegerType type)
+                                    { return rewriter.create<CmpIOp>(loc, CmpIPredicate::ne, newValA, newValB); })
+                 .Case<FloatType>([&](FloatType type)
+                                    { return rewriter.create<CmpFOp>(loc, CmpFPredicate::ONE, newValA, newValB); });
+  } else if (agg == "lt") {
+    aggVal = llvm::TypeSwitch<Type, Value>(valueType)
+                 .Case<IntegerType>([&](IntegerType type)
+                                    { return rewriter.create<CmpIOp>(loc, CmpIPredicate::slt, newValA, newValB); })
+                 .Case<FloatType>([&](FloatType type)
+                                    { return rewriter.create<CmpFOp>(loc, CmpFPredicate::OLT, newValA, newValB); });
+  } else if (agg == "le") {
+    aggVal = llvm::TypeSwitch<Type, Value>(valueType)
+                 .Case<IntegerType>([&](IntegerType type)
+                                    { return rewriter.create<CmpIOp>(loc, CmpIPredicate::sle, newValA, newValB); })
+                 .Case<FloatType>([&](FloatType type)
+                                    { return rewriter.create<CmpFOp>(loc, CmpFPredicate::OLE, newValA, newValB); });
+  } else if (agg == "gt") {
+    aggVal = llvm::TypeSwitch<Type, Value>(valueType)
+                 .Case<IntegerType>([&](IntegerType type)
+                                    { return rewriter.create<CmpIOp>(loc, CmpIPredicate::sgt, newValA, newValB); })
+                 .Case<FloatType>([&](FloatType type)
+                                    { return rewriter.create<CmpFOp>(loc, CmpFPredicate::OGT, newValA, newValB); });
+  } else if (agg == "ge") {
+    aggVal = llvm::TypeSwitch<Type, Value>(valueType)
+                 .Case<IntegerType>([&](IntegerType type)
+                                    { return rewriter.create<CmpIOp>(loc, CmpIPredicate::sge, newValA, newValB); })
+                 .Case<FloatType>([&](FloatType type)
+                                    { return rewriter.create<CmpFOp>(loc, CmpFPredicate::OGE, newValA, newValB); });
   }
+
   rewriter.create<memref::StoreOp>(loc, aggVal, Ox, posO);
   rewriter.create<scf::YieldOp>(
       loc, ValueRange{posAplus1, posBplus1, posOplus1, ctrue, ctrue});


### PR DESCRIPTION
Note that comparisons are currently disables while the implementation
for creating new outputs with unique dtypes is written. This commit
only supports operators which maintain the same dtype as the inputs.