### PR TITLE
Support for the unary operator "abs" in graphblas.apply

### DIFF
--- a/docs/dialect/graphblas_dialect_tutorials/graphblas_lower/graphblas_apply.ipynb
+++ b/docs/dialect/graphblas_dialect_tutorials/graphblas_lower/graphblas_apply.ipynb
@@ -81,11 +81,25 @@
     "  iterator_types = [\"parallel\", \"parallel\"]\n",
     "}\n",
     "\n",
+    "#trait_densify_vector = {\n",
+    "  indexing_maps = [\n",
+    "    affine_map<(i) -> (i)>,\n",
+    "    affine_map<(i) -> (i)>\n",
+    "  ],\n",
+    "  iterator_types = [\"parallel\"]\n",
+    "}\n",
+    "\n",
     "#CSR64 = #sparse_tensor.encoding<{\n",
     "  dimLevelType = [ \"dense\", \"compressed\" ],\n",
     "  dimOrdering = affine_map<(i,j) -> (i,j)>,\n",
     "  pointerBitWidth = 64,\n",
     "  indexBitWidth = 64\n",
+    "}>\n",
+    "\n",
+    "#SparseVec64 = #sparse_tensor.encoding<{ \n",
+    "    dimLevelType = [ \"compressed\" ], \n",
+    "    pointerBitWidth = 64, \n",
+    "    indexBitWidth = 64 \n",
     "}>\n",
     "\n",
     "func @csr_densify4x4(%argA: tensor<4x4xf64, #CSR64>) -> tensor<4x4xf64> {\n",
@@ -97,6 +111,17 @@
     "        linalg.yield %A : f64\n",
     "    } -> tensor<4x4xf64>\n",
     "  return %0 : tensor<4x4xf64>\n",
+    "}\n",
+    "\n",
+    "func @sparse_vector_densify4(%argA: tensor<4xf64, #SparseVec64>) -> tensor<4xf64> {\n",
+    "  %output_storage = constant dense<0.0> : tensor<4xf64>\n",
+    "  %0 = linalg.generic #trait_densify_vector\n",
+    "    ins(%argA: tensor<4xf64, #SparseVec64>)\n",
+    "    outs(%output_storage: tensor<4xf64>) {\n",
+    "      ^bb(%A: f64, %x: f64):\n",
+    "        linalg.yield %A : f64\n",
+    "    } -> tensor<4xf64>\n",
+    "  return %0 : tensor<4xf64>\n",
     "}\n",
     "\"\"\""
    ]
@@ -118,7 +143,7 @@
     {
      "data": {
       "text/plain": [
-       "['csr_densify4x4']"
+       "['csr_densify4x4', 'sparse_vector_densify4']"
       ]
      },
      "execution_count": 4,
@@ -139,18 +164,18 @@
     "\n",
     "Here, we'll show how to use the `graphblas.apply` op. \n",
     "\n",
-    "`graphblas.apply` takes 1 sparse tensor operand (either a CSR matrix, a CSC matrix, or a sparse vector), a [thunk](https://en.wikipedia.org/wiki/Thunk) operand, and an `apply_operator` attribute. \n",
+    "`graphblas.apply` takes 1 sparse tensor operand (either a CSR matrix, a CSC matrix, or a sparse vector), an optional [thunk](https://en.wikipedia.org/wiki/Thunk) operand, and an `apply_operator` attribute. \n",
     "\n",
-    "`graphblas.apply` applies element-wise the function indicated by the `apply_operator` attribute to each element and the thunk. The result will be have the same type as the input tensor.\n",
+    "The operator can be unary or binary. Binary operators require a thunk. The only supported binary operator is \"min\". Unary operators cannot take a thunk. The only supported unary operator is \"abs\".\n",
+    "\n",
+    "`graphblas.apply` applies element-wise the function indicated by the `apply_operator` attribute to each element. The result will be have the same type as the input tensor.\n",
     "\n",
     "Here are some example uses of the `graphblas.apply` op:\n",
     "```\n",
     "%a = graphblas.apply %sparse_matrix, %thunk { apply_operator = \"min\" } : (tensor<?x?xf64, #CSR64>, f64) to tensor<?x?xf64, #CSR64>\n",
-    "%b = graphblas.apply %sparse_matrix, %thunk { apply_operator = \"min\" } : (tensor<?x?xf64, #CSC64>, f64) to tensor<?x?xf64, #CSC64>\n",
+    "%b = graphblas.apply %sparse_matrix { apply_operator = \"abs\" } : (tensor<?x?xf64, #CSC64>) to tensor<?x?xf64, #CSC64>\n",
     "%c = graphblas.apply %sparse_vector, %thunk { apply_operator = \"min\" } : (tensor<?xf64, #CSR64>, f64) to tensor<?xf64, #CSR64>\n",
     "```\n",
-    "\n",
-    "The only currently supported option for the `apply_operator` attribute is \"min\".\n",
     "\n",
     "Let's create an example input CSR matrix."
    ]
@@ -214,6 +239,63 @@
   },
   {
    "cell_type": "markdown",
+   "id": "98ea49b7",
+   "metadata": {},
+   "source": [
+    "Let's also create an example input sparse vector."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ae70ad2a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "indices = np.array(\n",
+    "    [0, 3],\n",
+    "    dtype=np.uint64,\n",
+    ")\n",
+    "values = np.array([12, 34], dtype=np.float64)\n",
+    "sizes = np.array([4], dtype=np.uint64)\n",
+    "sparsity = np.array([True], dtype=np.bool8)\n",
+    "\n",
+    "sparse_vector = mlir_graphblas.sparse_utils.MLIRSparseTensor(indices, values, sizes, sparsity)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "13fd92fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dense_vector = engine.sparse_vector_densify4(sparse_vector)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "e664d081",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([12.,  0.,  0., 34.])"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dense_vector"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "893f8929",
    "metadata": {},
    "source": [
@@ -224,7 +306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "id": "c3df4772",
    "metadata": {},
    "outputs": [],
@@ -248,7 +330,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "id": "42401ae5",
    "metadata": {},
    "outputs": [
@@ -258,7 +340,7 @@
        "['clip']"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -269,7 +351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "id": "274035dc",
    "metadata": {},
    "outputs": [],
@@ -279,7 +361,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "id": "62e6cb76",
    "metadata": {},
    "outputs": [
@@ -292,7 +374,7 @@
        "       [200.,   0.,   0.,   0.]])"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -311,7 +393,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "id": "dcbee3c4",
    "metadata": {
     "scrolled": false
@@ -323,7 +405,7 @@
        "True"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -340,6 +422,120 @@
    "metadata": {},
    "source": [
     "The way `graphblas.apply` works for CSC matrices and sparse vectors is similar. We'll leave exploring that as an exercise for the reader. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef47cd15",
+   "metadata": {},
+   "source": [
+    "## graphblas.apply (Abs)\n",
+    "\n",
+    "Here, we'll apply the absolute value function to each element of a sparse vector."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "81ad9f89",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mlir_text = \"\"\"\n",
+    "#SparseVec64 = #sparse_tensor.encoding<{ \n",
+    "    dimLevelType = [ \"compressed\" ], \n",
+    "    pointerBitWidth = 64, \n",
+    "    indexBitWidth = 64 \n",
+    "}>\n",
+    "\n",
+    "module {\n",
+    "    func @vector_abs(%sparse_tensor: tensor<?xf64, #SparseVec64>) -> tensor<?xf64, #SparseVec64> {\n",
+    "        %answer = graphblas.apply %sparse_tensor { apply_operator = \"abs\" } : (tensor<?xf64, #SparseVec64>) to tensor<?xf64, #SparseVec64>\n",
+    "        return %answer : tensor<?xf64, #SparseVec64>\n",
+    "    }\n",
+    "}\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "b1e06cc2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['vector_abs']"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "engine.add(mlir_text, passes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "aab4fe02",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sparse_result = engine.vector_abs(sparse_vector)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "531e8634",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([12.,  0.,  0., 34.])"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "engine.sparse_vector_densify4(sparse_result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "afc6dc2f",
+   "metadata": {},
+   "source": [
+    "The result looks sane. Let's verify that it has the same behavior as NumPy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "3a707dc5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.all(np.abs(dense_vector) == engine.sparse_vector_densify4(sparse_result))"
    ]
   }
  ],

--- a/docs/dialect/ops_reference.rst
+++ b/docs/dialect/ops_reference.rst
@@ -234,7 +234,10 @@ Results:
 ``graphblas.apply``
 --------------------------
 
-Applies in an element-wise fashion the function indicated by the ``apply_operator`` attribute to each element and the thunk. Currently, the only valid operator is "min".
+Applies in an element-wise fashion the function indicated by the ``apply_operator``
+attribute to each element. The operator can be unary or binary. Binary operators
+require a thunk. The only supported binary operator is "min". Unary operators
+cannot take a thunk. The only supported unary operator is "abs".
 
 
 Example:
@@ -244,7 +247,7 @@ Example:
 
     %thunk = constant 100 : i64
     %matrix_answer = graphblas.apply %sparse_matrix, %thunk { apply_operator = "min" } : (tensor<?x?xi64, #CSR64>, i64) to tensor<?x?xi64, #CSR64>
-    %vector_answer = graphblas.apply %sparse_vector, %thunk { apply_operator = "min" } : (tensor<?xi64, #SparseVec64>, i64) to tensor<?xi64, #SparseVec64>
+    %vector_answer = graphblas.apply %sparse_vector { apply_operator = "abs" } : (tensor<?xi64, #SparseVec64>) to tensor<?xi64, #SparseVec64>
 
 Syntax:
 ^^^^^^^
@@ -265,7 +268,7 @@ Attributes:
      - Description
    * - ``apply_operator``
      - ``::mlir::StringAttr``
-     - Operator to apply.  Allowed: "min"
+     - Operator to apply.  Allowed: "min", "abs"
 
 Operands:
 ^^^^^^^^^

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
@@ -311,10 +311,11 @@ def GraphBLAS_MatrixReduceToScalarGenericOp : GraphBLAS_Op<"matrix_reduce_to_sca
 def GraphBLAS_ApplyOp : GraphBLAS_Op<"apply", [NoSideEffect]> {
     let summary = "tensor apply operation";
     let description = [{
-        Applies an operator to all elements of the given sparse tensor.  How
-        the thunk is used depends on the chosen operator.  Currently, the only valid
-        operator is "min".  The given sparse tensor must either be a CSR matrix, CSC
-        matrix, or a sparse vector.
+        Applies an operator to all elements of the given sparse tensor.  The operator
+        can be unary or binary. Binary operators require a thunk. The only supported
+        binary operator is "min". Unary operators cannot take a thunk. The only
+        supported unary operator is "abs".  The given sparse tensor must either
+        be a CSR matrix, CSC matrix, or a sparse vector.
 
         Example:
         ```mlir
@@ -323,16 +324,16 @@ def GraphBLAS_ApplyOp : GraphBLAS_Op<"apply", [NoSideEffect]> {
           graphblas.apply %sparse_matrix, %thunk { apply_operator = "min" } : 
             (tensor<?x?xi64, #CSR64>, i64) to tensor<?x?xi64, #CSR64>
         %vector_answer = 
-          graphblas.apply %sparse_vector, %thunk { apply_operator = "min" } : 
-            (tensor<?xi64, #SparseVec64>, i64) to tensor<?xi64, #SparseVec64>
+          graphblas.apply %sparse_vector { apply_operator = "abs" } : 
+            (tensor<?xi64, #SparseVec64>) to tensor<?xi64, #SparseVec64>
         ```
     }];
 
-    let arguments = (ins GraphBlasMatrixOrVectorOperand:$input, AnyType:$thunk, StrAttr:$apply_operator);
+    let arguments = (ins GraphBlasMatrixOrVectorOperand:$input, Optional<AnyType>:$thunk, StrAttr:$apply_operator);
     let results = (outs AnyTensor:$output);
     
     let assemblyFormat = [{
-           $input `,` $thunk attr-dict `:` `(` type($input) `,` type($thunk) `)` `to` type($output)
+           $input (`,` $thunk^)? attr-dict `:` `(` type($input) (`,` type($thunk)^)? `)` `to` type($output)
     }];
 
     let verifier = [{ return ::verify(*this); }];

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
@@ -31,7 +31,8 @@ static const llvm::StringSet<> supportedReduceAggregators{"plus"};
 static const llvm::StringSet<> supportedSelectors{"triu", "tril", "gt"};
 static const llvm::StringSet<> supportedThunkNeedingSelectors{"gt"};
 
-static const llvm::StringSet<> supportedApplyOperators{"min"};
+static const llvm::StringSet<> supportedBinaryApplyOperators{"min"};
+static const llvm::StringSet<> supportedUnaryApplyOperators{"abs"};
 
 bool typeIsCSR(mlir::Type inputType);
 bool typeIsCSC(mlir::Type inputType);

--- a/mlir_graphblas/src/test/GraphBLAS/check_ops.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/check_ops.mlir
@@ -88,8 +88,8 @@ module {
 
 module {
 
-    // CHECK: func @apply_matrix(%[[ARG0:.*]]: [[CSR_TYPE:tensor<.*->.*>]]) -> [[RETURN_TYPE:.*]] {
-    func @apply_matrix(%sparse_tensor: tensor<2x3xi64, #CSR64>) -> tensor<2x3xi64, #CSR64> {
+    // CHECK: func @apply_matrix_min(%[[ARG0:.*]]: [[CSR_TYPE:tensor<.*->.*>]]) -> [[RETURN_TYPE:.*]] {
+    func @apply_matrix_min(%sparse_tensor: tensor<2x3xi64, #CSR64>) -> tensor<2x3xi64, #CSR64> {
         // CHECK-NEXT: %[[THUNK:.*]] = constant 100 : [[THUNK_TYPE:.*]]
         %thunk = constant 100 : i64
         // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.apply %[[ARG0]], %[[THUNK]] {apply_operator = "min"} : ([[CSR_TYPE]], [[THUNK_TYPE]]) to [[CSR_TYPE]]
@@ -98,12 +98,28 @@ module {
         return %answer : tensor<2x3xi64, #CSR64>
     }
    
-    // CHECK: func @apply_vector(%[[ARG0:.*]]: [[VECTOR_TYPE:tensor<.*>]]) -> [[RETURN_TYPE:.*]] {
-    func @apply_vector(%sparse_tensor: tensor<3xi64, #SparseVec64>) -> tensor<3xi64, #SparseVec64> {
+    // CHECK: func @apply_vector_min(%[[ARG0:.*]]: [[VECTOR_TYPE:tensor<.*>]]) -> [[RETURN_TYPE:.*]] {
+    func @apply_vector_min(%sparse_tensor: tensor<3xi64, #SparseVec64>) -> tensor<3xi64, #SparseVec64> {
         // CHECK-NEXT: %[[THUNK:.*]] = constant 100 : [[THUNK_TYPE:.*]]
         %thunk = constant 100 : i64
         // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.apply %[[ARG0]], %[[THUNK]] {apply_operator = "min"} : ([[VECTOR_TYPE]], [[THUNK_TYPE]]) to [[VECTOR_TYPE]]
         %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "min" } : (tensor<3xi64, #SparseVec64>, i64) to tensor<3xi64, #SparseVec64>
+        // CHECK-NEXT: return %[[ANSWER]] : [[RETURN_TYPE]]
+        return %answer : tensor<3xi64, #SparseVec64>
+    }
+
+    // CHECK: func @apply_matrix_abs(%[[ARG0:.*]]: [[CSR_TYPE:tensor<.*->.*>]]) -> [[RETURN_TYPE:.*]] {
+    func @apply_matrix_abs(%sparse_tensor: tensor<2x3xi64, #CSR64>) -> tensor<2x3xi64, #CSR64> {
+        // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.apply %[[ARG0]] {apply_operator = "abs"} : ([[CSR_TYPE]]) to [[CSR_TYPE]]
+        %answer = graphblas.apply %sparse_tensor { apply_operator = "abs" } : (tensor<2x3xi64, #CSR64>) to tensor<2x3xi64, #CSR64>
+        // CHECK-NEXT: return %[[ANSWER]] : [[RETURN_TYPE]]
+        return %answer : tensor<2x3xi64, #CSR64>
+    }
+   
+    // CHECK: func @apply_vector_abs(%[[ARG0:.*]]: [[VECTOR_TYPE:tensor<.*>]]) -> [[RETURN_TYPE:.*]] {
+    func @apply_vector_abs(%sparse_tensor: tensor<3xi64, #SparseVec64>) -> tensor<3xi64, #SparseVec64> {
+        // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.apply %[[ARG0]] {apply_operator = "abs"} : ([[VECTOR_TYPE]]) to [[VECTOR_TYPE]]
+        %answer = graphblas.apply %sparse_tensor { apply_operator = "abs" } : (tensor<3xi64, #SparseVec64>) to tensor<3xi64, #SparseVec64>
         // CHECK-NEXT: return %[[ANSWER]] : [[RETURN_TYPE]]
         return %answer : tensor<3xi64, #SparseVec64>
     }

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_apply.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_apply.mlir
@@ -183,3 +183,35 @@ module {
         return %answer : tensor<6xi8, #SparseVec64>
     }
 }
+
+// -----
+
+#CSR64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "dense", "compressed" ],
+  dimOrdering = affine_map<(i,j) -> (i,j)>,
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+module {
+    func @apply_wrapper(%sparse_tensor: tensor<2x3xbf16, #CSR64>, %thunk: bf16) -> tensor<2x3xbf16, #CSR64> {
+        %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "abs" } : (tensor<2x3xbf16, #CSR64>, bf16) to tensor<2x3xbf16, #CSR64> // expected-error {{"abs" is a unary opertator, but was given a thunk.}}
+        return %answer : tensor<2x3xbf16, #CSR64>
+    }
+}
+
+// -----
+
+#CSR64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "dense", "compressed" ],
+  dimOrdering = affine_map<(i,j) -> (i,j)>,
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+module {
+    func @apply_wrapper(%sparse_tensor: tensor<2x3xbf16, #CSR64>) -> tensor<2x3xbf16, #CSR64> {
+        %answer = graphblas.apply %sparse_tensor { apply_operator = "min" } : (tensor<2x3xbf16, #CSR64>) to tensor<2x3xbf16, #CSR64> // expected-error {{"min" requires a thunk.}}
+        return %answer : tensor<2x3xbf16, #CSR64>
+    }
+}

--- a/mlir_graphblas/src/test/GraphBLAS/opt_multiply_apply.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/opt_multiply_apply.mlir
@@ -44,6 +44,7 @@ func @fuse_adjacent(%A: tensor<?x?xf64, #CSR64>, %B: tensor<?x?xf64, #CSC64>, %t
     return %apply_result : tensor<?x?xf64, #CSR64>
 }
 
+
 // CHECK-LABEL:   func @fuse_adjacent_with_mask(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                                  %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
@@ -74,32 +75,33 @@ func @fuse_adjacent_with_mask(%A: tensor<?x?xf64, #CSR64>, %B: tensor<?x?xf64, #
 }
 
 
-// CHECK-LABEL:   func @nofuse_multi_use(
-// CHECK-SAME:                           %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
-// CHECK-SAME:                           %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
-// CHECK-SAME:                           %[[VAL_2:.*]]: f64) -> (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) {
-// CHECK:           %[[VAL_3:.*]] = constant 0.000000e+00 : f64
-// CHECK:           %[[VAL_4:.*]] = graphblas.matrix_multiply_generic %[[VAL_0]], %[[VAL_1]] {mask_complement = false} : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) to tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
-// CHECK:             graphblas.yield add_identity %[[VAL_3]] : f64
+// CHECK-LABEL:   builtin.func @nofuse_multi_use(
+// CHECK-SAME:                                   %[[VAL_0:.*]]: tensor<?x?xi32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
+// CHECK-SAME:                                   %[[VAL_1:.*]]: tensor<?x?xi32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> (tensor<?x?xi32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xi32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) {
+// CHECK:           %[[VAL_2:.*]] = constant 0 : i32
+// CHECK:           %[[VAL_3:.*]] = constant 31 : i32
+// CHECK:           %[[VAL_4:.*]] = graphblas.matrix_multiply_generic %[[VAL_0]], %[[VAL_1]] {mask_complement = false} : (tensor<?x?xi32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xi32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) to tensor<?x?xi32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
+// CHECK:             graphblas.yield add_identity %[[VAL_2]] : i32
 // CHECK:           },  {
-// CHECK:           ^bb0(%[[VAL_5:.*]]: f64, %[[VAL_6:.*]]: f64):
-// CHECK:             %[[VAL_7:.*]] = addf %[[VAL_5]], %[[VAL_6]] : f64
-// CHECK:             graphblas.yield add %[[VAL_7]] : f64
+// CHECK:           ^bb0(%[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32):
+// CHECK:             %[[VAL_7:.*]] = addi %[[VAL_5]], %[[VAL_6]] : i32
+// CHECK:             graphblas.yield add %[[VAL_7]] : i32
 // CHECK:           },  {
-// CHECK:           ^bb0(%[[VAL_8:.*]]: f64, %[[VAL_9:.*]]: f64):
-// CHECK:             %[[VAL_10:.*]] = addf %[[VAL_8]], %[[VAL_9]] : f64
-// CHECK:             graphblas.yield mult %[[VAL_10]] : f64
+// CHECK:           ^bb0(%[[VAL_8:.*]]: i32, %[[VAL_9:.*]]: i32):
+// CHECK:             %[[VAL_10:.*]] = addi %[[VAL_8]], %[[VAL_9]] : i32
+// CHECK:             graphblas.yield mult %[[VAL_10]] : i32
 // CHECK:           }
-// CHECK:           %[[VAL_11:.*]] = graphblas.apply_generic %[[VAL_12:.*]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
-// CHECK:           ^bb0(%[[VAL_13:.*]]: f64):
-// CHECK:             %[[VAL_14:.*]] = cmpf olt, %[[VAL_13]], %[[VAL_2]] : f64
-// CHECK:             %[[VAL_15:.*]] = select %[[VAL_14]], %[[VAL_13]], %[[VAL_2]] : f64
-// CHECK:             graphblas.yield transform_out %[[VAL_15]] : f64
+// CHECK:           %[[VAL_11:.*]] = graphblas.apply_generic %[[VAL_12:.*]] : tensor<?x?xi32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<?x?xi32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
+// CHECK:           ^bb0(%[[VAL_13:.*]]: i32):
+// CHECK:             %[[VAL_14:.*]] = shift_right_signed %[[VAL_13]], %[[VAL_3]] : i32
+// CHECK:             %[[VAL_15:.*]] = addi %[[VAL_14]], %[[VAL_13]] : i32
+// CHECK:             %[[VAL_16:.*]] = xor %[[VAL_14]], %[[VAL_15]] : i32
+// CHECK:             graphblas.yield transform_out %[[VAL_16]] : i32
 // CHECK:           }
-// CHECK:           return %[[VAL_11]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           return %[[VAL_17:.*]], %[[VAL_18:.*]] : tensor<?x?xi32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xi32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
-func @nofuse_multi_use(%A: tensor<?x?xf64, #CSR64>, %B: tensor<?x?xf64, #CSC64>, %thunk: f64) -> (tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSR64>) {
-    %C = graphblas.matrix_multiply %A, %B { semiring = "plus_plus" } : (tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSC64>) to tensor<?x?xf64, #CSR64> 
-    %apply_result = graphblas.apply %C, %thunk { apply_operator = "min" } : (tensor<?x?xf64, #CSR64>, f64) to tensor<?x?xf64, #CSR64>
-    return %apply_result, %C : tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSR64>
+func @nofuse_multi_use(%A: tensor<?x?xi32, #CSR64>, %B: tensor<?x?xi32, #CSC64>) -> (tensor<?x?xi32, #CSR64>, tensor<?x?xi32, #CSR64>) {
+    %C = graphblas.matrix_multiply %A, %B { semiring = "plus_plus" } : (tensor<?x?xi32, #CSR64>, tensor<?x?xi32, #CSC64>) to tensor<?x?xi32, #CSR64> 
+    %apply_result = graphblas.apply %C { apply_operator = "abs" } : (tensor<?x?xi32, #CSR64>) to tensor<?x?xi32, #CSR64>
+    return %apply_result, %C : tensor<?x?xi32, #CSR64>, tensor<?x?xi32, #CSR64>
 }

--- a/mlir_graphblas/src/test/GraphBLAS/structuralize_apply.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/structuralize_apply.mlir
@@ -1,9 +1,9 @@
 // RUN: graphblas-opt %s | graphblas-opt --graphblas-structuralize | FileCheck %s
 
-#SparseVec64 = #sparse_tensor.encoding<{ 
-    dimLevelType = [ "compressed" ], 
-    pointerBitWidth = 64, 
-    indexBitWidth = 64 
+#SparseVec64 = #sparse_tensor.encoding<{
+    dimLevelType = [ "compressed" ],
+    pointerBitWidth = 64,
+    indexBitWidth = 64
 }>
 
 #CSR64 = #sparse_tensor.encoding<{
@@ -13,36 +13,132 @@
   indexBitWidth = 64
 }>
 
-// CHECK-LABEL:   func @apply_min_matrix(
-// CHECK-SAME:                    %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
-// CHECK-SAME:                    %[[VAL_1:.*]]: f64) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:           %[[VAL_2:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
-// CHECK:           ^bb0(%[[VAL_3:.*]]: f64):
-// CHECK:             %[[VAL_4:.*]] = cmpf olt, %[[VAL_3]], %[[VAL_1]] : f64
-// CHECK:             %[[VAL_5:.*]] = select %[[VAL_4]], %[[VAL_3]], %[[VAL_1]] : f64
-// CHECK:             graphblas.yield transform_out %[[VAL_5]] : f64
-// CHECK:           }
-// CHECK:           return %[[VAL_6:.*]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:         }
+module {
 
-func @apply_min_matrix(%sparse_tensor: tensor<?x?xf64, #CSR64>, %thunk: f64) -> tensor<?x?xf64, #CSR64> {
-    %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "min" } : (tensor<?x?xf64, #CSR64>, f64) to tensor<?x?xf64, #CSR64>
-    return %answer : tensor<?x?xf64, #CSR64>
+// CHECK:           builtin.func @apply_min_float_matrix(%[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, %[[VAL_1:.*]]: f64) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK:             %[[VAL_2:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
+// CHECK:             ^bb0(%[[VAL_3:.*]]: f64):
+// CHECK:               %[[VAL_4:.*]] = cmpf olt, %[[VAL_3]], %[[VAL_1]] : f64
+// CHECK:               %[[VAL_5:.*]] = select %[[VAL_4]], %[[VAL_3]], %[[VAL_1]] : f64
+// CHECK:               graphblas.yield transform_out %[[VAL_5]] : f64
+// CHECK:             }
+// CHECK:             return %[[VAL_6:.*]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           }
+
+    func @apply_min_float_matrix(%sparse_tensor: tensor<?x?xf64, #CSR64>, %thunk: f64) -> tensor<?x?xf64, #CSR64> {
+        %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "min" } : (tensor<?x?xf64, #CSR64>, f64) to tensor<?x?xf64, #CSR64>
+        return %answer : tensor<?x?xf64, #CSR64>
+    }
+
+// CHECK:           builtin.func @apply_min_float_vector(%[[VAL_7:.*]]: tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, %[[VAL_8:.*]]: f64) -> tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK:             %[[VAL_9:.*]] = graphblas.apply_generic %[[VAL_7]] : tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>  {
+// CHECK:             ^bb0(%[[VAL_10:.*]]: f64):
+// CHECK:               %[[VAL_11:.*]] = cmpf olt, %[[VAL_10]], %[[VAL_8]] : f64
+// CHECK:               %[[VAL_12:.*]] = select %[[VAL_11]], %[[VAL_10]], %[[VAL_8]] : f64
+// CHECK:               graphblas.yield transform_out %[[VAL_12]] : f64
+// CHECK:             }
+// CHECK:             return %[[VAL_13:.*]] : tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           }
+
+    func @apply_min_float_vector(%sparse_tensor: tensor<8xf64, #SparseVec64>, %thunk: f64) -> tensor<8xf64, #SparseVec64> {
+        %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "min" } : (tensor<8xf64, #SparseVec64>, f64) to tensor<8xf64, #SparseVec64>
+        return %answer : tensor<8xf64, #SparseVec64>
+    }
+
+// CHECK:           builtin.func @apply_abs__floatmatrix(%[[VAL_14:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK:             %[[VAL_15:.*]] = graphblas.apply_generic %[[VAL_14]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
+// CHECK:             ^bb0(%[[VAL_16:.*]]: f64):
+// CHECK:               %[[VAL_17:.*]] = absf %[[VAL_16]] : f64
+// CHECK:               graphblas.yield transform_out %[[VAL_17]] : f64
+// CHECK:             }
+// CHECK:             return %[[VAL_18:.*]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           }
+
+    func @apply_abs__floatmatrix(%sparse_tensor: tensor<?x?xf64, #CSR64>) -> tensor<?x?xf64, #CSR64> {
+        %answer = graphblas.apply %sparse_tensor { apply_operator = "abs" } : (tensor<?x?xf64, #CSR64>) to tensor<?x?xf64, #CSR64>
+        return %answer : tensor<?x?xf64, #CSR64>
+    }
+
+// CHECK:           builtin.func @apply_abs__floatvector(%[[VAL_19:.*]]: tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK:             %[[VAL_20:.*]] = graphblas.apply_generic %[[VAL_19]] : tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>  {
+// CHECK:             ^bb0(%[[VAL_21:.*]]: f64):
+// CHECK:               %[[VAL_22:.*]] = absf %[[VAL_21]] : f64
+// CHECK:               graphblas.yield transform_out %[[VAL_22]] : f64
+// CHECK:             }
+// CHECK:             return %[[VAL_23:.*]] : tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           }
+
+    func @apply_abs__floatvector(%sparse_tensor: tensor<8xf64, #SparseVec64>) -> tensor<8xf64, #SparseVec64> {
+        %answer = graphblas.apply %sparse_tensor { apply_operator = "abs" } : (tensor<8xf64, #SparseVec64>) to tensor<8xf64, #SparseVec64>
+        return %answer : tensor<8xf64, #SparseVec64>
+    }
+
 }
 
-// CHECK-LABEL:   builtin.func @apply_min_vector(
-// CHECK-SAME:                                   %[[VAL_0:.*]]: tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>,
-// CHECK-SAME:                                   %[[VAL_1:.*]]: f64) -> tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:           %[[VAL_2:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>  {
-// CHECK:           ^bb0(%[[VAL_3:.*]]: f64):
-// CHECK:             %[[VAL_4:.*]] = cmpf olt, %[[VAL_3]], %[[VAL_1]] : f64
-// CHECK:             %[[VAL_5:.*]] = select %[[VAL_4]], %[[VAL_3]], %[[VAL_1]] : f64
-// CHECK:             graphblas.yield transform_out %[[VAL_5]] : f64
-// CHECK:           }
-// CHECK:           return %[[VAL_6:.*]] : tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:         }
+module {
 
-func @apply_min_vector(%sparse_tensor: tensor<8xf64, #SparseVec64>, %thunk: f64) -> tensor<8xf64, #SparseVec64> {
-    %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "min" } : (tensor<8xf64, #SparseVec64>, f64) to tensor<8xf64, #SparseVec64>
-    return %answer : tensor<8xf64, #SparseVec64>
+// CHECK:           builtin.func @apply_min_int_matrix(%[[VAL_0:.*]]: tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, %[[VAL_1:.*]]: i8) -> tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK:             %[[VAL_2:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
+// CHECK:             ^bb0(%[[VAL_3:.*]]: i8):
+// CHECK:               %[[VAL_4:.*]] = cmpi slt, %[[VAL_3]], %[[VAL_1]] : i8
+// CHECK:               %[[VAL_5:.*]] = select %[[VAL_4]], %[[VAL_3]], %[[VAL_1]] : i8
+// CHECK:               graphblas.yield transform_out %[[VAL_5]] : i8
+// CHECK:             }
+// CHECK:             return %[[VAL_6:.*]] : tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           }
+
+    func @apply_min_int_matrix(%sparse_tensor: tensor<?x?xi8, #CSR64>, %thunk: i8) -> tensor<?x?xi8, #CSR64> {
+        %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "min" } : (tensor<?x?xi8, #CSR64>, i8) to tensor<?x?xi8, #CSR64>
+        return %answer : tensor<?x?xi8, #CSR64>
+    }
+
+// CHECK:           builtin.func @apply_min_int_vector(%[[VAL_7:.*]]: tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, %[[VAL_8:.*]]: i8) -> tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK:             %[[VAL_9:.*]] = graphblas.apply_generic %[[VAL_7]] : tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>  {
+// CHECK:             ^bb0(%[[VAL_10:.*]]: i8):
+// CHECK:               %[[VAL_11:.*]] = cmpi slt, %[[VAL_10]], %[[VAL_8]] : i8
+// CHECK:               %[[VAL_12:.*]] = select %[[VAL_11]], %[[VAL_10]], %[[VAL_8]] : i8
+// CHECK:               graphblas.yield transform_out %[[VAL_12]] : i8
+// CHECK:             }
+// CHECK:             return %[[VAL_13:.*]] : tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           }
+
+    func @apply_min_int_vector(%sparse_tensor: tensor<8xi8, #SparseVec64>, %thunk: i8) -> tensor<8xi8, #SparseVec64> {
+        %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "min" } : (tensor<8xi8, #SparseVec64>, i8) to tensor<8xi8, #SparseVec64>
+        return %answer : tensor<8xi8, #SparseVec64>
+    }
+
+// CHECK:           builtin.func @apply_abs_int_matrix(%[[VAL_0:.*]]: tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK:             %[[VAL_1:.*]] = constant 7 : i8
+// CHECK:             %[[VAL_2:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
+// CHECK:             ^bb0(%[[VAL_3:.*]]: i8):
+// CHECK:               %[[VAL_4:.*]] = shift_right_signed %[[VAL_3]], %[[VAL_1]] : i8
+// CHECK:               %[[VAL_5:.*]] = addi %[[VAL_4]], %[[VAL_3]] : i8
+// CHECK:               %[[VAL_6:.*]] = xor %[[VAL_4]], %[[VAL_5]] : i8
+// CHECK:               graphblas.yield transform_out %[[VAL_6]] : i8
+// CHECK:             }
+// CHECK:             return %[[VAL_7:.*]] : tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           }
+
+    func @apply_abs_int_matrix(%sparse_tensor: tensor<?x?xi8, #CSR64>) -> tensor<?x?xi8, #CSR64> {
+        %answer = graphblas.apply %sparse_tensor { apply_operator = "abs" } : (tensor<?x?xi8, #CSR64>) to tensor<?x?xi8, #CSR64>
+        return %answer : tensor<?x?xi8, #CSR64>
+    }
+
+// CHECK:           builtin.func @apply_abs_int_vector(%[[VAL_8:.*]]: tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK:             %[[VAL_9:.*]] = constant 7 : i8
+// CHECK:             %[[VAL_10:.*]] = graphblas.apply_generic %[[VAL_8]] : tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>  {
+// CHECK:             ^bb0(%[[VAL_11:.*]]: i8):
+// CHECK:               %[[VAL_12:.*]] = shift_right_signed %[[VAL_11]], %[[VAL_9]] : i8
+// CHECK:               %[[VAL_13:.*]] = addi %[[VAL_12]], %[[VAL_11]] : i8
+// CHECK:               %[[VAL_14:.*]] = xor %[[VAL_12]], %[[VAL_13]] : i8
+// CHECK:               graphblas.yield transform_out %[[VAL_14]] : i8
+// CHECK:             }
+// CHECK:             return %[[VAL_15:.*]] : tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           }
+
+    func @apply_abs_int_vector(%sparse_tensor: tensor<8xi8, #SparseVec64>) -> tensor<8xi8, #SparseVec64> {
+        %answer = graphblas.apply %sparse_tensor { apply_operator = "abs" } : (tensor<8xi8, #SparseVec64>) to tensor<8xi8, #SparseVec64>
+        return %answer : tensor<8xi8, #SparseVec64>
+    }
+
 }


### PR DESCRIPTION
This PR supports the unary operator `abs` in the `graphblas.apply` op.