### PR TITLE
Support for the unary operator "minv" (i.e. multiplicative inverse) in graphblas.apply

### DIFF
--- a/docs/dialect/graphblas_dialect_tutorials/graphblas_lower/graphblas_apply.ipynb
+++ b/docs/dialect/graphblas_dialect_tutorials/graphblas_lower/graphblas_apply.ipynb
@@ -166,9 +166,11 @@
     "\n",
     "`graphblas.apply` takes 1 sparse tensor operand (either a CSR matrix, a CSC matrix, or a sparse vector), an optional [thunk](https://en.wikipedia.org/wiki/Thunk) operand, and an `apply_operator` attribute. \n",
     "\n",
-    "The operator can be unary or binary. Binary operators require a thunk. The only supported binary operator is \"min\". Unary operators cannot take a thunk. The only supported unary operator is \"abs\".\n",
+    "The operator can be unary or binary. Binary operators require a thunk. The only supported binary operator is \"min\". Unary operators cannot take a thunk. The supported unary operators are \"abs\" and \"minv\" (i.e. [multiplicative inverse](https://en.wikipedia.org/wiki/Multiplicative_inverse)).\n",
     "\n",
-    "`graphblas.apply` applies element-wise the function indicated by the `apply_operator` attribute to each element. The result will be have the same type as the input tensor.\n",
+    "Using \"minv\" with integer types uses signed integer division and rounds towards zero. For example, the multiplicative inverse of -2 is 0.\n",
+    "\n",
+    "`graphblas.apply` applies element-wise the function indicated by the `apply_operator` attribute to each element. The result will have the same type as the input tensor.\n",
     "\n",
     "Here are some example uses of the `graphblas.apply` op:\n",
     "```\n",
@@ -429,7 +431,7 @@
    "id": "ef47cd15",
    "metadata": {},
    "source": [
-    "## graphblas.apply (Abs)\n",
+    "## graphblas.apply (Unary Operators)\n",
     "\n",
     "Here, we'll apply the absolute value function to each element of a sparse vector."
    ]
@@ -536,6 +538,14 @@
    ],
    "source": [
     "np.all(np.abs(dense_vector) == engine.sparse_vector_densify4(sparse_result))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ea3d7f7",
+   "metadata": {},
+   "source": [
+    "The way `graphblas.apply` works for the other unary operators is similar. We'll leave exploring that as an exercise for the reader."
    ]
   }
  ],

--- a/docs/dialect/ops_reference.rst
+++ b/docs/dialect/ops_reference.rst
@@ -237,7 +237,11 @@ Results:
 Applies in an element-wise fashion the function indicated by the ``apply_operator``
 attribute to each element. The operator can be unary or binary. Binary operators
 require a thunk. The only supported binary operator is "min". Unary operators
-cannot take a thunk. The only supported unary operator is "abs".
+cannot take a thunk. The supported unary operators are "abs" and "minv" (i.e.
+multiplicative inverse or `1/x`).
+
+Using "minv" with integer types uses signed integer division and rounds towards
+zero. For example, `minv(-2) == 1 / -2 == 0`.
 
 
 Example:
@@ -268,7 +272,7 @@ Attributes:
      - Description
    * - ``apply_operator``
      - ``::mlir::StringAttr``
-     - Operator to apply.  Allowed: "min", "abs"
+     - Operator to apply.  Allowed: "min", "abs", "minv"
 
 Operands:
 ^^^^^^^^^

--- a/mlir_graphblas/functions.py
+++ b/mlir_graphblas/functions.py
@@ -278,7 +278,7 @@ class Apply(BaseFunction):
         apply(input: MLIRSparseTensor, thunk: f64) -> MLIRSparseTensor
     """
 
-    _unary_operators = {"abs"}
+    _unary_operators = {"abs", "minv"}
     _binary_operators = {"min"}
     _valid_operators = _unary_operators | _binary_operators
 

--- a/mlir_graphblas/ops.py
+++ b/mlir_graphblas/ops.py
@@ -406,7 +406,7 @@ class GraphBLAS_MatrixReduceToScalar(BaseOp):
 class GraphBLAS_Apply(BaseOp):
     dialect = "graphblas"
     name = "apply"
-    allowed_unary_ops = {"abs"}
+    allowed_unary_ops = {"abs", "minv"}
     allowed_binary_ops = {"min"}
     allowed_ops = allowed_unary_ops | allowed_binary_ops
 

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
@@ -313,9 +313,13 @@ def GraphBLAS_ApplyOp : GraphBLAS_Op<"apply", [NoSideEffect]> {
     let description = [{
         Applies an operator to all elements of the given sparse tensor.  The operator
         can be unary or binary. Binary operators require a thunk. The only supported
-        binary operator is "min". Unary operators cannot take a thunk. The only
-        supported unary operator is "abs".  The given sparse tensor must either
-        be a CSR matrix, CSC matrix, or a sparse vector.
+        binary operator is "min". Unary operators cannot take a thunk.  The supported
+        unary operators are "abs" and "minv" (i.e. multiplicative inverse or 1/x).
+        The given sparse tensor must either be a CSR matrix, CSC matrix, or a sparse
+        vector.
+
+        Using "minv" with integer types uses signed integer division and rounds towards
+        zero. For example, minv(-2) == 1 / -2 == 0.
 
         Example:
         ```mlir

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
@@ -34,7 +34,7 @@ static const llvm::StringSet<> supportedSelectors{"triu", "tril", "gt"};
 static const llvm::StringSet<> supportedThunkNeedingSelectors{"gt"};
 
 static const llvm::StringSet<> supportedBinaryApplyOperators{"min"};
-static const llvm::StringSet<> supportedUnaryApplyOperators{"abs"};
+static const llvm::StringSet<> supportedUnaryApplyOperators{"abs", "minv"};
 
 bool typeIsCSR(mlir::Type inputType);
 bool typeIsCSC(mlir::Type inputType);

--- a/mlir_graphblas/src/test/GraphBLAS/check_ops.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/check_ops.mlir
@@ -124,6 +124,22 @@ module {
         return %answer : tensor<3xi64, #SparseVec64>
     }
 
+    // CHECK: func @apply_matrix_minv(%[[ARG0:.*]]: [[CSR_TYPE:tensor<.*->.*>]]) -> [[RETURN_TYPE:.*]] {
+    func @apply_matrix_minv(%sparse_tensor: tensor<2x3xi64, #CSR64>) -> tensor<2x3xi64, #CSR64> {
+        // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.apply %[[ARG0]] {apply_operator = "minv"} : ([[CSR_TYPE]]) to [[CSR_TYPE]]
+        %answer = graphblas.apply %sparse_tensor { apply_operator = "minv" } : (tensor<2x3xi64, #CSR64>) to tensor<2x3xi64, #CSR64>
+        // CHECK-NEXT: return %[[ANSWER]] : [[RETURN_TYPE]]
+        return %answer : tensor<2x3xi64, #CSR64>
+    }
+   
+    // CHECK: func @apply_vector_minv(%[[ARG0:.*]]: [[VECTOR_TYPE:tensor<.*>]]) -> [[RETURN_TYPE:.*]] {
+    func @apply_vector_minv(%sparse_tensor: tensor<3xi64, #SparseVec64>) -> tensor<3xi64, #SparseVec64> {
+        // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.apply %[[ARG0]] {apply_operator = "minv"} : ([[VECTOR_TYPE]]) to [[VECTOR_TYPE]]
+        %answer = graphblas.apply %sparse_tensor { apply_operator = "minv" } : (tensor<3xi64, #SparseVec64>) to tensor<3xi64, #SparseVec64>
+        // CHECK-NEXT: return %[[ANSWER]] : [[RETURN_TYPE]]
+        return %answer : tensor<3xi64, #SparseVec64>
+    }
+
 }
 
 module {

--- a/mlir_graphblas/src/test/GraphBLAS/opt_multiply_apply.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/opt_multiply_apply.mlir
@@ -45,32 +45,30 @@ func @fuse_adjacent(%A: tensor<?x?xf64, #CSR64>, %B: tensor<?x?xf64, #CSC64>, %t
 }
 
 
-// CHECK-LABEL:   func @fuse_adjacent_with_mask(
-// CHECK-SAME:                                  %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
-// CHECK-SAME:                                  %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
-// CHECK-SAME:                                  %[[VAL_2:.*]]: f64) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:           %[[VAL_3:.*]] = constant 0.000000e+00 : f64
-// CHECK:           %[[VAL_4:.*]] = constant 1.000000e+00 : f64
-// CHECK:           %[[VAL_5:.*]] = graphblas.matrix_multiply_generic %[[VAL_0]], %[[VAL_1]], %[[VAL_0]] {mask_complement = false} : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) to tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
-// CHECK:             graphblas.yield add_identity %[[VAL_3]] : f64
+// CHECK-LABEL:   builtin.func @fuse_adjacent_with_mask(
+// CHECK-SAME:                                          %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
+// CHECK-SAME:                                          %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK:           %[[VAL_2:.*]] = constant 0.000000e+00 : f64
+// CHECK:           %[[VAL_3:.*]] = constant 1.000000e+00 : f64
+// CHECK:           %[[VAL_4:.*]] = graphblas.matrix_multiply_generic %[[VAL_0]], %[[VAL_1]], %[[VAL_0]] {mask_complement = false} : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) to tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
+// CHECK:             graphblas.yield add_identity %[[VAL_2]] : f64
 // CHECK:           },  {
-// CHECK:           ^bb0(%[[VAL_6:.*]]: f64, %[[VAL_7:.*]]: f64):
-// CHECK:             %[[VAL_8:.*]] = addf %[[VAL_6]], %[[VAL_7]] : f64
-// CHECK:             graphblas.yield add %[[VAL_8]] : f64
+// CHECK:           ^bb0(%[[VAL_5:.*]]: f64, %[[VAL_6:.*]]: f64):
+// CHECK:             %[[VAL_7:.*]] = addf %[[VAL_5]], %[[VAL_6]] : f64
+// CHECK:             graphblas.yield add %[[VAL_7]] : f64
 // CHECK:           },  {
-// CHECK:           ^bb0(%[[VAL_9:.*]]: f64, %[[VAL_10:.*]]: f64):
-// CHECK:             graphblas.yield mult %[[VAL_4]] : f64
+// CHECK:           ^bb0(%[[VAL_8:.*]]: f64, %[[VAL_9:.*]]: f64):
+// CHECK:             graphblas.yield mult %[[VAL_3]] : f64
 // CHECK:           },  {
-// CHECK:           ^bb0(%[[VAL_11:.*]]: f64):
-// CHECK:             %[[VAL_12:.*]] = cmpf olt, %[[VAL_11]], %[[VAL_2]] : f64
-// CHECK:             %[[VAL_13:.*]] = select %[[VAL_12]], %[[VAL_11]], %[[VAL_2]] : f64
-// CHECK:             graphblas.yield transform_out %[[VAL_13]] : f64
+// CHECK:           ^bb0(%[[VAL_10:.*]]: f64):
+// CHECK:             %[[VAL_11:.*]] = divf %[[VAL_3]], %[[VAL_10]] : f64
+// CHECK:             graphblas.yield transform_out %[[VAL_11]] : f64
 // CHECK:           }
-// CHECK:           return %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           return %[[VAL_12:.*]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
-func @fuse_adjacent_with_mask(%A: tensor<?x?xf64, #CSR64>, %B: tensor<?x?xf64, #CSC64>, %thunk: f64) -> tensor<?x?xf64, #CSR64> {
+func @fuse_adjacent_with_mask(%A: tensor<?x?xf64, #CSR64>, %B: tensor<?x?xf64, #CSC64>) -> tensor<?x?xf64, #CSR64> {
     %C = graphblas.matrix_multiply %A, %B, %A { semiring = "plus_pair" } : (tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSC64>, tensor<?x?xf64, #CSR64>) to tensor<?x?xf64, #CSR64> 
-    %apply_result = graphblas.apply %C, %thunk { apply_operator = "min" } : (tensor<?x?xf64, #CSR64>, f64) to tensor<?x?xf64, #CSR64>
+    %apply_result = graphblas.apply %C { apply_operator = "minv" } : (tensor<?x?xf64, #CSR64>) to tensor<?x?xf64, #CSR64>
     return %apply_result : tensor<?x?xf64, #CSR64>
 }
 

--- a/mlir_graphblas/src/test/GraphBLAS/structuralize_apply.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/structuralize_apply.mlir
@@ -45,7 +45,7 @@ module {
         return %answer : tensor<8xf64, #SparseVec64>
     }
 
-// CHECK:           builtin.func @apply_abs__floatmatrix(%[[VAL_14:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK:           builtin.func @apply_abs_float_matrix(%[[VAL_14:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:             %[[VAL_15:.*]] = graphblas.apply_generic %[[VAL_14]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:             ^bb0(%[[VAL_16:.*]]: f64):
 // CHECK:               %[[VAL_17:.*]] = absf %[[VAL_16]] : f64
@@ -54,12 +54,12 @@ module {
 // CHECK:             return %[[VAL_18:.*]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           }
 
-    func @apply_abs__floatmatrix(%sparse_tensor: tensor<?x?xf64, #CSR64>) -> tensor<?x?xf64, #CSR64> {
+    func @apply_abs_float_matrix(%sparse_tensor: tensor<?x?xf64, #CSR64>) -> tensor<?x?xf64, #CSR64> {
         %answer = graphblas.apply %sparse_tensor { apply_operator = "abs" } : (tensor<?x?xf64, #CSR64>) to tensor<?x?xf64, #CSR64>
         return %answer : tensor<?x?xf64, #CSR64>
     }
 
-// CHECK:           builtin.func @apply_abs__floatvector(%[[VAL_19:.*]]: tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK:           builtin.func @apply_abs_float_vector(%[[VAL_19:.*]]: tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:             %[[VAL_20:.*]] = graphblas.apply_generic %[[VAL_19]] : tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:             ^bb0(%[[VAL_21:.*]]: f64):
 // CHECK:               %[[VAL_22:.*]] = absf %[[VAL_21]] : f64
@@ -68,8 +68,40 @@ module {
 // CHECK:             return %[[VAL_23:.*]] : tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           }
 
-    func @apply_abs__floatvector(%sparse_tensor: tensor<8xf64, #SparseVec64>) -> tensor<8xf64, #SparseVec64> {
+    func @apply_abs_float_vector(%sparse_tensor: tensor<8xf64, #SparseVec64>) -> tensor<8xf64, #SparseVec64> {
         %answer = graphblas.apply %sparse_tensor { apply_operator = "abs" } : (tensor<8xf64, #SparseVec64>) to tensor<8xf64, #SparseVec64>
+        return %answer : tensor<8xf64, #SparseVec64>
+    }
+
+// CHECK-LABEL:   builtin.func @apply_minv_float_matrix(
+// CHECK-SAME:                                          %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK:           %[[VAL_1:.*]] = constant 1.000000e+00 : f64
+// CHECK:           %[[VAL_2:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
+// CHECK:           ^bb0(%[[VAL_3:.*]]: f64):
+// CHECK:             %[[VAL_4:.*]] = divf %[[VAL_1]], %[[VAL_3]] : f64
+// CHECK:             graphblas.yield transform_out %[[VAL_4]] : f64
+// CHECK:           }
+// CHECK:           return %[[VAL_5:.*]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:         }
+
+    func @apply_minv_float_matrix(%sparse_tensor: tensor<?x?xf64, #CSR64>) -> tensor<?x?xf64, #CSR64> {
+        %answer = graphblas.apply %sparse_tensor { apply_operator = "minv" } : (tensor<?x?xf64, #CSR64>) to tensor<?x?xf64, #CSR64>
+        return %answer : tensor<?x?xf64, #CSR64>
+    }
+    
+// CHECK-LABEL:   builtin.func @apply_minv_float_vector(
+// CHECK-SAME:                                          %[[VAL_0:.*]]: tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK:           %[[VAL_1:.*]] = constant 1.000000e+00 : f64
+// CHECK:           %[[VAL_2:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>  {
+// CHECK:           ^bb0(%[[VAL_3:.*]]: f64):
+// CHECK:             %[[VAL_4:.*]] = divf %[[VAL_1]], %[[VAL_3]] : f64
+// CHECK:             graphblas.yield transform_out %[[VAL_4]] : f64
+// CHECK:           }
+// CHECK:           return %[[VAL_5:.*]] : tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:         }
+
+    func @apply_minv_float_vector(%sparse_tensor: tensor<8xf64, #SparseVec64>) -> tensor<8xf64, #SparseVec64> {
+        %answer = graphblas.apply %sparse_tensor { apply_operator = "minv" } : (tensor<8xf64, #SparseVec64>) to tensor<8xf64, #SparseVec64>
         return %answer : tensor<8xf64, #SparseVec64>
     }
 
@@ -138,6 +170,38 @@ module {
 
     func @apply_abs_int_vector(%sparse_tensor: tensor<8xi8, #SparseVec64>) -> tensor<8xi8, #SparseVec64> {
         %answer = graphblas.apply %sparse_tensor { apply_operator = "abs" } : (tensor<8xi8, #SparseVec64>) to tensor<8xi8, #SparseVec64>
+        return %answer : tensor<8xi8, #SparseVec64>
+    }
+
+// CHECK-LABEL:   builtin.func @apply_minv_int_matrix(
+// CHECK-SAME:                                        %[[VAL_0:.*]]: tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK:           %[[VAL_1:.*]] = constant 1 : i8
+// CHECK:           %[[VAL_2:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
+// CHECK:           ^bb0(%[[VAL_3:.*]]: i8):
+// CHECK:             %[[VAL_4:.*]] = divi_signed %[[VAL_1]], %[[VAL_3]] : i8
+// CHECK:             graphblas.yield transform_out %[[VAL_4]] : i8
+// CHECK:           }
+// CHECK:           return %[[VAL_5:.*]] : tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:         }
+
+    func @apply_minv_int_matrix(%sparse_tensor: tensor<?x?xi8, #CSR64>) -> tensor<?x?xi8, #CSR64> {
+        %answer = graphblas.apply %sparse_tensor { apply_operator = "minv" } : (tensor<?x?xi8, #CSR64>) to tensor<?x?xi8, #CSR64>
+        return %answer : tensor<?x?xi8, #CSR64>
+    }
+
+// CHECK-LABEL:   builtin.func @apply_minv_int_vector(
+// CHECK-SAME:                                        %[[VAL_0:.*]]: tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK:           %[[VAL_1:.*]] = constant 1 : i8
+// CHECK:           %[[VAL_2:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>  {
+// CHECK:           ^bb0(%[[VAL_3:.*]]: i8):
+// CHECK:             %[[VAL_4:.*]] = divi_signed %[[VAL_1]], %[[VAL_3]] : i8
+// CHECK:             graphblas.yield transform_out %[[VAL_4]] : i8
+// CHECK:           }
+// CHECK:           return %[[VAL_5:.*]] : tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:         }
+
+    func @apply_minv_int_vector(%sparse_tensor: tensor<8xi8, #SparseVec64>) -> tensor<8xi8, #SparseVec64> {
+        %answer = graphblas.apply %sparse_tensor { apply_operator = "minv" } : (tensor<8xi8, #SparseVec64>) to tensor<8xi8, #SparseVec64>
         return %answer : tensor<8xi8, #SparseVec64>
     }
 


### PR DESCRIPTION
This PR adds support for the unary operator `minv` (i.e. [multiplicative inverse](https://en.wikipedia.org/wiki/Multiplicative_inverse)) in `graphblas.apply`.