### PR TITLE
Support for the aggregator "count" in graphblas.reduce_to_vector

### DIFF
--- a/mlir_graphblas/functions.py
+++ b/mlir_graphblas/functions.py
@@ -234,7 +234,7 @@ class MatrixReduceToScalar(BaseFunction):
       matrix_reduce_to_scalar(input: MLIRSparseTensor) -> float64
     """
 
-    _valid_aggregators = {"plus"}
+    _valid_aggregators = {"plus", "count"}
     _agg_aliases = {
         "sum": "plus",
     }

--- a/mlir_graphblas/ops.py
+++ b/mlir_graphblas/ops.py
@@ -364,7 +364,7 @@ class GraphBLAS_MatrixSelect(BaseOp):
 class GraphBLAS_MatrixReduceToVector(BaseOp):
     dialect = "graphblas"
     name = "matrix_reduce_to_vector"
-    allowed_aggregators = {"plus"}
+    allowed_aggregators = {"plus", "count"}
 
     @classmethod
     def call(cls, irbuilder, input, aggregator, axis, return_type):
@@ -385,7 +385,7 @@ class GraphBLAS_MatrixReduceToVector(BaseOp):
 class GraphBLAS_MatrixReduceToScalar(BaseOp):
     dialect = "graphblas"
     name = "matrix_reduce_to_scalar"
-    allowed_aggregators = {"plus"}
+    allowed_aggregators = {"plus", "count"}
 
     @classmethod
     def call(cls, irbuilder, input, aggregator):

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
@@ -235,14 +235,15 @@ def GraphBLAS_MatrixReduceToVectorOp : GraphBLAS_Op<"matrix_reduce_to_vector", [
         The given tensor must have a CSR sparsity or a CSC sparsity.
         The resulting sparse vector's element type must be the same as the element type of the input tensor.
         If the axis attribute is 0, the input tensor will be reduced column-wise, so the resulting
-        vector's size must be the  number of rows in the input tensor. 
-        If the axis attribute is 1, the input tensor will be reduced row-wise, so the resulting
         vector's size must be the  number of columns in the input tensor. 
+        If the axis attribute is 1, the input tensor will be reduced row-wise, so the resulting
+        vector's size must be the  number of rows in the input tensor.
+        The supported aggregators are "plus" and "count".
 
         Example:
         ```mlir
         %vec1 = graphblas.matrix_reduce_to_vector %matrix { aggregator = "plus", axis = 0 } : tensor<7x9xi32, #CSR64> to tensor<9xi32, #SparseVec64>
-        %vec2 = graphblas.matrix_reduce_to_vector %matrix { aggregator = "plus", axis = 1 } : tensor<7x9xi32, #CSR64> to tensor<7xi32, #SparseVec64>
+        %vec2 = graphblas.matrix_reduce_to_vector %matrix { aggregator = "count", axis = 1 } : tensor<7x9xi32, #CSR64> to tensor<7xi32, #SparseVec64>
         ```
     }];
 

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
@@ -28,7 +28,7 @@ static const llvm::StringSet<> supportedSemiringAddNames{"plus", "any", "min"};
 static const llvm::StringSet<> supportedSemiringMultiplyNames{
     "pair", "times", "plus", "first", "second"};
 
-static const llvm::StringSet<> supportedReduceAggregators{"plus"};
+static const llvm::StringSet<> supportedReduceAggregators{"plus", "count"};
 
 static const llvm::StringSet<> supportedSelectors{"triu", "tril", "gt"};
 static const llvm::StringSet<> supportedThunkNeedingSelectors{"gt"};

--- a/mlir_graphblas/src/test/GraphBLAS/check_ops.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/check_ops.mlir
@@ -76,10 +76,18 @@ module {
 
 module {
 
-    // CHECK: func @matrix_reduce_to_scalar(%[[ARG0:.*]]: [[CSR_TYPE:tensor<.*->.*>]]) -> [[RETURN_TYPE:.*]] {
-    func @matrix_reduce_to_scalar(%sparse_tensor: tensor<2x3xi64, #CSR64>) -> i64 {
+    // CHECK: func @matrix_reduce_to_scalar_plus(%[[ARG0:.*]]: [[CSR_TYPE:tensor<.*->.*>]]) -> [[RETURN_TYPE:.*]] {
+    func @matrix_reduce_to_scalar_plus(%sparse_tensor: tensor<2x3xi64, #CSR64>) -> i64 {
         // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.matrix_reduce_to_scalar %[[ARG0]] {aggregator = "plus"} : [[CSR_TYPE]] to [[RETURN_TYPE]]
         %answer = graphblas.matrix_reduce_to_scalar %sparse_tensor { aggregator = "plus" } : tensor<2x3xi64, #CSR64> to i64
+        // CHECK-NEXT: return %[[ANSWER]] : [[RETURN_TYPE]]
+        return %answer : i64
+    }
+
+    // CHECK: func @matrix_reduce_to_scalar_count(%[[ARG0:.*]]: [[CSR_TYPE:tensor<.*->.*>]]) -> [[RETURN_TYPE:.*]] {
+    func @matrix_reduce_to_scalar_count(%sparse_tensor: tensor<2x3xi64, #CSR64>) -> i64 {
+        // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.matrix_reduce_to_scalar %[[ARG0]] {aggregator = "count"} : [[CSR_TYPE]] to [[RETURN_TYPE]]
+        %answer = graphblas.matrix_reduce_to_scalar %sparse_tensor { aggregator = "count" } : tensor<2x3xi64, #CSR64> to i64
         // CHECK-NEXT: return %[[ANSWER]] : [[RETURN_TYPE]]
         return %answer : i64
     }
@@ -328,12 +336,22 @@ module {
 
 module {
 
-    // CHECK: func @matrix_reduce_to_vector_wrapper(%[[MATRIX:.*]]: [[MATRIX_TYPE:tensor<.*->.*>]]) -> ([[RETURN_TYPE_0:tensor<.*>]], [[RETURN_TYPE_1:tensor<.*>]]) {
-    func @matrix_reduce_to_vector_wrapper(%matrix: tensor<7x9xi32, #CSR64>) -> (tensor<9xi32, #SparseVec64>, tensor<7xi32, #SparseVec64>) {
+    // CHECK: func @matrix_reduce_to_vector_plus(%[[MATRIX:.*]]: [[MATRIX_TYPE:tensor<.*->.*>]]) -> ([[RETURN_TYPE_0:tensor<.*>]], [[RETURN_TYPE_1:tensor<.*>]]) {
+    func @matrix_reduce_to_vector_plus(%matrix: tensor<7x9xi32, #CSR64>) -> (tensor<9xi32, #SparseVec64>, tensor<7xi32, #SparseVec64>) {
         // CHECK-NEXT: %[[ANSWER_0:.*]] = graphblas.matrix_reduce_to_vector %[[MATRIX]] {aggregator = "plus", axis = 0 : i64} : [[MATRIX_TYPE]] to [[RETURN_TYPE_0]]
         %vec1 = graphblas.matrix_reduce_to_vector %matrix { aggregator = "plus", axis = 0 } : tensor<7x9xi32, #CSR64> to tensor<9xi32, #SparseVec64>
         // CHECK-NEXT: %[[ANSWER_1:.*]] = graphblas.matrix_reduce_to_vector %[[MATRIX]] {aggregator = "plus", axis = 1 : i64} : [[MATRIX_TYPE]] to [[RETURN_TYPE_1]]
         %vec2 = graphblas.matrix_reduce_to_vector %matrix { aggregator = "plus", axis = 1 } : tensor<7x9xi32, #CSR64> to tensor<7xi32, #SparseVec64>
+	// CHECK-NEXT: return %[[ANSWER_0]], %[[ANSWER_1]] : [[RETURN_TYPE_0]], [[RETURN_TYPE_1]]
+        return %vec1, %vec2 : tensor<9xi32, #SparseVec64>, tensor<7xi32, #SparseVec64>
+    }
+
+    // CHECK: func @matrix_reduce_to_vector_count(%[[MATRIX:.*]]: [[MATRIX_TYPE:tensor<.*->.*>]]) -> ([[RETURN_TYPE_0:tensor<.*>]], [[RETURN_TYPE_1:tensor<.*>]]) {
+    func @matrix_reduce_to_vector_count(%matrix: tensor<7x9xi32, #CSR64>) -> (tensor<9xi32, #SparseVec64>, tensor<7xi32, #SparseVec64>) {
+        // CHECK-NEXT: %[[ANSWER_0:.*]] = graphblas.matrix_reduce_to_vector %[[MATRIX]] {aggregator = "count", axis = 0 : i64} : [[MATRIX_TYPE]] to [[RETURN_TYPE_0]]
+        %vec1 = graphblas.matrix_reduce_to_vector %matrix { aggregator = "count", axis = 0 } : tensor<7x9xi32, #CSR64> to tensor<9xi32, #SparseVec64>
+        // CHECK-NEXT: %[[ANSWER_1:.*]] = graphblas.matrix_reduce_to_vector %[[MATRIX]] {aggregator = "count", axis = 1 : i64} : [[MATRIX_TYPE]] to [[RETURN_TYPE_1]]
+        %vec2 = graphblas.matrix_reduce_to_vector %matrix { aggregator = "count", axis = 1 } : tensor<7x9xi32, #CSR64> to tensor<7xi32, #SparseVec64>
 	// CHECK-NEXT: return %[[ANSWER_0]], %[[ANSWER_1]] : [[RETURN_TYPE_0]], [[RETURN_TYPE_1]]
         return %vec1, %vec2 : tensor<9xi32, #SparseVec64>, tensor<7xi32, #SparseVec64>
     }

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_matrix_reduce_to_vector.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_matrix_reduce_to_vector.mlir
@@ -8,7 +8,7 @@
 
 module {
     func @matrix_reduce_to_vector_wrapper(%matrix: tensor<*xi32>) -> tensor<9xi32, #SparseVec64> {
-        %vec = graphblas.matrix_reduce_to_vector %matrix { aggregator = "plus", axis = 0 } : tensor<*xi32> to tensor<9xi32, #SparseVec64> // expected-error {{operand #0 must be 2D tensor of any type values, but got 'tensor<*xi32>'}}
+        %vec = graphblas.matrix_reduce_to_vector %matrix { aggregator = "count", axis = 0 } : tensor<*xi32> to tensor<9xi32, #SparseVec64> // expected-error {{operand #0 must be 2D tensor of any type values, but got 'tensor<*xi32>'}}
         return %vec : tensor<9xi32, #SparseVec64>
     }
 }

--- a/mlir_graphblas/tests/test_mlir_builder.py
+++ b/mlir_graphblas/tests/test_mlir_builder.py
@@ -682,7 +682,7 @@ def test_ir_reduce_to_vector(
         matrix, "plus", 1, reduce_rows_output_type
     )
     reduced_columns = ir_builder.graphblas.matrix_reduce_to_vector(
-        matrix, "plus", 0, reduce_columns_output_type
+        matrix, "count", 0, reduce_columns_output_type
     )
 
     zero_scalar = ir_builder.constant(0, mlir_type)
@@ -724,8 +724,10 @@ def test_ir_reduce_to_vector(
     reduced_rows_clamped = densify_vector(reduced_rows_clamped)
     reduced_columns_abs = densify_vector(reduced_columns_abs)
 
-    expected_reduced_rows = np.sum(dense_input_tensor, axis=1)
-    expected_reduced_columns = np.sum(dense_input_tensor, axis=0)
+    expected_reduced_rows = dense_input_tensor.sum(axis=1)
+    expected_reduced_columns = (
+        dense_input_tensor.astype(bool).sum(axis=0).astype(np_type)
+    )
 
     expected_reduced_rows_clamped = np.copy(expected_reduced_rows)
     expected_reduced_rows_clamped[expected_reduced_rows_clamped > 0] = 0


### PR DESCRIPTION
This PR adds support for `count` in `graphblas.reduce_to_vector`. It does not work for `graphblas.reduce_to_scalar` (but there are stubs now).

This work exposed a few issues: 
- https://github.com/metagraph-dev/mlir-graphblas/issues/142
- https://github.com/metagraph-dev/mlir-graphblas/issues/143
- https://github.com/metagraph-dev/mlir-graphblas/issues/144