### PR TITLE
Put builtin dialect back in for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Conda Version](https://img.shields.io/conda/v/metagraph/mlir-graphblas.svg)](https://anaconda.org/metagraph/mlir-graphblas)
 [![Build Status](https://github.com/metagraph-dev/mlir-graphblas/actions/workflows/test_and_deploy.yml/badge.svg?branch=main)](https://github.com/metagraph-dev/mlir-graphblas/actions/workflows/test_and_deploy.yml?query=branch%3Amain)
 
+*Note that this code currently requires [llvm-project@3a2ff98](https://github.com/llvm/llvm-project/commit/3a2ff98).*
+
 ## graphblas-opt
 
 In order to build `graphblas-opt`, run `python3 build.py` from `mlir_graphblas/src/`. This will build `graphblas-opt` and run the tests for `graphblas-opt`. The built files will be stored in `mlir_graphblas/src/build`.

--- a/mlir_graphblas/engine.py
+++ b/mlir_graphblas/engine.py
@@ -810,7 +810,7 @@ class MlirJitEngine:
         lowered_text = self._cli.apply_passes(dummy_declarations_string, passes)
         lowered_lines = list(filter(len, lowered_text.splitlines()))
         assert (
-            lowered_lines[0] == 'module attributes {llvm.data_layout = ""}  {'
+            lowered_lines[0] == 'builtin.module attributes {llvm.data_layout = ""}  {'
         )
         assert lowered_lines[-1] == "}"
         lowered_lines = lowered_lines[1:-1]

--- a/mlir_graphblas/tests/test_cli.py
+++ b/mlir_graphblas/tests/test_cli.py
@@ -41,8 +41,8 @@ def test_apply_passes(cli_input):
     assert (
         result
         == """\
-module  {
-  func @scale_func(%arg0: memref<?xf32>, %arg1: f32) -> memref<?xf32> {
+builtin.module  {
+  builtin.func @scale_func(%arg0: memref<?xf32>, %arg1: f32) -> memref<?xf32> {
     %c0 = constant 0 : index
     %0 = memref.dim %arg0, %c0 : memref<?xf32>
     %1 = memref.alloc(%0) : memref<?xf32>

--- a/mlir_graphblas/tests/test_tools.py
+++ b/mlir_graphblas/tests/test_tools.py
@@ -5,8 +5,8 @@ import mlir_graphblas
 TEST_CASES = (
     pytest.param(
         """
-module  {
-  func @test_func(%arg0: tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
+builtin.module  {
+  builtin.func @test_func(%arg0: tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
     return %arg0 : tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
   }
 }
@@ -18,8 +18,8 @@ module  {
     indexBitWidth = 64 
 }>
 
-module  {
-  func @test_func(%arg0: tensor<2x3xf64, #CSX64>) -> tensor<2x3xf64, #CSX64> {
+builtin.module  {
+  builtin.func @test_func(%arg0: tensor<2x3xf64, #CSX64>) -> tensor<2x3xf64, #CSX64> {
     return %arg0 : tensor<2x3xf64, #CSX64>
   }
 }
@@ -28,8 +28,8 @@ module  {
     ),
     pytest.param(
         """
-module  {
-  func @test_func(%arg0: tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
+builtin.module  {
+  builtin.func @test_func(%arg0: tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
     return %arg0 : tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
   }
 }
@@ -42,8 +42,8 @@ module  {
     indexBitWidth = 64 
 }>
 
-module  {
-  func @test_func(%arg0: tensor<2x3xf64, #CSC64>) -> tensor<2x3xf64, #CSC64> {
+builtin.module  {
+  builtin.func @test_func(%arg0: tensor<2x3xf64, #CSC64>) -> tensor<2x3xf64, #CSC64> {
     return %arg0 : tensor<2x3xf64, #CSC64>
   }
 }
@@ -52,8 +52,8 @@ module  {
     ),
     pytest.param(
         """
-module  {
-  func @test_func(%arg0: tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
+builtin.module  {
+  builtin.func @test_func(%arg0: tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
     return %arg0 : tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
   }
 }
@@ -66,8 +66,8 @@ module  {
     indexBitWidth = 64 
 }>
 
-module  {
-  func @test_func(%arg0: tensor<2x3xf64, #CSR64>) -> tensor<2x3xf64, #CSR64> {
+builtin.module  {
+  builtin.func @test_func(%arg0: tensor<2x3xf64, #CSR64>) -> tensor<2x3xf64, #CSR64> {
     return %arg0 : tensor<2x3xf64, #CSR64>
   }
 }
@@ -76,8 +76,8 @@ module  {
     ),
     pytest.param(
         """
-module  {
-  func @convert_layout_wrapper(%arg0: tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
+builtin.module  {
+  builtin.func @convert_layout_wrapper(%arg0: tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
     %0 = graphblas.convert_layout %arg0 : tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
     return %0 : tensor<2x3xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
   }
@@ -98,8 +98,8 @@ module  {
     indexBitWidth = 64 
 }>
 
-module  {
-  func @convert_layout_wrapper(%arg0: tensor<2x3xf64, #CSR64>) -> tensor<2x3xf64, #CSC64> {
+builtin.module  {
+  builtin.func @convert_layout_wrapper(%arg0: tensor<2x3xf64, #CSR64>) -> tensor<2x3xf64, #CSC64> {
     %0 = graphblas.convert_layout %arg0 : tensor<2x3xf64, #CSR64> to tensor<2x3xf64, #CSC64>
     return %0 : tensor<2x3xf64, #CSC64>
   }
@@ -109,8 +109,8 @@ module  {
     ),
     pytest.param(
         """
-module  {
-  func @vector_argminmax_min(%arg0: tensor<3xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> index {
+builtin.module  {
+  builtin.func @vector_argminmax_min(%arg0: tensor<3xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> index {
     %0 = graphblas.vector_argminmax %arg0 {minmax = "min"} : tensor<3xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
     return %0 : index
   }
@@ -123,8 +123,8 @@ module  {
     indexBitWidth = 64 
 }>
 
-module  {
-  func @vector_argminmax_min(%arg0: tensor<3xi64, #SparseVec64>) -> index {
+builtin.module  {
+  builtin.func @vector_argminmax_min(%arg0: tensor<3xi64, #SparseVec64>) -> index {
     %0 = graphblas.vector_argminmax %arg0 {minmax = "min"} : tensor<3xi64, #SparseVec64>
     return %0 : index
   }


### PR DESCRIPTION
PR #149 reasonably updated the code base to work with the latest MLIR, which as of [this commit](https://github.com/llvm/llvm-project/commit/387f95541bdc575f75bba95d323b51198d3b9e2b) removes printing of `builtin` on `module` and `func`.  Unfortunately, it seems that updating to that MLIR version also brings in some changes to the sparse tensor handling which appears to break some of our code when working with non-square CSC matrices (which have permuted indices).

Eventually we need to deal with that and upgrade MLIR, but for now we need to keep working on other features.  This PR can be reverted when we want to upgrade MLIR.
