### PR TITLE
Remove CSX and allow creating new MLIRSparseTensors

### DIFF
--- a/mlir_graphblas/SparseUtils.cpp
+++ b/mlir_graphblas/SparseUtils.cpp
@@ -387,7 +387,7 @@ public:
         SparseTensorStorageBase *tensor = new SparseTensorStorage<P, I, V>(sizes, this);
         return tensor;
     }
-    // New tensor of dimentions `ndims` (no shape; must use `resize_dim`)
+    // New tensor of dimensions `ndims` (no shape; must use `resize_dim`)
     void *empty(uint64_t ndims) override {
         SparseTensorStorageBase *tensor = new SparseTensorStorage<P, I, V>(ndims);
         return tensor;
@@ -744,17 +744,10 @@ IMPL1(MemRef1DI16, sparseValuesI16, int16_t, getValues)
 IMPL1(MemRef1DI8, sparseValuesI8, int8_t, getValues)
 
 /// Releases sparse tensor storage.
-//// --> MODIFIED
-void delSparseVector(void *tensor)
+void delSparseTensor(void *tensor)
 {
   delete static_cast<SparseTensorStorageBase *>(tensor);
 }
-
-void delSparseMatrix(void *tensor)
-{
-  delete static_cast<SparseTensorStorageBase *>(tensor);
-}
-//// <- MODIFIED
 
 /// Helper to get pointer, one per value type.
 PTR(getPtrF64)
@@ -797,73 +790,132 @@ void swap_indices(void *tensor, void *new_indices) {
 void swap_values(void *tensor, void *new_values) {
     static_cast<SparseTensorStorageBase *>(tensor)->swap_values(new_values);
 }
-// Vector versions
-void vector_resize_pointers(void *tensor, uint64_t d, uint64_t size) {
+void resize_pointers(void *tensor, uint64_t d, uint64_t size) {
     static_cast<SparseTensorStorageBase *>(tensor)->resize_pointers(d, size);
 }
-void vector_resize_index(void *tensor, uint64_t d, uint64_t size) {
+void resize_index(void *tensor, uint64_t d, uint64_t size) {
     static_cast<SparseTensorStorageBase *>(tensor)->resize_index(d, size);
 }
-void vector_resize_values(void *tensor, uint64_t size) {
+void resize_values(void *tensor, uint64_t size) {
     static_cast<SparseTensorStorageBase *>(tensor)->resize_values(size);
 }
-void vector_resize_dim(void *tensor, uint64_t d, uint64_t size) {
+void resize_dim(void *tensor, uint64_t d, uint64_t size) {
     static_cast<SparseTensorStorageBase *>(tensor)->resize_dim(d, size);
 }
-void *dup_vector(void *tensor) {
+void *dup_tensor(void *tensor) {
     return static_cast<SparseTensorStorageBase *>(tensor)->dup();
 }
-void *ptr8_to_vector(void *tensor) {
-    return tensor;
-}
-void *vector_to_ptr8(void *tensor) {
-    return tensor;
-}
-void *vector_empty_like(void *tensor) {
+void *empty_like(void *tensor) {
     return static_cast<SparseTensorStorageBase *>(tensor)->empty_like();
 }
-void *vector_empty(void *tensor, uint64_t ndims) {
+void *empty(void *tensor, uint64_t ndims) {
     return static_cast<SparseTensorStorageBase *>(tensor)->empty(ndims);
 }
-// Matrix versions
-void matrix_resize_pointers(void *tensor, uint64_t d, uint64_t size) {
-    static_cast<SparseTensorStorageBase *>(tensor)->resize_pointers(d, size);
-}
-void matrix_resize_index(void *tensor, uint64_t d, uint64_t size) {
-    static_cast<SparseTensorStorageBase *>(tensor)->resize_index(d, size);
-}
-void matrix_resize_values(void *tensor, uint64_t size) {
-    static_cast<SparseTensorStorageBase *>(tensor)->resize_values(size);
-}
-void matrix_resize_dim(void *tensor, uint64_t d, uint64_t size) {
-    static_cast<SparseTensorStorageBase *>(tensor)->resize_dim(d, size);
-}
-void *dup_matrix(void *tensor) {
-    return static_cast<SparseTensorStorageBase *>(tensor)->dup();
-}
-void *ptr8_to_matrix(void *tensor) {
+// Combinations of real types to !llvm.ptr<i8>
+void *matrix_csr_f64_p64i64_to_ptr8(void *tensor) {
     return tensor;
 }
-void *matrix_to_ptr8(void *tensor) {
+void *matrix_csc_f64_p64i64_to_ptr8(void *tensor) {
     return tensor;
 }
-void *cast_csr_to_csx(void *tensor) {
+void *matrix_csr_f32_p64i64_to_ptr8(void *tensor) {
     return tensor;
 }
-void *cast_csc_to_csx(void *tensor) {
+void *matrix_csc_f32_p64i64_to_ptr8(void *tensor) {
     return tensor;
 }
-void *cast_csx_to_csc(void *tensor) {
+void *matrix_csr_i64_p64i64_to_ptr8(void *tensor) {
     return tensor;
 }
-void *cast_csx_to_csr(void *tensor) {
+void *matrix_csc_i64_p64i64_to_ptr8(void *tensor) {
     return tensor;
 }
-void *matrix_empty_like(void *tensor) {
-    return static_cast<SparseTensorStorageBase *>(tensor)->empty_like();
+void *vector_f64_p64i64_to_ptr8(void *tensor) {
+    return tensor;
 }
-void *matrix_empty(void *tensor, uint64_t ndims) {
-    return static_cast<SparseTensorStorageBase *>(tensor)->empty(ndims);
+void *vector_f32_p64i64_to_ptr8(void *tensor) {
+    return tensor;
+}
+void *vector_i64_p64i64_to_ptr8(void *tensor) {
+    return tensor;
+}
+// Combinations of !llvm.ptr<i8> to real types
+void *ptr8_to_matrix_csr_f64_p64i64(void *tensor) {
+    return tensor;
+}
+void *ptr8_to_matrix_csc_f64_p64i64(void *tensor) {
+    return tensor;
+}
+void *ptr8_to_matrix_csr_f32_p64i64(void *tensor) {
+    return tensor;
+}
+void *ptr8_to_matrix_csc_f32_p64i64(void *tensor) {
+    return tensor;
+}
+void *ptr8_to_matrix_csr_i64_p64i64(void *tensor) {
+    return tensor;
+}
+void *ptr8_to_matrix_csc_i64_p64i64(void *tensor) {
+    return tensor;
+}
+void *ptr8_to_vector_f64_p64i64(void *tensor) {
+    return tensor;
+}
+void *ptr8_to_vector_f32_p64i64(void *tensor) {
+    return tensor;
+}
+void *ptr8_to_vector_i64_p64i64(void *tensor) {
+    return tensor;
+}
+// New tensor generic constructors
+void *matrix_prep_size(SparseTensorStorageBase *matrix, uint64_t nrows, uint64_t ncols, bool columnOriented) {
+    matrix->resize_dim(0, nrows);
+    matrix->resize_dim(1, ncols);
+    matrix->resize_pointers(1, (columnOriented ? ncols : nrows) + 1);
+    return matrix;
+}
+void *vector_prep_size(SparseTensorStorageBase *vector, uint64_t size) {
+    vector->resize_dim(0, size);
+    vector->resize_pointers(0, 2);
+    return vector;
+}
+// New matrix specialized constructors
+void *new_matrix_csr_f64_p64i64(uint64_t nrows, uint64_t ncols) {
+    SparseTensorStorageBase *tensor = new SparseTensorStorage<uint64_t, uint64_t, double>(2);
+    return matrix_prep_size(tensor, nrows, ncols, false);
+}
+void *new_matrix_csc_f64_p64i64(uint64_t nrows, uint64_t ncols) {
+    SparseTensorStorageBase *tensor = new SparseTensorStorage<uint64_t, uint64_t, double>(2);
+    return matrix_prep_size(tensor, nrows, ncols, true);
+}
+void *new_matrix_csr_f32_p64i64(uint64_t nrows, uint64_t ncols) {
+    SparseTensorStorageBase *tensor = new SparseTensorStorage<uint64_t, uint64_t, float>(2);
+    return matrix_prep_size(tensor, nrows, ncols, false);
+}
+void *new_matrix_csc_f32_p64i64(uint64_t nrows, uint64_t ncols) {
+    SparseTensorStorageBase *tensor = new SparseTensorStorage<uint64_t, uint64_t, float>(2);
+    return matrix_prep_size(tensor, nrows, ncols, true);
+}
+void *new_matrix_csr_i64_p64i64(uint64_t nrows, uint64_t ncols) {
+    SparseTensorStorageBase *tensor = new SparseTensorStorage<uint64_t, uint64_t, int64_t>(2);
+    return matrix_prep_size(tensor, nrows, ncols, false);
+}
+void *new_matrix_csc_i64_p64i64(uint64_t nrows, uint64_t ncols) {
+    SparseTensorStorageBase *tensor = new SparseTensorStorage<uint64_t, uint64_t, int64_t>(2);
+    return matrix_prep_size(tensor, nrows, ncols, true);
+}
+// New vector specialized constructors
+void *new_vector_f64_p64i64(uint64_t size) {
+    SparseTensorStorageBase *tensor = new SparseTensorStorage<uint64_t, uint64_t, double>(1);
+    return vector_prep_size(tensor, size);
+}
+void *new_vector_f32_p64i64(uint64_t size) {
+    SparseTensorStorageBase *tensor = new SparseTensorStorage<uint64_t, uint64_t, float>(1);
+    return vector_prep_size(tensor, size);
+}
+void *new_vector_i64_p64i64(uint64_t size) {
+    SparseTensorStorageBase *tensor = new SparseTensorStorage<uint64_t, uint64_t, int64_t>(1);
+    return vector_prep_size(tensor, size);
 }
 
 //// <- MODIFIED

--- a/mlir_graphblas/functions.py
+++ b/mlir_graphblas/functions.py
@@ -31,6 +31,7 @@ _standard_passes = (
 )
 
 
+# TODO: eliminate this and all functions; extract required pieces into MLIRFunctionBuilder
 class BaseFunction:
     func_name = None
     _compiled = None  # (engine, passes, callable)
@@ -61,12 +62,6 @@ class BaseFunction:
   indexBitWidth = 64
 }>
 
-#CSX64 = #sparse_tensor.encoding<{
-  dimLevelType = [ "dense", "compressed" ],
-  pointerBitWidth = 64,
-  indexBitWidth = 64
-}>
-
 #CV64 = #sparse_tensor.encoding<{
   dimLevelType = [ "compressed" ],
   pointerBitWidth = 64,
@@ -74,21 +69,6 @@ class BaseFunction:
 }>
 
 module  {
-    func private @cast_csr_to_csx(tensor<?x?xf64, #CSR64>) -> tensor<?x?xf64, #CSX64>
-    func private @cast_csc_to_csx(tensor<?x?xf64, #CSC64>) -> tensor<?x?xf64, #CSX64>
-    func private @cast_csx_to_csr(tensor<?x?xf64, #CSX64>) -> tensor<?x?xf64, #CSR64>
-    func private @cast_csx_to_csc(tensor<?x?xf64, #CSX64>) -> tensor<?x?xf64, #CSC64>
-    
-    func private @ptr8_to_matrix(!llvm.ptr<i8>) -> tensor<?x?xf64, #CSX64>
-    func private @ptr8_to_vector(!llvm.ptr<i8>) -> tensor<?xf64, #CV64>
-    func private @matrix_to_ptr8(tensor<?x?xf64, #CSX64>) -> !llvm.ptr<i8>
-    func private @vector_to_ptr8(tensor<?xf64, #CV64>) -> !llvm.ptr<i8>
-    
-    func private @delSparseMatrix(tensor<?x?xf64, #CSX64>) -> ()
-    func private @delSparseVector(tensor<?xf64, #CV64>) -> ()
-    func private @dup_matrix(tensor<?x?xf64, #CSX64>) -> tensor<?x?xf64, #CSX64>
-    func private @dup_vector(tensor<?xf64, #CV64>) -> tensor<?xf64, #CV64>
-
     {{ body }}
 
 }

--- a/mlir_graphblas/mlir_builder.py
+++ b/mlir_graphblas/mlir_builder.py
@@ -398,7 +398,9 @@ class MLIRFunctionBuilder(BaseFunction):
             assert function.get_mlir(make_private=True) == function_mlir_text
         else:
             if isinstance(function, MLIRFunctionBuilder):
-                function_mlir_text = function.get_mlir(make_private=True, include_func_defs=False)
+                function_mlir_text = function.get_mlir(
+                    make_private=True, include_func_defs=False
+                )
             else:
                 function_mlir_text = function.get_mlir(make_private=True)
             full_function_mlir_text = function.get_mlir_module(make_private=True)

--- a/mlir_graphblas/mlir_builder.py
+++ b/mlir_graphblas/mlir_builder.py
@@ -218,10 +218,13 @@ class MLIRFunctionBuilder(BaseFunction):
     # MLIR Generation/Compilation Methods #
     #######################################
 
-    def get_mlir(self, make_private=True) -> str:
-        needed_function_definitions = "\n\n".join(
-            func_def for func_def, _, _ in self.needed_function_table.values()
-        )
+    def get_mlir(self, make_private=True, include_func_defs=True) -> str:
+        if include_func_defs:
+            needed_function_definitions = "\n\n".join(
+                func_def for func_def, _, _ in self.needed_function_table.values()
+            )
+        else:
+            needed_function_definitions = ""
 
         joined_statements = "\n".join(self.function_body_statements)
 
@@ -394,7 +397,10 @@ class MLIRFunctionBuilder(BaseFunction):
             ]
             assert function.get_mlir(make_private=True) == function_mlir_text
         else:
-            function_mlir_text = function.get_mlir(make_private=True)
+            if isinstance(function, MLIRFunctionBuilder):
+                function_mlir_text = function.get_mlir(make_private=True, include_func_defs=False)
+            else:
+                function_mlir_text = function.get_mlir(make_private=True)
             full_function_mlir_text = function.get_mlir_module(make_private=True)
             mlir_ast = parse_mlir_functions(full_function_mlir_text, self.engine._cli)
             mlir_functions: List[mlir.astnodes.Function] = [
@@ -413,6 +419,11 @@ class MLIRFunctionBuilder(BaseFunction):
                 input_types,
                 return_type,  # TODO handle non-singleton returns here
             )
+            # Add function header definitions to self.needed_function_table
+            # Doing this avoid duplication conflicts
+            if isinstance(function, MLIRFunctionBuilder):
+                for key, vals in function.needed_function_table.items():
+                    self.needed_function_table[key] = vals
 
         result_var = self.new_var(return_type)  # TODO handle non-singleton returns here
         statement = "".join(

--- a/mlir_graphblas/ops.py
+++ b/mlir_graphblas/ops.py
@@ -723,6 +723,7 @@ class GraphBLAS_MatrixSelectRandom(BaseOp):
 # util ops
 ###########################################
 
+
 class PtrToTensorOp(BaseOp):
     dialect = "util"
     name = "ptr8_to_tensor"
@@ -735,7 +736,9 @@ class PtrToTensorOp(BaseOp):
         ret_val = irbuilder.new_var(return_type)
         funcname = f"ptr8_to_{tensor_type.to_short_string()}"
         irbuilder.needed_function_table[funcname] = (
-            f"func private @{funcname}(!llvm.ptr<i8>) -> {return_type}", ["!llvm.ptr<i8>"], return_type
+            f"func private @{funcname}(!llvm.ptr<i8>) -> {return_type}",
+            ["!llvm.ptr<i8>"],
+            return_type,
         )
 
         return ret_val, (
@@ -755,7 +758,9 @@ class TensorToPtrOp(BaseOp):
         ret_val = irbuilder.new_var("!llvm.ptr<i8>")
         funcname = f"{input.type.to_short_string()}_to_ptr8"
         irbuilder.needed_function_table[funcname] = (
-            f"func private @{funcname}({input.type}) -> !llvm.ptr<i8>", [str(input.type)], "!llvm.ptr<i8>"
+            f"func private @{funcname}({input.type}) -> !llvm.ptr<i8>",
+            [str(input.type)],
+            "!llvm.ptr<i8>",
         )
 
         return ret_val, (
@@ -774,7 +779,9 @@ class DelSparseTensor(BaseOp):
         input, cast_string = TensorToPtrOp.call(irbuilder, input)
         cast_string += "\n"
         irbuilder.needed_function_table["delSparseTensor"] = (
-            f"func private @delSparseTensor(!llvm.ptr<i8>) -> ()", ["!llvm.ptr<i8>"], ""
+            f"func private @delSparseTensor(!llvm.ptr<i8>) -> ()",
+            ["!llvm.ptr<i8>"],
+            "",
         )
 
         return None, cast_string + (

--- a/mlir_graphblas/ops.py
+++ b/mlir_graphblas/ops.py
@@ -701,70 +701,6 @@ class GraphBLAS_VectorArgMax(BaseOp):
 # util ops
 ###########################################
 
-# TODO these are used by the ops below ; should we inspect the
-# inputs to get the bitwidths instead of assuming 64?
-CSR64 = SparseEncodingType(["dense", "compressed"], [0, 1], 64, 64)
-CSC64 = SparseEncodingType(["dense", "compressed"], [1, 0], 64, 64)
-CSX64 = SparseEncodingType(["dense", "compressed"], None, 64, 64)
-CV64 = SparseEncodingType(["compressed"], None, 64, 64)
-
-
-class CastCsrToCsxOp(BaseOp):
-    dialect = "util"
-    name = "cast_csr_to_csx"
-
-    @classmethod
-    def call(cls, irbuilder, input):
-        cls.ensure_mlirvar(input)
-        ret_val = irbuilder.new_var(f"tensor<?x?xf64, {CSX64}>")
-        return ret_val, (
-            f"{ret_val.assign} = call @cast_csr_to_csx({input}) : "
-            f"({input.type}) -> tensor<?x?xf64, {CSX64}>"
-        )
-
-
-class CastCscToCsxOp(BaseOp):
-    dialect = "util"
-    name = "cast_csc_to_csx"
-
-    @classmethod
-    def call(cls, irbuilder, input):
-        cls.ensure_mlirvar(input)
-        ret_val = irbuilder.new_var(f"tensor<?x?xf64, {CSX64}>")
-        return ret_val, (
-            f"{ret_val.assign} = call @cast_csc_to_csx({input}) : "
-            f"({input.type}) -> tensor<?x?xf64, {CSX64}>"
-        )
-
-
-class CastCsxToCsrOp(BaseOp):
-    dialect = "util"
-    name = "cast_csx_to_csr"
-
-    @classmethod
-    def call(cls, irbuilder, input):
-        cls.ensure_mlirvar(input)
-        ret_val = irbuilder.new_var(f"tensor<?x?xf64, {CSR64}>")
-        return ret_val, (
-            f"{ret_val.assign} = call @cast_csx_to_csr({input}) : "
-            f"({input.type}) -> tensor<?x?xf64, {CSR64}>"
-        )
-
-
-class CastCsxToCscOp(BaseOp):
-    dialect = "util"
-    name = "cast_csx_to_csc"
-
-    @classmethod
-    def call(cls, irbuilder, input):
-        cls.ensure_mlirvar(input)
-        ret_val = irbuilder.new_var(f"tensor<?x?xf64, {CSC64}>")
-        return ret_val, (
-            f"{ret_val.assign} = call @cast_csx_to_csc({input}) : "
-            f"({input.type}) -> tensor<?x?xf64, {CSC64}>"
-        )
-
-
 class PtrToTensorOp(BaseOp):
     dialect = "util"
     name = "ptr8_to_tensor"
@@ -773,39 +709,17 @@ class PtrToTensorOp(BaseOp):
     def call(cls, irbuilder, input, return_type):
         cls.ensure_mlirvar(input)
         tensor_type = TensorType.parse(return_type, irbuilder.aliases)
-        encoding = tensor_type.encoding
-        if encoding.rank == 2:
-            if encoding.levels != ["dense", "compressed"]:
-                raise TypeError(
-                    f"Return type must denote a CSR or CSC tensor (got {return_type})."
-                )
-            ret_val = irbuilder.new_var(f"tensor<?x?xf64, {CSX64}>")
-            ret_string = (
-                f"{ret_val.assign} = call @ptr8_to_matrix({input}) : "
-                f"(!llvm.ptr<i8>) -> tensor<?x?xf64, {CSX64}>"
-            )
-            if encoding.ordering is None:
-                pass
-            elif encoding.ordering == [0, 1]:
-                ret_val, cast_string = CastCsxToCsrOp.call(irbuilder, ret_val)
-                ret_string = ret_string + "\n" + cast_string
-            elif encoding.ordering == [1, 0]:
-                ret_val, cast_string = CastCsxToCscOp.call(irbuilder, ret_val)
-                ret_string = ret_string + "\n" + cast_string
-            else:
-                raise TypeError(
-                    f"Return type must denote a CSR or CSC tensor (got {return_type})."
-                )
-        elif encoding.rank == 1:
-            ret_val = irbuilder.new_var(f"tensor<?xf64, {CV64}>")
-            ret_string = (
-                f"{ret_val.assign} = call @ptr8_to_vector({input}) : "
-                f"(!llvm.ptr<i8>) -> tensor<?xf64, {CV64}>"
-            )
-        else:
-            raise ValueError(f"Invalid rank: {encoding}")
 
-        return ret_val, ret_string
+        ret_val = irbuilder.new_var(return_type)
+        funcname = f"ptr8_to_{tensor_type.to_short_string()}"
+        irbuilder.needed_function_table[funcname] = (
+            f"func private @{funcname}(!llvm.ptr<i8>) -> {return_type}", ["!llvm.ptr<i8>"], return_type
+        )
+
+        return ret_val, (
+            f"{ret_val.assign} = call @{funcname}({input}) : "
+            f"(!llvm.ptr<i8>) -> {return_type}"
+        )
 
 
 class TensorToPtrOp(BaseOp):
@@ -817,37 +731,15 @@ class TensorToPtrOp(BaseOp):
         cls.ensure_mlirvar(input, TensorType)
 
         ret_val = irbuilder.new_var("!llvm.ptr<i8>")
-        encoding = input.type.encoding
-        if encoding.rank == 2:
-            if encoding.levels != ["dense", "compressed"]:
-                raise TypeError(
-                    f"Input type must denote a CSR or CSC tensor (got {input.type})."
-                )
+        funcname = f"{input.type.to_short_string()}_to_ptr8"
+        irbuilder.needed_function_table[funcname] = (
+            f"func private @{funcname}({input.type}) -> !llvm.ptr<i8>", [str(input.type)], "!llvm.ptr<i8>"
+        )
 
-            if encoding.ordering is None:
-                cast_string = ""
-            elif encoding.ordering == [0, 1]:
-                input, cast_string = CastCsrToCsxOp.call(irbuilder, input)
-                cast_string += "\n"
-            elif encoding.ordering == [1, 0]:
-                input, cast_string = CastCscToCsxOp.call(irbuilder, input)
-                cast_string += "\n"
-            else:
-                raise TypeError(
-                    f"Return type must denote a CSR or CSC tensor (got {input.type})."
-                )
-
-            return ret_val, cast_string + (
-                f"{ret_val.assign} = call @matrix_to_ptr8({input}) : "
-                f"({input.type}) -> !llvm.ptr<i8>"
-            )
-        elif encoding.rank == 1:
-            return ret_val, (
-                f"{ret_val.assign} = call @vector_to_ptr8({input}) : "
-                f"({input.type}) -> !llvm.ptr<i8>"
-            )
-        else:
-            raise ValueError(f"Invalid rank: {encoding}")
+        return ret_val, (
+            f"{ret_val.assign} = call @{funcname}({input}) : "
+            f"({input.type}) -> !llvm.ptr<i8>"
+        )
 
 
 class DelSparseTensor(BaseOp):
@@ -857,21 +749,12 @@ class DelSparseTensor(BaseOp):
     @classmethod
     def call(cls, irbuilder, input):
         cls.ensure_mlirvar(input, TensorType)
-        encoding = input.type.encoding
-        if encoding.rank == 2:
-            if encoding.ordering is None:
-                cast_string = ""
-            elif encoding.ordering == [0, 1]:
-                input, cast_string = CastCsrToCsxOp.call(irbuilder, input)
-                cast_string += "\n"
-            elif encoding.ordering == [1, 0]:
-                input, cast_string = CastCscToCsxOp.call(irbuilder, input)
-                cast_string += "\n"
+        input, cast_string = TensorToPtrOp.call(irbuilder, input)
+        cast_string += "\n"
+        irbuilder.needed_function_table["delSparseTensor"] = (
+            f"func private @delSparseTensor(!llvm.ptr<i8>) -> ()", ["!llvm.ptr<i8>"], ""
+        )
 
-            return None, cast_string + (
-                f"call @delSparseMatrix({input}) : ({input.type}) -> ()"
-            )
-        elif encoding.rank == 1:
-            return None, f"call @delSparseVector({input}) : ({input.type}) -> ()"
-        else:
-            raise ValueError(f"Invalid rank: {encoding}")
+        return None, cast_string + (
+            f"call @delSparseTensor({input}) : (!llvm.ptr<i8>) -> ()"
+        )

--- a/mlir_graphblas/sparse_utils.pyx
+++ b/mlir_graphblas/sparse_utils.pyx
@@ -306,18 +306,24 @@ cpdef empty_mlir_sparse_tensor_fast(uint64_t[:] sizes, bint is_sparse=True, poin
         else:
             raise TypeError(f"Invalid type combo for pointers, indices, and values: {pointer_dtype}, {index_dtype}, {value_dtype}")
     elif pointer_type_num == np.NPY_UINT64:
-        if index_type_num == np.NPY_UINT32:
-            if value_type_num == np.NPY_FLOAT32:
-                data = (new SparseTensorStorage[uint64_t, uint32_t, float32_t](sizes_vector, is_sparse))
-            elif value_type_num == np.NPY_FLOAT64:
-                data = (new SparseTensorStorage[uint64_t, uint32_t, float64_t](sizes_vector, is_sparse))
-            else:
-                raise TypeError(f"Invalid type combo for pointers, indices, and values: {pointer_dtype}, {index_dtype}, {value_dtype}")
-        elif index_type_num == np.NPY_UINT64:
+        if index_type_num == np.NPY_UINT64:
             if value_type_num == np.NPY_FLOAT32:
                 data = (new SparseTensorStorage[uint64_t, uint64_t, float32_t](sizes_vector, is_sparse))
             elif value_type_num == np.NPY_FLOAT64:
                 data = (new SparseTensorStorage[uint64_t, uint64_t, float64_t](sizes_vector, is_sparse))
+            elif value_type_num == np.NPY_INT8:
+                data = (new SparseTensorStorage[uint64_t, uint64_t, int8_t](sizes_vector, is_sparse))
+            elif value_type_num == np.NPY_INT16:
+                data = (new SparseTensorStorage[uint64_t, uint64_t, int16_t](sizes_vector, is_sparse))
+            elif value_type_num == np.NPY_INT32:
+                data = (new SparseTensorStorage[uint64_t, uint64_t, int32_t](sizes_vector, is_sparse))
+            else:
+                raise TypeError(f"Invalid type combo for pointers, indices, and values: {pointer_dtype}, {index_dtype}, {value_dtype}")
+        elif index_type_num == np.NPY_UINT32:
+            if value_type_num == np.NPY_FLOAT32:
+                data = (new SparseTensorStorage[uint64_t, uint32_t, float32_t](sizes_vector, is_sparse))
+            elif value_type_num == np.NPY_FLOAT64:
+                data = (new SparseTensorStorage[uint64_t, uint32_t, float64_t](sizes_vector, is_sparse))
             else:
                 raise TypeError(f"Invalid type combo for pointers, indices, and values: {pointer_dtype}, {index_dtype}, {value_dtype}")
         else:

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASPasses.td
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASPasses.td
@@ -17,6 +17,7 @@ def GraphBLASLowering : Pass<"graphblas-lower", "ModuleOp"> {
   let summary = "TODO add documentation";
   let constructor = "mlir::createGraphBLASLoweringPass()";
   let dependentDialects = [
+    "LLVM::LLVMDialect",
     "linalg::LinalgDialect",
     "AffineDialect",
     "memref::MemRefDialect",

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
@@ -41,24 +41,28 @@ bool typeIsCSR(mlir::Type inputType);
 bool typeIsCSC(mlir::Type inputType);
 mlir::RankedTensorType getCompressedVectorType(mlir::MLIRContext *context,
                                                mlir::ArrayRef<int64_t> shape,
+                                               mlir::Type valueType, unsigned ptrBitWidth, unsigned idxBitWidth);
+mlir::RankedTensorType getCompressedVectorType(mlir::MLIRContext *context,
                                                mlir::Type valueType);
-mlir::RankedTensorType getCSRTensorType(mlir::MLIRContext *context,
-                                        llvm::ArrayRef<int64_t> shape,
-                                        mlir::Type valueType);
-mlir::RankedTensorType getCSCTensorType(mlir::MLIRContext *context,
-                                        llvm::ArrayRef<int64_t> shape,
-                                        mlir::Type valueType);
+mlir::RankedTensorType getSingleCompressedMatrixType(mlir::MLIRContext *context,
+                                                     mlir::ArrayRef<int64_t> shape,
+                                                     bool columnOriented,
+                                                     mlir::Type valueType, unsigned ptrBitWidth, unsigned idxBitWidth);
+mlir::RankedTensorType getCSRType(mlir::MLIRContext *context,
+                                  mlir::Type valueType);
+mlir::RankedTensorType getCSCType(mlir::MLIRContext *context,
+                                  mlir::Type valueType);
 
 int64_t getRank(mlir::Type inputType);
 int64_t getRank(mlir::Value inputValue);
 
-mlir::Value convertToExternalCSR(mlir::OpBuilder &builder, mlir::ModuleOp &mod,
-                                 mlir::Location loc, mlir::Value input);
-mlir::Value convertToExternalCSC(mlir::OpBuilder &builder, mlir::ModuleOp &mod,
-                                 mlir::Location loc, mlir::Value input);
-mlir::Value callEmpty(mlir::OpBuilder &builder, mlir::ModuleOp &mod,
-                      mlir::Location loc, mlir::Value inputTensor,
-                      llvm::ArrayRef<int64_t> resultShape);
+mlir::Value castToPtr8(mlir::OpBuilder &builder, mlir::ModuleOp &mod,
+                       mlir::Location loc, mlir::Value input);
+mlir::Value castToTensor(mlir::OpBuilder &builder, mlir::ModuleOp &mod,
+                         mlir::Location loc, mlir::Value input, mlir::RankedTensorType tensorType);
+mlir::Value callNewTensor(mlir::OpBuilder &builder, mlir::ModuleOp &mod,
+                          mlir::Location loc, mlir::ValueRange shape,
+                          mlir::RankedTensorType tensorType);
 mlir::Value callEmptyLike(mlir::OpBuilder &builder, mlir::ModuleOp &mod,
                           mlir::Location loc, mlir::Value tensor);
 mlir::Value callDupTensor(mlir::OpBuilder &builder, mlir::ModuleOp &mod,

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
@@ -41,13 +41,16 @@ bool typeIsCSR(mlir::Type inputType);
 bool typeIsCSC(mlir::Type inputType);
 mlir::RankedTensorType getCompressedVectorType(mlir::MLIRContext *context,
                                                mlir::ArrayRef<int64_t> shape,
-                                               mlir::Type valueType, unsigned ptrBitWidth, unsigned idxBitWidth);
+                                               mlir::Type valueType,
+                                               unsigned ptrBitWidth,
+                                               unsigned idxBitWidth);
 mlir::RankedTensorType getCompressedVectorType(mlir::MLIRContext *context,
                                                mlir::Type valueType);
-mlir::RankedTensorType getSingleCompressedMatrixType(mlir::MLIRContext *context,
-                                                     mlir::ArrayRef<int64_t> shape,
-                                                     bool columnOriented,
-                                                     mlir::Type valueType, unsigned ptrBitWidth, unsigned idxBitWidth);
+mlir::RankedTensorType
+getSingleCompressedMatrixType(mlir::MLIRContext *context,
+                              mlir::ArrayRef<int64_t> shape,
+                              bool columnOriented, mlir::Type valueType,
+                              unsigned ptrBitWidth, unsigned idxBitWidth);
 mlir::RankedTensorType getCSRType(mlir::MLIRContext *context,
                                   mlir::Type valueType);
 mlir::RankedTensorType getCSCType(mlir::MLIRContext *context,
@@ -59,7 +62,8 @@ int64_t getRank(mlir::Value inputValue);
 mlir::Value castToPtr8(mlir::OpBuilder &builder, mlir::ModuleOp &mod,
                        mlir::Location loc, mlir::Value input);
 mlir::Value castToTensor(mlir::OpBuilder &builder, mlir::ModuleOp &mod,
-                         mlir::Location loc, mlir::Value input, mlir::RankedTensorType tensorType);
+                         mlir::Location loc, mlir::Value input,
+                         mlir::RankedTensorType tensorType);
 mlir::Value callNewTensor(mlir::OpBuilder &builder, mlir::ModuleOp &mod,
                           mlir::Location loc, mlir::ValueRange shape,
                           mlir::RankedTensorType tensorType);

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASLowerPass.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASLowerPass.cpp
@@ -135,19 +135,10 @@ public:
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
     Value inputTensor = op.input();
-    Type inputType = inputTensor.getType();
-    unsigned rank = inputType.dyn_cast<RankedTensorType>().getRank();
 
     Value duplicate = callDupTensor(rewriter, module, loc, inputTensor);
-    if (rank == 2) {
-      if (typeIsCSC(inputType)) {
-        duplicate = convertToExternalCSC(rewriter, module, loc, duplicate);
-      } else {
-        duplicate = convertToExternalCSR(rewriter, module, loc, duplicate);
-      }
-    }
-
     rewriter.replaceOp(op, duplicate);
+
     return success();
   };
 };
@@ -158,6 +149,7 @@ public:
   using OpRewritePattern<graphblas::ConvertLayoutOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(graphblas::ConvertLayoutOp op,
                                 PatternRewriter &rewriter) const override {
+    MLIRContext *context = op.getContext();
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
 
@@ -172,7 +164,12 @@ public:
     }
 
     // otherwise, the rest of this function changes the data layout
-    Type valueType = inputType.dyn_cast<RankedTensorType>().getElementType();
+    RankedTensorType inputTensorType = inputType.dyn_cast<RankedTensorType>();
+    sparse_tensor::SparseTensorEncodingAttr sparseEncoding =
+        sparse_tensor::getSparseTensorEncoding(inputTensorType);
+    unsigned ptrBitWidth = sparseEncoding.getPointerBitWidth();
+    unsigned idxBitWidth = sparseEncoding.getIndexBitWidth();
+    Type valueType = inputTensorType.getElementType();
     Type int64Type = rewriter.getIntegerType(64);
     Type indexType = rewriter.getIndexType();
 
@@ -216,12 +213,12 @@ public:
     callResizeIndex(rewriter, module, loc, duplicate, c1, nnz);
     callResizeValues(rewriter, module, loc, duplicate, nnz);
 
-    // verify function will ensure that this is CSR->CSC or CSC->CSR
-    Value output;
-    if (csr2csc)
-      output = convertToExternalCSC(rewriter, module, loc, duplicate);
-    else
-      output = convertToExternalCSR(rewriter, module, loc, duplicate);
+    // the verify function will ensure that this is CSR->CSC or CSC->CSR
+    Value output = castToPtr8(rewriter, module, loc, duplicate);
+    RankedTensorType flippedType = getSingleCompressedMatrixType(context, inputTensorType.getShape(),
+                                                                 csr2csc, valueType, ptrBitWidth,
+                                                                 idxBitWidth);
+    output = castToTensor(rewriter, module, loc, output, flippedType);
 
     Value outputPtrs = rewriter.create<sparse_tensor::ToPointersOp>(
         loc, memref1DI64Type, output, c1);
@@ -332,49 +329,47 @@ public:
   using OpRewritePattern<graphblas::TransposeOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(graphblas::TransposeOp op,
                                 PatternRewriter &rewriter) const override {
+    MLIRContext *context = op.getContext();
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
 
     Value inputTensor = op.input();
     RankedTensorType inputType =
         inputTensor.getType().dyn_cast<RankedTensorType>();
+    llvm::ArrayRef<int64_t> inputShape = inputType.getShape();
+    sparse_tensor::SparseTensorEncodingAttr sparseEncoding =
+        sparse_tensor::getSparseTensorEncoding(inputType);
+    unsigned ptrBitWidth = sparseEncoding.getPointerBitWidth();
+    unsigned idxBitWidth = sparseEncoding.getIndexBitWidth();
+    Type inputValueType = inputType.getElementType();
     RankedTensorType outputType =
         op->getResultTypes().front().dyn_cast<RankedTensorType>();
 
     bool inputTypeIsCSR = typeIsCSR(inputType);
     bool outputTypeIsCSR = typeIsCSR(outputType);
 
+    RankedTensorType flippedInputType = getSingleCompressedMatrixType(context, inputShape,
+                                                                      inputTypeIsCSR,
+                                                                      inputValueType, ptrBitWidth, idxBitWidth);
+
     // Add a graphblas.convert_layout op if the input and output compression
     // types are the same
     if (inputTypeIsCSR == outputTypeIsCSR) {
       // TODO consider separating this out into its own rewrite pattern
-      MLIRContext *context = op.getContext();
-      Type inputTensorValueType = inputType.getElementType();
-      llvm::ArrayRef<int64_t> inputShape = inputType.getShape();
-      RankedTensorType newType =
-          inputTypeIsCSR
-              ? getCSCTensorType(context, inputShape, inputTensorValueType)
-              : getCSRTensorType(context, inputShape, inputTensorValueType);
-      graphblas::ConvertLayoutOp newConvertLayoutOp =
-          rewriter.create<graphblas::ConvertLayoutOp>(loc, newType,
-                                                      inputTensor);
-      Value newLayOutInputTensor = newConvertLayoutOp.getResult();
-      graphblas::TransposeOp newTransposeOp =
-          rewriter.create<graphblas::TransposeOp>(loc, outputType,
-                                                  newLayOutInputTensor);
+      Value flippedInput =
+          rewriter.create<graphblas::ConvertLayoutOp>(loc, flippedInputType, inputTensor);
+      Value transposed =
+          rewriter.create<graphblas::TransposeOp>(loc, outputType, flippedInput);
 
-      rewriter.replaceOp(op, newTransposeOp.getResult());
+      rewriter.replaceOp(op, transposed);
 
       return success();
     }
 
     // Cast types
     Value output = callDupTensor(rewriter, module, loc, inputTensor);
-    if (inputTypeIsCSR) {
-      output = convertToExternalCSC(rewriter, module, loc, output);
-    } else {
-      output = convertToExternalCSR(rewriter, module, loc, output);
-    }
+    output = castToPtr8(rewriter, module, loc, output);
+    output = castToTensor(rewriter, module, loc, output, flippedInputType);
 
     // Swap sizes
     Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
@@ -614,6 +609,7 @@ public:
   using OpRewritePattern<graphblas::ReduceToVectorOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(graphblas::ReduceToVectorOp op,
                                 PatternRewriter &rewriter) const override {
+    MLIRContext *context = op.getContext();
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
 
@@ -630,32 +626,33 @@ public:
     if ((axis == 0 && matrixTypeIsCSR) || (axis == 1 && !matrixTypeIsCSR)) {
       // TODO consider moving this out to its own rewrite pattern
 
-      MLIRContext *context = op.getContext();
+      sparse_tensor::SparseTensorEncodingAttr sparseEncoding =
+        sparse_tensor::getSparseTensorEncoding(matrixType);
+      unsigned ptrBitWidth = sparseEncoding.getPointerBitWidth();
+      unsigned idxBitWidth = sparseEncoding.getIndexBitWidth();
 
-      RankedTensorType newMatrixType =
-          matrixTypeIsCSR ? getCSCTensorType(context, matrixShape, elementType)
-                          : getCSRTensorType(context, matrixShape, elementType);
-      graphblas::ConvertLayoutOp newConvertLayoutOp =
-          rewriter.create<graphblas::ConvertLayoutOp>(loc, newMatrixType,
-                                                      matrix);
-      Value newLayoutInputTensor = newConvertLayoutOp.getResult();
+      RankedTensorType flippedMatrixType =
+          getSingleCompressedMatrixType(context, matrixShape, matrixTypeIsCSR, elementType, ptrBitWidth, idxBitWidth);
+      Value convertedTensor =
+          rewriter.create<graphblas::ConvertLayoutOp>(loc, flippedMatrixType, matrix);
       Type originalVectorType = op->getResultTypes().front();
-      graphblas::ReduceToVectorOp newReduceOp =
+      Value reducedResult =
           rewriter.create<graphblas::ReduceToVectorOp>(
-              loc, originalVectorType, newLayoutInputTensor, aggregator, axis);
+              loc, originalVectorType, convertedTensor, aggregator, axis);
 
-      rewriter.replaceOp(op, newReduceOp.getResult());
+      rewriter.replaceOp(op, reducedResult);
 
       return success();
     }
 
-    if (matrixShape[0] != -1 || matrixShape[1] != -1) {
+    // TODO: why is this code here? We need a higher level strategy to either reject sparse tensors
+    // TODO:   with hardcoded shape or to automatically convert them to "?" for every graphblas op
+    // TODO:   as part of the structuralize passes
+    /*if (matrixShape[0] != -1 || matrixShape[1] != -1) {
       // TODO consider moving this out to its own rewrite pattern
 
       // TODO this casting doesn't actually safely lower down to the LLVM
       // dialect since it doesn't survive the --sparse-tensor-conversion pass
-
-      MLIRContext *context = op.getContext();
 
       static const ArrayRef<int64_t> newMatrixShape = {-1, -1};
       RankedTensorType newMatrixType =
@@ -679,7 +676,7 @@ public:
       rewriter.replaceOp(op, castVector);
 
       return success();
-    }
+    }*/
 
     Type indexType = rewriter.getIndexType();
     Type int64Type = rewriter.getIntegerType(64);
@@ -716,11 +713,10 @@ public:
     Value matrixValues = rewriter.create<sparse_tensor::ToValuesOp>(
         loc, memref1DValueType, matrix);
 
-    int64_t outputLength = (axis == 1) ? matrixShape[0] : matrixShape[1];
-    ArrayRef<int64_t> outputShape = {outputLength};
-    Value output = callEmpty(rewriter, module, loc, matrix, outputShape);
+    ValueRange outputShape = {len_dense_dim};
 
-    callResizeDim(rewriter, module, loc, output, c0, len_dense_dim);
+    RankedTensorType vectorType = getCompressedVectorType(context, elementType);
+    Value output = callNewTensor(rewriter, module, loc, outputShape, vectorType);
 
     scf::ForOp nnzLoop =
         rewriter.create<scf::ForOp>(loc, c0, len_dense_dim, c1, ValueRange{c0});
@@ -1375,7 +1371,6 @@ private:
     callResizeDim(rewriter, module, loc, C, c0, nrow);
     callResizeDim(rewriter, module, loc, C, c1, ncol);
     callResizePointers(rewriter, module, loc, C, c1, nrow_plus_one);
-    C = convertToExternalCSR(rewriter, module, loc, C);
 
     Value Ap = rewriter.create<sparse_tensor::ToPointersOp>(
         loc, memref1DI64Type, A, c1);
@@ -1479,7 +1474,6 @@ private:
     Value nnz = rewriter.create<graphblas::NumValsOp>(loc, C);
     callResizeIndex(rewriter, module, loc, C, c1, nnz);
     callResizeValues(rewriter, module, loc, C, nnz);
-    C = convertToExternalCSR(rewriter, module, loc, C);
     Value Cj = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memref1DI64Type,
                                                            C, c1);
     Value Cx =
@@ -2231,19 +2225,11 @@ public:
 
     unsigned rank = aType.getRank(); // ranks guaranteed to be equal
 
-    Value output;
+    Value output = callEmptyLike(rewriter, module, loc, a);
     if (rank == 2) {
-      Value outputX = callEmptyLike(rewriter, module, loc, a);
-      computeMatrixElementWise(rewriter, module, a, b, outputX, unionOperator,
+      computeMatrixElementWise(rewriter, module, a, b, output, unionOperator,
                                /* intersect */ false);
-      // Convert to same ordering as inputs
-      if (typeIsCSR(aType)) {
-        output = convertToExternalCSR(rewriter, module, loc, outputX);
-      } else {
-        output = convertToExternalCSC(rewriter, module, loc, outputX);
-      }
     } else {
-      output = callEmptyLike(rewriter, module, loc, a);
       computeVectorElementWise(rewriter, module, a, b, output, unionOperator,
                                /* intersect */ false);
     }
@@ -2274,19 +2260,11 @@ public:
 
     unsigned rank = aType.getRank(); // ranks guaranteed to be equal
 
-    Value output;
+    Value output = callEmptyLike(rewriter, module, loc, a);
     if (rank == 2) {
-      Value outputX = callEmptyLike(rewriter, module, loc, a);
-      computeMatrixElementWise(rewriter, module, a, b, outputX,
+      computeMatrixElementWise(rewriter, module, a, b, output,
                                intersectOperator, /* intersect */ true);
-      // Convert to same ordering as inputs
-      if (typeIsCSR(aType)) {
-        output = convertToExternalCSR(rewriter, module, loc, outputX);
-      } else {
-        output = convertToExternalCSC(rewriter, module, loc, outputX);
-      }
     } else {
-      output = callEmptyLike(rewriter, module, loc, a);
       computeVectorElementWise(rewriter, module, a, b, output,
                                intersectOperator, /* intersect */ true);
     }

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOps.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOps.cpp
@@ -64,7 +64,7 @@ checkCompressedMatrix(Type inputType, int inputIndex,
                        "sparse encoding.";
 
   // Even if (compressionType == EITHER), we still need to check that the
-  // dim ordering is present, i.e. not CSX
+  // dim ordering is present
   AffineMap dimOrdering = sparseEncoding.getDimOrdering();
   unsigned dimOrdering0 = dimOrdering.getDimPosition(0);
   unsigned dimOrdering1 = dimOrdering.getDimPosition(1);

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASUtils.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASUtils.cpp
@@ -242,10 +242,14 @@ void callDelSparseTensor(OpBuilder &builder, ModuleOp &mod, Location loc,
 Value callNewTensor(OpBuilder &builder, ModuleOp &mod, Location loc,
                     ValueRange shape, RankedTensorType tensorType) {
   Type indexType = builder.getIndexType();
+  int64_t rank = tensorType.getRank();
 
   std::string funcName = "new_" + buildSparseTypeString(tensorType);
-  FlatSymbolRefAttr func =
-      getFunc(mod, loc, funcName, tensorType, {indexType, indexType});
+  FlatSymbolRefAttr func;
+  if (rank == 2)
+    func = getFunc(mod, loc, funcName, tensorType, TypeRange{indexType, indexType});
+  else
+    func = getFunc(mod, loc, funcName, tensorType, TypeRange{indexType});
   CallOp callOpResult = builder.create<CallOp>(loc, func, tensorType, shape);
   Value result = callOpResult->getResult(0);
   return result;

--- a/mlir_graphblas/src/test/GraphBLAS/lower_apply_generic.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_apply_generic.mlir
@@ -13,19 +13,14 @@
   indexBitWidth = 64
 }>
 
-// CHECK-LABEL:   func private @cast_csx_to_csr(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:         func private @dup_matrix(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:         func private @cast_csr_to_csx(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:         func private @dup_vector(tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-
 // CHECK-LABEL:   func @apply_min_matrix(
-// CHECK-SAME:                                   %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
-// CHECK-SAME:                                   %[[VAL_1:.*]]: f64) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:           %[[VAL_2:.*]] = constant 1 : index
-// CHECK:           %[[VAL_3:.*]] = constant 0 : index
-// CHECK:           %[[VAL_4:.*]] = call @cast_csr_to_csx(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_5:.*]] = call @dup_matrix(%[[VAL_4]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_6:.*]] = call @cast_csx_to_csr(%[[VAL_5]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK-SAME:                           %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
+// CHECK-SAME:                           %[[VAL_1:.*]]: f64) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK-DAG:       %[[VAL_2:.*]] = constant 1 : index
+// CHECK-DAG:       %[[VAL_3:.*]] = constant 0 : index
+// CHECK:           %[[VAL_4:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_5:.*]] = call @dup_tensor(%[[VAL_4]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_6:.*]] = call @ptr8_to_matrix_csr_f64_p64i64(%[[VAL_5]]) : (!llvm.ptr<i8>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_7:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           %[[VAL_8:.*]] = sparse_tensor.values %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           %[[VAL_9:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
@@ -53,24 +48,26 @@ func @apply_min_matrix(%sparse_tensor: tensor<?x?xf64, #CSR64>, %thunk: f64) -> 
 }
 
 // CHECK-LABEL:   func @apply_min_vector(
-// CHECK-SAME:                                   %[[VAL_0:.*]]: tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>,
-// CHECK-SAME:                                   %[[VAL_1:.*]]: f64) -> tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:           %[[VAL_2:.*]] = constant 0 : index
-// CHECK:           %[[VAL_3:.*]] = constant 1 : index
-// CHECK:           %[[VAL_4:.*]] = call @dup_vector(%[[VAL_0]]) : (tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_5:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_6:.*]] = sparse_tensor.values %[[VAL_4]] : tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_7:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_8:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_3]]] : memref<?xi64>
-// CHECK:           %[[VAL_9:.*]] = index_cast %[[VAL_8]] : i64 to index
-// CHECK:           scf.parallel (%[[VAL_10:.*]]) = (%[[VAL_2]]) to (%[[VAL_9]]) step (%[[VAL_3]]) {
-// CHECK:             %[[VAL_11:.*]] = memref.load %[[VAL_5]]{{\[}}%[[VAL_10]]] : memref<?xf64>
-// CHECK:             %[[VAL_12:.*]] = cmpf olt, %[[VAL_11]], %[[VAL_1]] : f64
-// CHECK:             %[[VAL_13:.*]] = select %[[VAL_12]], %[[VAL_11]], %[[VAL_1]] : f64
-// CHECK:             memref.store %[[VAL_13]], %[[VAL_6]]{{\[}}%[[VAL_10]]] : memref<?xf64>
+// CHECK-SAME:                           %[[VAL_0:.*]]: tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>,
+// CHECK-SAME:                           %[[VAL_1:.*]]: f64) -> tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK-DAG:       %[[VAL_2:.*]] = constant 0 : index
+// CHECK-DAG:       %[[VAL_3:.*]] = constant 1 : index
+// CHECK:           %[[VAL_4:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_5:.*]] = call @dup_tensor(%[[VAL_4]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_6:.*]] = call @ptr8_to_vector_f64_p64i64(%[[VAL_5]]) : (!llvm.ptr<i8>) -> tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_7:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_8:.*]] = sparse_tensor.values %[[VAL_6]] : tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_9:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_10:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_3]]] : memref<?xi64>
+// CHECK:           %[[VAL_11:.*]] = index_cast %[[VAL_10]] : i64 to index
+// CHECK:           scf.parallel (%[[VAL_12:.*]]) = (%[[VAL_2]]) to (%[[VAL_11]]) step (%[[VAL_3]]) {
+// CHECK:             %[[VAL_13:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_12]]] : memref<?xf64>
+// CHECK:             %[[VAL_14:.*]] = cmpf olt, %[[VAL_13]], %[[VAL_1]] : f64
+// CHECK:             %[[VAL_15:.*]] = select %[[VAL_14]], %[[VAL_13]], %[[VAL_1]] : f64
+// CHECK:             memref.store %[[VAL_15]], %[[VAL_8]]{{\[}}%[[VAL_12]]] : memref<?xf64>
 // CHECK:             scf.yield
 // CHECK:           }
-// CHECK:           return %[[VAL_4]] : tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           return %[[VAL_6]] : tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
 
 func @apply_min_vector(%sparse_tensor: tensor<7xf64, #SparseVec64>, %thunk: f64) -> tensor<7xf64, #SparseVec64> {

--- a/mlir_graphblas/src/test/GraphBLAS/lower_comment.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_comment.mlir
@@ -7,38 +7,32 @@
   indexBitWidth = 64
 }>
 
-// CHECK-DAG:     func private @matrix_resize_values(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index)
-// CHECK-DAG:     func private @matrix_resize_index(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK-DAG:     func private @cast_csx_to_csr(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK-DAG:     func private @dup_matrix(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK-DAG:     func private @cast_csr_to_csx(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-
 // CHECK-LABEL:   func @select_triu(
 // CHECK-SAME:                      %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK-DAG:       %[[VAL_1:.*]] = constant 0 : index
-// CHECK-DAG:       %[[VAL_2:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 0 : i64
-// CHECK-DAG:       %[[VAL_4:.*]] = constant 1 : i64
-// CHECK:           %[[VAL_5:.*]] = tensor.dim %[[VAL_0]], %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_6:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_7:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK-DAG:       %[[VAL_1:.*]] = constant 0 : i64
+// CHECK-DAG:       %[[VAL_2:.*]] = constant 1 : i64
+// CHECK-DAG:       %[[VAL_3:.*]] = constant 1 : index
+// CHECK-DAG:       %[[VAL_4:.*]] = constant 0 : index
+// CHECK:           %[[VAL_5:.*]] = tensor.dim %[[VAL_0]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_6:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_7:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_8:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_9:.*]] = call @cast_csr_to_csx(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_10:.*]] = call @dup_matrix(%[[VAL_9]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_11:.*]] = call @cast_csx_to_csr(%[[VAL_10]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_12:.*]] = sparse_tensor.pointers %[[VAL_11]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_13:.*]] = sparse_tensor.indices %[[VAL_11]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_9:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_10:.*]] = call @dup_tensor(%[[VAL_9]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_11:.*]] = call @ptr8_to_matrix_csr_f64_p64i64(%[[VAL_10]]) : (!llvm.ptr<i8>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_12:.*]] = sparse_tensor.pointers %[[VAL_11]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_13:.*]] = sparse_tensor.indices %[[VAL_11]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_14:.*]] = sparse_tensor.values %[[VAL_11]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           memref.store %[[VAL_3]], %[[VAL_12]]{{\[}}%[[VAL_1]]] : memref<?xi64>
-// CHECK:           scf.for %[[VAL_15:.*]] = %[[VAL_1]] to %[[VAL_5]] step %[[VAL_2]] {
-// CHECK:             %[[VAL_16:.*]] = addi %[[VAL_15]], %[[VAL_2]] : index
+// CHECK:           memref.store %[[VAL_1]], %[[VAL_12]]{{\[}}%[[VAL_4]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_15:.*]] = %[[VAL_4]] to %[[VAL_5]] step %[[VAL_3]] {
+// CHECK:             %[[VAL_16:.*]] = addi %[[VAL_15]], %[[VAL_3]] : index
 // CHECK:             %[[VAL_17:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_15]]] : memref<?xi64>
 // CHECK:             memref.store %[[VAL_17]], %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:             %[[VAL_18:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_15]]] : memref<?xi64>
 // CHECK:             %[[VAL_19:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:             %[[VAL_20:.*]] = index_cast %[[VAL_18]] : i64 to index
 // CHECK:             %[[VAL_21:.*]] = index_cast %[[VAL_19]] : i64 to index
-// CHECK:             scf.for %[[VAL_22:.*]] = %[[VAL_20]] to %[[VAL_21]] step %[[VAL_2]] {
+// CHECK:             scf.for %[[VAL_22:.*]] = %[[VAL_20]] to %[[VAL_21]] step %[[VAL_3]] {
 // CHECK:               %[[VAL_23:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_22]]] : memref<?xi64>
 // CHECK:               %[[VAL_24:.*]] = index_cast %[[VAL_23]] : i64 to index
 // CHECK:               %[[VAL_25:.*]] = memref.load %[[VAL_8]]{{\[}}%[[VAL_22]]] : memref<?xf64>
@@ -48,19 +42,19 @@
 // CHECK:                 %[[VAL_28:.*]] = index_cast %[[VAL_27]] : i64 to index
 // CHECK:                 memref.store %[[VAL_23]], %[[VAL_13]]{{\[}}%[[VAL_28]]] : memref<?xi64>
 // CHECK:                 memref.store %[[VAL_25]], %[[VAL_14]]{{\[}}%[[VAL_28]]] : memref<?xf64>
-// CHECK:                 %[[VAL_29:.*]] = addi %[[VAL_27]], %[[VAL_4]] : i64
+// CHECK:                 %[[VAL_29:.*]] = addi %[[VAL_27]], %[[VAL_2]] : i64
 // CHECK:                 memref.store %[[VAL_29]], %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:               }
 // CHECK:             }
 // CHECK:           }
-// CHECK:           %[[VAL_100:.*]] = sparse_tensor.pointers %[[VAL_11]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_101:.*]] = tensor.dim %[[VAL_11]], %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_30:.*]] = memref.load %[[VAL_100]]{{\[}}%[[VAL_101]]] : memref<?xi64>
-// CHECK:           %[[VAL_31:.*]] = index_cast %[[VAL_30]] : i64 to index
-// CHECK:           %[[VAL_32:.*]] = call @cast_csr_to_csx(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @matrix_resize_index(%[[VAL_32]], %[[VAL_2]], %[[VAL_31]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           %[[VAL_33:.*]] = call @cast_csr_to_csx(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @matrix_resize_values(%[[VAL_33]], %[[VAL_31]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
+// CHECK:           %[[VAL_30:.*]] = sparse_tensor.pointers %[[VAL_11]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_31:.*]] = tensor.dim %[[VAL_11]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_32:.*]] = memref.load %[[VAL_30]]{{\[}}%[[VAL_31]]] : memref<?xi64>
+// CHECK:           %[[VAL_33:.*]] = index_cast %[[VAL_32]] : i64 to index
+// CHECK:           %[[VAL_34:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_index(%[[VAL_34]], %[[VAL_3]], %[[VAL_33]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_35:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_values(%[[VAL_35]], %[[VAL_33]]) : (!llvm.ptr<i8>, index) -> ()
 // CHECK:           return %[[VAL_11]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
 

--- a/mlir_graphblas/src/test/GraphBLAS/lower_convert_layout.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_convert_layout.mlir
@@ -14,91 +14,88 @@
   indexBitWidth = 64
 }>
 
-// CHECK-DAG:     func private @cast_csx_to_csc(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK-DAG:     func private @cast_csr_to_csx(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK-DAG:     func private @cast_csx_to_csr(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK-DAG:     func private @matrix_resize_values(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index)
-// CHECK-DAG:     func private @matrix_resize_index(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK-DAG:     func private @matrix_resize_pointers(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK-DAG:     func private @matrix_resize_dim(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK-DAG:     func private @matrix_empty_like(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK-DAG:     func private @cast_csc_to_csx(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-
 // CHECK-LABEL:   func @convert_layout(
 // CHECK-SAME:                         %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK-DAG:       %[[VAL_1:.*]] = constant 0 : index
-// CHECK-DAG:       %[[VAL_2:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 0 : i64
-// CHECK-DAG:       %[[VAL_4:.*]] = constant 1 : i64
-// CHECK:           %[[VAL_5:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_6:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK-DAG:       %[[VAL_1:.*]] = constant 0 : i64
+// CHECK-DAG:       %[[VAL_2:.*]] = constant 1 : i64
+// CHECK-DAG:       %[[VAL_3:.*]] = constant 1 : index
+// CHECK-DAG:       %[[VAL_4:.*]] = constant 0 : index
+// CHECK:           %[[VAL_5:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_6:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_7:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_8:.*]] = tensor.dim %[[VAL_0]], %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_9:.*]] = tensor.dim %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_100:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_101:.*]] = tensor.dim %[[VAL_0]], %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_11:.*]] = memref.load %[[VAL_100]]{{\[}}%[[VAL_101]]] : memref<?xi64>
-// CHECK:           %[[VAL_12:.*]] = index_cast %[[VAL_11]] : i64 to index
-// CHECK:           %[[VAL_13:.*]] = call @cast_csr_to_csx(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_14:.*]] = call @matrix_empty_like(%[[VAL_13]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @matrix_resize_dim(%[[VAL_14]], %[[VAL_1]], %[[VAL_8]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @matrix_resize_dim(%[[VAL_14]], %[[VAL_2]], %[[VAL_9]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           %[[VAL_10:.*]] = addi %[[VAL_9]], %[[VAL_2]] : index
-// CHECK:           call @matrix_resize_pointers(%[[VAL_14]], %[[VAL_2]], %[[VAL_10]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @matrix_resize_index(%[[VAL_14]], %[[VAL_2]], %[[VAL_12]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @matrix_resize_values(%[[VAL_14]], %[[VAL_12]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
-// CHECK:           %[[VAL_15:.*]] = call @cast_csx_to_csc(%[[VAL_14]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_16:.*]] = sparse_tensor.pointers %[[VAL_15]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_17:.*]] = sparse_tensor.indices %[[VAL_15]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_18:.*]] = sparse_tensor.values %[[VAL_15]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           scf.for %[[VAL_19:.*]] = %[[VAL_1]] to %[[VAL_9]] step %[[VAL_2]] {
-// CHECK:             memref.store %[[VAL_3]], %[[VAL_16]]{{\[}}%[[VAL_19]]] : memref<?xi64>
+// CHECK:           %[[VAL_8:.*]] = tensor.dim %[[VAL_0]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_9:.*]] = tensor.dim %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_10:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_11:.*]] = tensor.dim %[[VAL_0]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_12:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_11]]] : memref<?xi64>
+// CHECK:           %[[VAL_13:.*]] = index_cast %[[VAL_12]] : i64 to index
+// CHECK:           %[[VAL_14:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_15:.*]] = call @empty_like(%[[VAL_14]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_16:.*]] = call @ptr8_to_matrix_csr_f64_p64i64(%[[VAL_15]]) : (!llvm.ptr<i8>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_17:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_16]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_dim(%[[VAL_17]], %[[VAL_4]], %[[VAL_8]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_18:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_16]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_dim(%[[VAL_18]], %[[VAL_3]], %[[VAL_9]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_19:.*]] = addi %[[VAL_9]], %[[VAL_3]] : index
+// CHECK:           %[[VAL_20:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_16]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_pointers(%[[VAL_20]], %[[VAL_3]], %[[VAL_19]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_21:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_16]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_index(%[[VAL_21]], %[[VAL_3]], %[[VAL_13]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_22:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_16]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_values(%[[VAL_22]], %[[VAL_13]]) : (!llvm.ptr<i8>, index) -> ()
+// CHECK:           %[[VAL_23:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_16]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_24:.*]] = call @ptr8_to_matrix_csc_f64_p64i64(%[[VAL_23]]) : (!llvm.ptr<i8>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_25:.*]] = sparse_tensor.pointers %[[VAL_24]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_26:.*]] = sparse_tensor.indices %[[VAL_24]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_27:.*]] = sparse_tensor.values %[[VAL_24]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           scf.for %[[VAL_28:.*]] = %[[VAL_4]] to %[[VAL_9]] step %[[VAL_3]] {
+// CHECK:             memref.store %[[VAL_1]], %[[VAL_25]]{{\[}}%[[VAL_28]]] : memref<?xi64>
 // CHECK:           }
-// CHECK:           scf.for %[[VAL_20:.*]] = %[[VAL_1]] to %[[VAL_12]] step %[[VAL_2]] {
-// CHECK:             %[[VAL_21:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_20]]] : memref<?xi64>
-// CHECK:             %[[VAL_22:.*]] = index_cast %[[VAL_21]] : i64 to index
-// CHECK:             %[[VAL_23:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_22]]] : memref<?xi64>
-// CHECK:             %[[VAL_24:.*]] = addi %[[VAL_23]], %[[VAL_4]] : i64
-// CHECK:             memref.store %[[VAL_24]], %[[VAL_16]]{{\[}}%[[VAL_22]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_29:.*]] = %[[VAL_4]] to %[[VAL_13]] step %[[VAL_3]] {
+// CHECK:             %[[VAL_30:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_29]]] : memref<?xi64>
+// CHECK:             %[[VAL_31:.*]] = index_cast %[[VAL_30]] : i64 to index
+// CHECK:             %[[VAL_32:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_31]]] : memref<?xi64>
+// CHECK:             %[[VAL_33:.*]] = addi %[[VAL_32]], %[[VAL_2]] : i64
+// CHECK:             memref.store %[[VAL_33]], %[[VAL_25]]{{\[}}%[[VAL_31]]] : memref<?xi64>
 // CHECK:           }
-// CHECK:           memref.store %[[VAL_3]], %[[VAL_16]]{{\[}}%[[VAL_9]]] : memref<?xi64>
-// CHECK:           scf.for %[[VAL_25:.*]] = %[[VAL_1]] to %[[VAL_9]] step %[[VAL_2]] {
-// CHECK:             %[[VAL_26:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_25]]] : memref<?xi64>
-// CHECK:             %[[VAL_27:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_9]]] : memref<?xi64>
-// CHECK:             memref.store %[[VAL_27]], %[[VAL_16]]{{\[}}%[[VAL_25]]] : memref<?xi64>
-// CHECK:             %[[VAL_28:.*]] = addi %[[VAL_27]], %[[VAL_26]] : i64
-// CHECK:             memref.store %[[VAL_28]], %[[VAL_16]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:           memref.store %[[VAL_1]], %[[VAL_25]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_34:.*]] = %[[VAL_4]] to %[[VAL_9]] step %[[VAL_3]] {
+// CHECK:             %[[VAL_35:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_34]]] : memref<?xi64>
+// CHECK:             %[[VAL_36:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_36]], %[[VAL_25]]{{\[}}%[[VAL_34]]] : memref<?xi64>
+// CHECK:             %[[VAL_37:.*]] = addi %[[VAL_36]], %[[VAL_35]] : i64
+// CHECK:             memref.store %[[VAL_37]], %[[VAL_25]]{{\[}}%[[VAL_9]]] : memref<?xi64>
 // CHECK:           }
-// CHECK:           scf.for %[[VAL_29:.*]] = %[[VAL_1]] to %[[VAL_8]] step %[[VAL_2]] {
-// CHECK:             %[[VAL_30:.*]] = index_cast %[[VAL_29]] : index to i64
-// CHECK:             %[[VAL_31:.*]] = memref.load %[[VAL_5]]{{\[}}%[[VAL_29]]] : memref<?xi64>
-// CHECK:             %[[VAL_32:.*]] = index_cast %[[VAL_31]] : i64 to index
-// CHECK:             %[[VAL_33:.*]] = addi %[[VAL_29]], %[[VAL_2]] : index
-// CHECK:             %[[VAL_34:.*]] = memref.load %[[VAL_5]]{{\[}}%[[VAL_33]]] : memref<?xi64>
-// CHECK:             %[[VAL_35:.*]] = index_cast %[[VAL_34]] : i64 to index
-// CHECK:             scf.for %[[VAL_36:.*]] = %[[VAL_32]] to %[[VAL_35]] step %[[VAL_2]] {
-// CHECK:               %[[VAL_37:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_36]]] : memref<?xi64>
-// CHECK:               %[[VAL_38:.*]] = index_cast %[[VAL_37]] : i64 to index
-// CHECK:               %[[VAL_39:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_38]]] : memref<?xi64>
-// CHECK:               %[[VAL_40:.*]] = index_cast %[[VAL_39]] : i64 to index
-// CHECK:               memref.store %[[VAL_30]], %[[VAL_17]]{{\[}}%[[VAL_40]]] : memref<?xi64>
-// CHECK:               %[[VAL_41:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_36]]] : memref<?xf64>
-// CHECK:               memref.store %[[VAL_41]], %[[VAL_18]]{{\[}}%[[VAL_40]]] : memref<?xf64>
-// CHECK:               %[[VAL_42:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_38]]] : memref<?xi64>
-// CHECK:               %[[VAL_43:.*]] = addi %[[VAL_42]], %[[VAL_4]] : i64
-// CHECK:               memref.store %[[VAL_43]], %[[VAL_16]]{{\[}}%[[VAL_38]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_38:.*]] = %[[VAL_4]] to %[[VAL_8]] step %[[VAL_3]] {
+// CHECK:             %[[VAL_39:.*]] = index_cast %[[VAL_38]] : index to i64
+// CHECK:             %[[VAL_40:.*]] = memref.load %[[VAL_5]]{{\[}}%[[VAL_38]]] : memref<?xi64>
+// CHECK:             %[[VAL_41:.*]] = index_cast %[[VAL_40]] : i64 to index
+// CHECK:             %[[VAL_42:.*]] = addi %[[VAL_38]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_43:.*]] = memref.load %[[VAL_5]]{{\[}}%[[VAL_42]]] : memref<?xi64>
+// CHECK:             %[[VAL_44:.*]] = index_cast %[[VAL_43]] : i64 to index
+// CHECK:             scf.for %[[VAL_45:.*]] = %[[VAL_41]] to %[[VAL_44]] step %[[VAL_3]] {
+// CHECK:               %[[VAL_46:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_45]]] : memref<?xi64>
+// CHECK:               %[[VAL_47:.*]] = index_cast %[[VAL_46]] : i64 to index
+// CHECK:               %[[VAL_48:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_47]]] : memref<?xi64>
+// CHECK:               %[[VAL_49:.*]] = index_cast %[[VAL_48]] : i64 to index
+// CHECK:               memref.store %[[VAL_39]], %[[VAL_26]]{{\[}}%[[VAL_49]]] : memref<?xi64>
+// CHECK:               %[[VAL_50:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_45]]] : memref<?xf64>
+// CHECK:               memref.store %[[VAL_50]], %[[VAL_27]]{{\[}}%[[VAL_49]]] : memref<?xf64>
+// CHECK:               %[[VAL_51:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_47]]] : memref<?xi64>
+// CHECK:               %[[VAL_52:.*]] = addi %[[VAL_51]], %[[VAL_2]] : i64
+// CHECK:               memref.store %[[VAL_52]], %[[VAL_25]]{{\[}}%[[VAL_47]]] : memref<?xi64>
 // CHECK:             }
 // CHECK:           }
-// CHECK:           %[[VAL_44:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_9]]] : memref<?xi64>
-// CHECK:           memref.store %[[VAL_3]], %[[VAL_16]]{{\[}}%[[VAL_9]]] : memref<?xi64>
-// CHECK:           scf.for %[[VAL_45:.*]] = %[[VAL_1]] to %[[VAL_9]] step %[[VAL_2]] {
-// CHECK:             %[[VAL_46:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_45]]] : memref<?xi64>
-// CHECK:             %[[VAL_47:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_9]]] : memref<?xi64>
-// CHECK:             memref.store %[[VAL_47]], %[[VAL_16]]{{\[}}%[[VAL_45]]] : memref<?xi64>
-// CHECK:             memref.store %[[VAL_46]], %[[VAL_16]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:           %[[VAL_53:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:           memref.store %[[VAL_1]], %[[VAL_25]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_54:.*]] = %[[VAL_4]] to %[[VAL_9]] step %[[VAL_3]] {
+// CHECK:             %[[VAL_55:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_54]]] : memref<?xi64>
+// CHECK:             %[[VAL_56:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_56]], %[[VAL_25]]{{\[}}%[[VAL_54]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_55]], %[[VAL_25]]{{\[}}%[[VAL_9]]] : memref<?xi64>
 // CHECK:           }
-// CHECK:           memref.store %[[VAL_44]], %[[VAL_16]]{{\[}}%[[VAL_9]]] : memref<?xi64>
-// CHECK:           return %[[VAL_15]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           memref.store %[[VAL_53]], %[[VAL_25]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:           return %[[VAL_24]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
 
 func @convert_layout(%sparse_tensor: tensor<?x?xf64, #CSR64>) -> tensor<?x?xf64, #CSC64> {

--- a/mlir_graphblas/src/test/GraphBLAS/lower_intersect.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_intersect.mlir
@@ -14,113 +14,117 @@
 }>
 
 
-// CHECK-LABEL:   func @vector_intersect(
-// CHECK-SAME:                           %[[VAL_0:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>,
-// CHECK-SAME:                           %[[VAL_1:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK-LABEL:   .func @vector_intersect(
+// CHECK-SAME:                            %[[VAL_0:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>,
+// CHECK-SAME:                            %[[VAL_1:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK-DAG:       %[[VAL_2:.*]] = constant 0 : index
 // CHECK-DAG:       %[[VAL_3:.*]] = constant 1 : index
 // CHECK-DAG:       %[[VAL_4:.*]] = constant 0 : i64
 // CHECK-DAG:       %[[VAL_5:.*]] = constant false
 // CHECK-DAG:       %[[VAL_6:.*]] = constant true
 // CHECK-DAG:       %[[VAL_7:.*]] = constant 0.000000e+00 : f64
-// CHECK:           %[[VAL_8:.*]] = call @vector_empty_like(%[[VAL_0]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_9:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_10:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_3]]] : memref<?xi64>
-// CHECK:           %[[VAL_11:.*]] = index_cast %[[VAL_10]] : i64 to index
-// CHECK:           %[[VAL_12:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_13:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_3]]] : memref<?xi64>
-// CHECK:           %[[VAL_14:.*]] = index_cast %[[VAL_13]] : i64 to index
-// CHECK:           %[[VAL_15:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_16:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_17:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_18:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_19:.*]]:7 = scf.while (%[[VAL_20:.*]] = %[[VAL_2]], %[[VAL_21:.*]] = %[[VAL_2]], %[[VAL_22:.*]] = %[[VAL_2]], %[[VAL_23:.*]] = %[[VAL_2]], %[[VAL_24:.*]] = %[[VAL_6]], %[[VAL_25:.*]] = %[[VAL_6]], %[[VAL_26:.*]] = %[[VAL_2]]) : (index, index, index, index, i1, i1, index) -> (index, index, index, index, i1, i1, index) {
-// CHECK:             %[[VAL_27:.*]] = cmpi ult, %[[VAL_20]], %[[VAL_11]] : index
-// CHECK:             %[[VAL_28:.*]] = cmpi ult, %[[VAL_21]], %[[VAL_14]] : index
-// CHECK:             %[[VAL_29:.*]] = and %[[VAL_27]], %[[VAL_28]] : i1
-// CHECK:             scf.condition(%[[VAL_29]]) %[[VAL_20]], %[[VAL_21]], %[[VAL_22]], %[[VAL_23]], %[[VAL_24]], %[[VAL_25]], %[[VAL_26]] : index, index, index, index, i1, i1, index
+// CHECK:           %[[VAL_8:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_9:.*]] = call @empty_like(%[[VAL_8]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_10:.*]] = call @ptr8_to_vector_f64_p64i64(%[[VAL_9]]) : (!llvm.ptr<i8>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_11:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_12:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_3]]] : memref<?xi64>
+// CHECK:           %[[VAL_13:.*]] = index_cast %[[VAL_12]] : i64 to index
+// CHECK:           %[[VAL_14:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_15:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_3]]] : memref<?xi64>
+// CHECK:           %[[VAL_16:.*]] = index_cast %[[VAL_15]] : i64 to index
+// CHECK:           %[[VAL_17:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_18:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_19:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_20:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_21:.*]]:7 = scf.while (%[[VAL_22:.*]] = %[[VAL_2]], %[[VAL_23:.*]] = %[[VAL_2]], %[[VAL_24:.*]] = %[[VAL_2]], %[[VAL_25:.*]] = %[[VAL_2]], %[[VAL_26:.*]] = %[[VAL_6]], %[[VAL_27:.*]] = %[[VAL_6]], %[[VAL_28:.*]] = %[[VAL_2]]) : (index, index, index, index, i1, i1, index) -> (index, index, index, index, i1, i1, index) {
+// CHECK:             %[[VAL_29:.*]] = cmpi ult, %[[VAL_22]], %[[VAL_13]] : index
+// CHECK:             %[[VAL_30:.*]] = cmpi ult, %[[VAL_23]], %[[VAL_16]] : index
+// CHECK:             %[[VAL_31:.*]] = and %[[VAL_29]], %[[VAL_30]] : i1
+// CHECK:             scf.condition(%[[VAL_31]]) %[[VAL_22]], %[[VAL_23]], %[[VAL_24]], %[[VAL_25]], %[[VAL_26]], %[[VAL_27]], %[[VAL_28]] : index, index, index, index, i1, i1, index
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_30:.*]]: index, %[[VAL_31:.*]]: index, %[[VAL_32:.*]]: index, %[[VAL_33:.*]]: index, %[[VAL_34:.*]]: i1, %[[VAL_35:.*]]: i1, %[[VAL_36:.*]]: index):
-// CHECK:             %[[VAL_37:.*]] = scf.if %[[VAL_34]] -> (index) {
-// CHECK:               %[[VAL_38:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_30]]] : memref<?xi64>
-// CHECK:               %[[VAL_39:.*]] = index_cast %[[VAL_38]] : i64 to index
-// CHECK:               scf.yield %[[VAL_39]] : index
+// CHECK:           ^bb0(%[[VAL_32:.*]]: index, %[[VAL_33:.*]]: index, %[[VAL_34:.*]]: index, %[[VAL_35:.*]]: index, %[[VAL_36:.*]]: i1, %[[VAL_37:.*]]: i1, %[[VAL_38:.*]]: index):
+// CHECK:             %[[VAL_39:.*]] = scf.if %[[VAL_36]] -> (index) {
+// CHECK:               %[[VAL_40:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_32]]] : memref<?xi64>
+// CHECK:               %[[VAL_41:.*]] = index_cast %[[VAL_40]] : i64 to index
+// CHECK:               scf.yield %[[VAL_41]] : index
 // CHECK:             } else {
-// CHECK:               scf.yield %[[VAL_32]] : index
+// CHECK:               scf.yield %[[VAL_34]] : index
 // CHECK:             }
-// CHECK:             %[[VAL_40:.*]] = scf.if %[[VAL_35]] -> (index) {
-// CHECK:               %[[VAL_41:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_31]]] : memref<?xi64>
-// CHECK:               %[[VAL_42:.*]] = index_cast %[[VAL_41]] : i64 to index
-// CHECK:               scf.yield %[[VAL_42]] : index
+// CHECK:             %[[VAL_42:.*]] = scf.if %[[VAL_37]] -> (index) {
+// CHECK:               %[[VAL_43:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_33]]] : memref<?xi64>
+// CHECK:               %[[VAL_44:.*]] = index_cast %[[VAL_43]] : i64 to index
+// CHECK:               scf.yield %[[VAL_44]] : index
 // CHECK:             } else {
-// CHECK:               scf.yield %[[VAL_33]] : index
+// CHECK:               scf.yield %[[VAL_35]] : index
 // CHECK:             }
-// CHECK:             %[[VAL_43:.*]] = cmpi ult, %[[VAL_44:.*]], %[[VAL_45:.*]] : index
-// CHECK:             %[[VAL_46:.*]] = cmpi ugt, %[[VAL_44]], %[[VAL_45]] : index
-// CHECK:             %[[VAL_47:.*]] = addi %[[VAL_30]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_48:.*]] = addi %[[VAL_31]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_49:.*]] = addi %[[VAL_36]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_50:.*]]:5 = scf.if %[[VAL_43]] -> (index, index, i1, i1, index) {
-// CHECK:               scf.yield %[[VAL_47]], %[[VAL_31]], %[[VAL_6]], %[[VAL_5]], %[[VAL_36]] : index, index, i1, i1, index
+// CHECK:             %[[VAL_45:.*]] = cmpi ult, %[[VAL_46:.*]], %[[VAL_47:.*]] : index
+// CHECK:             %[[VAL_48:.*]] = cmpi ugt, %[[VAL_46]], %[[VAL_47]] : index
+// CHECK:             %[[VAL_49:.*]] = addi %[[VAL_32]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_50:.*]] = addi %[[VAL_33]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_51:.*]] = addi %[[VAL_38]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_52:.*]]:5 = scf.if %[[VAL_45]] -> (index, index, i1, i1, index) {
+// CHECK:               scf.yield %[[VAL_49]], %[[VAL_33]], %[[VAL_6]], %[[VAL_5]], %[[VAL_38]] : index, index, i1, i1, index
 // CHECK:             } else {
-// CHECK:               %[[VAL_51:.*]]:5 = scf.if %[[VAL_46]] -> (index, index, i1, i1, index) {
-// CHECK:                 scf.yield %[[VAL_30]], %[[VAL_48]], %[[VAL_5]], %[[VAL_6]], %[[VAL_36]] : index, index, i1, i1, index
+// CHECK:               %[[VAL_53:.*]]:5 = scf.if %[[VAL_48]] -> (index, index, i1, i1, index) {
+// CHECK:                 scf.yield %[[VAL_32]], %[[VAL_50]], %[[VAL_5]], %[[VAL_6]], %[[VAL_38]] : index, index, i1, i1, index
 // CHECK:               } else {
-// CHECK:                 scf.yield %[[VAL_47]], %[[VAL_48]], %[[VAL_6]], %[[VAL_6]], %[[VAL_49]] : index, index, i1, i1, index
+// CHECK:                 scf.yield %[[VAL_49]], %[[VAL_50]], %[[VAL_6]], %[[VAL_6]], %[[VAL_51]] : index, index, i1, i1, index
 // CHECK:               }
-// CHECK:               scf.yield %[[VAL_52:.*]]#0, %[[VAL_52]]#1, %[[VAL_52]]#2, %[[VAL_52]]#3, %[[VAL_52]]#4 : index, index, i1, i1, index
+// CHECK:               scf.yield %[[VAL_54:.*]]#0, %[[VAL_54]]#1, %[[VAL_54]]#2, %[[VAL_54]]#3, %[[VAL_54]]#4 : index, index, i1, i1, index
 // CHECK:             }
-// CHECK:             scf.yield %[[VAL_53:.*]]#0, %[[VAL_53]]#1, %[[VAL_44]], %[[VAL_45]], %[[VAL_53]]#2, %[[VAL_53]]#3, %[[VAL_53]]#4 : index, index, index, index, i1, i1, index
+// CHECK:             scf.yield %[[VAL_55:.*]]#0, %[[VAL_55]]#1, %[[VAL_46]], %[[VAL_47]], %[[VAL_55]]#2, %[[VAL_55]]#3, %[[VAL_55]]#4 : index, index, index, index, i1, i1, index
 // CHECK:           }
-// CHECK:           %[[VAL_54:.*]] = index_cast %[[VAL_55:.*]]#6 : index to i64
-// CHECK:           call @vector_resize_index(%[[VAL_8]], %[[VAL_2]], %[[VAL_55]]#6) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @vector_resize_values(%[[VAL_8]], %[[VAL_55]]#6) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
-// CHECK:           %[[VAL_56:.*]] = sparse_tensor.pointers %[[VAL_8]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           memref.store %[[VAL_54]], %[[VAL_56]]{{\[}}%[[VAL_3]]] : memref<?xi64>
-// CHECK:           %[[VAL_57:.*]] = sparse_tensor.indices %[[VAL_8]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_58:.*]] = sparse_tensor.values %[[VAL_8]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_59:.*]]:9 = scf.while (%[[VAL_60:.*]] = %[[VAL_2]], %[[VAL_61:.*]] = %[[VAL_2]], %[[VAL_62:.*]] = %[[VAL_2]], %[[VAL_63:.*]] = %[[VAL_4]], %[[VAL_64:.*]] = %[[VAL_4]], %[[VAL_65:.*]] = %[[VAL_7]], %[[VAL_66:.*]] = %[[VAL_7]], %[[VAL_67:.*]] = %[[VAL_6]], %[[VAL_68:.*]] = %[[VAL_6]]) : (index, index, index, i64, i64, f64, f64, i1, i1) -> (index, index, index, i64, i64, f64, f64, i1, i1) {
-// CHECK:             %[[VAL_69:.*]] = cmpi ult, %[[VAL_60]], %[[VAL_11]] : index
-// CHECK:             %[[VAL_70:.*]] = cmpi ult, %[[VAL_61]], %[[VAL_14]] : index
-// CHECK:             %[[VAL_71:.*]] = and %[[VAL_69]], %[[VAL_70]] : i1
-// CHECK:             scf.condition(%[[VAL_71]]) %[[VAL_60]], %[[VAL_61]], %[[VAL_62]], %[[VAL_63]], %[[VAL_64]], %[[VAL_65]], %[[VAL_66]], %[[VAL_67]], %[[VAL_68]] : index, index, index, i64, i64, f64, f64, i1, i1
+// CHECK:           %[[VAL_56:.*]] = index_cast %[[VAL_57:.*]]#6 : index to i64
+// CHECK:           %[[VAL_58:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_10]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_index(%[[VAL_58]], %[[VAL_2]], %[[VAL_57]]#6) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_59:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_10]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_values(%[[VAL_59]], %[[VAL_57]]#6) : (!llvm.ptr<i8>, index) -> ()
+// CHECK:           %[[VAL_60:.*]] = sparse_tensor.pointers %[[VAL_10]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           memref.store %[[VAL_56]], %[[VAL_60]]{{\[}}%[[VAL_3]]] : memref<?xi64>
+// CHECK:           %[[VAL_61:.*]] = sparse_tensor.indices %[[VAL_10]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_62:.*]] = sparse_tensor.values %[[VAL_10]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_63:.*]]:9 = scf.while (%[[VAL_64:.*]] = %[[VAL_2]], %[[VAL_65:.*]] = %[[VAL_2]], %[[VAL_66:.*]] = %[[VAL_2]], %[[VAL_67:.*]] = %[[VAL_4]], %[[VAL_68:.*]] = %[[VAL_4]], %[[VAL_69:.*]] = %[[VAL_7]], %[[VAL_70:.*]] = %[[VAL_7]], %[[VAL_71:.*]] = %[[VAL_6]], %[[VAL_72:.*]] = %[[VAL_6]]) : (index, index, index, i64, i64, f64, f64, i1, i1) -> (index, index, index, i64, i64, f64, f64, i1, i1) {
+// CHECK:             %[[VAL_73:.*]] = cmpi ult, %[[VAL_64]], %[[VAL_13]] : index
+// CHECK:             %[[VAL_74:.*]] = cmpi ult, %[[VAL_65]], %[[VAL_16]] : index
+// CHECK:             %[[VAL_75:.*]] = and %[[VAL_73]], %[[VAL_74]] : i1
+// CHECK:             scf.condition(%[[VAL_75]]) %[[VAL_64]], %[[VAL_65]], %[[VAL_66]], %[[VAL_67]], %[[VAL_68]], %[[VAL_69]], %[[VAL_70]], %[[VAL_71]], %[[VAL_72]] : index, index, index, i64, i64, f64, f64, i1, i1
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_72:.*]]: index, %[[VAL_73:.*]]: index, %[[VAL_74:.*]]: index, %[[VAL_75:.*]]: i64, %[[VAL_76:.*]]: i64, %[[VAL_77:.*]]: f64, %[[VAL_78:.*]]: f64, %[[VAL_79:.*]]: i1, %[[VAL_80:.*]]: i1):
-// CHECK:             %[[VAL_81:.*]]:2 = scf.if %[[VAL_79]] -> (i64, f64) {
-// CHECK:               %[[VAL_82:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_72]]] : memref<?xi64>
-// CHECK:               %[[VAL_83:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_72]]] : memref<?xf64>
-// CHECK:               scf.yield %[[VAL_82]], %[[VAL_83]] : i64, f64
+// CHECK:           ^bb0(%[[VAL_76:.*]]: index, %[[VAL_77:.*]]: index, %[[VAL_78:.*]]: index, %[[VAL_79:.*]]: i64, %[[VAL_80:.*]]: i64, %[[VAL_81:.*]]: f64, %[[VAL_82:.*]]: f64, %[[VAL_83:.*]]: i1, %[[VAL_84:.*]]: i1):
+// CHECK:             %[[VAL_85:.*]]:2 = scf.if %[[VAL_83]] -> (i64, f64) {
+// CHECK:               %[[VAL_86:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_76]]] : memref<?xi64>
+// CHECK:               %[[VAL_87:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_76]]] : memref<?xf64>
+// CHECK:               scf.yield %[[VAL_86]], %[[VAL_87]] : i64, f64
 // CHECK:             } else {
-// CHECK:               scf.yield %[[VAL_75]], %[[VAL_77]] : i64, f64
+// CHECK:               scf.yield %[[VAL_79]], %[[VAL_81]] : i64, f64
 // CHECK:             }
-// CHECK:             %[[VAL_84:.*]]:2 = scf.if %[[VAL_80]] -> (i64, f64) {
-// CHECK:               %[[VAL_85:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_73]]] : memref<?xi64>
-// CHECK:               %[[VAL_86:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_73]]] : memref<?xf64>
-// CHECK:               scf.yield %[[VAL_85]], %[[VAL_86]] : i64, f64
+// CHECK:             %[[VAL_88:.*]]:2 = scf.if %[[VAL_84]] -> (i64, f64) {
+// CHECK:               %[[VAL_89:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_77]]] : memref<?xi64>
+// CHECK:               %[[VAL_90:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_77]]] : memref<?xf64>
+// CHECK:               scf.yield %[[VAL_89]], %[[VAL_90]] : i64, f64
 // CHECK:             } else {
-// CHECK:               scf.yield %[[VAL_76]], %[[VAL_78]] : i64, f64
+// CHECK:               scf.yield %[[VAL_80]], %[[VAL_82]] : i64, f64
 // CHECK:             }
-// CHECK:             %[[VAL_87:.*]] = cmpi ult, %[[VAL_88:.*]]#0, %[[VAL_89:.*]]#0 : i64
-// CHECK:             %[[VAL_90:.*]] = cmpi ugt, %[[VAL_88]]#0, %[[VAL_89]]#0 : i64
-// CHECK:             %[[VAL_91:.*]] = addi %[[VAL_72]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_92:.*]] = addi %[[VAL_73]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_93:.*]] = addi %[[VAL_74]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_94:.*]]:5 = scf.if %[[VAL_87]] -> (index, index, index, i1, i1) {
-// CHECK:               scf.yield %[[VAL_91]], %[[VAL_73]], %[[VAL_74]], %[[VAL_6]], %[[VAL_5]] : index, index, index, i1, i1
+// CHECK:             %[[VAL_91:.*]] = cmpi ult, %[[VAL_92:.*]]#0, %[[VAL_93:.*]]#0 : i64
+// CHECK:             %[[VAL_94:.*]] = cmpi ugt, %[[VAL_92]]#0, %[[VAL_93]]#0 : i64
+// CHECK:             %[[VAL_95:.*]] = addi %[[VAL_76]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_96:.*]] = addi %[[VAL_77]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_97:.*]] = addi %[[VAL_78]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_98:.*]]:5 = scf.if %[[VAL_91]] -> (index, index, index, i1, i1) {
+// CHECK:               scf.yield %[[VAL_95]], %[[VAL_77]], %[[VAL_78]], %[[VAL_6]], %[[VAL_5]] : index, index, index, i1, i1
 // CHECK:             } else {
-// CHECK:               %[[VAL_95:.*]]:5 = scf.if %[[VAL_90]] -> (index, index, index, i1, i1) {
-// CHECK:                 scf.yield %[[VAL_72]], %[[VAL_92]], %[[VAL_74]], %[[VAL_5]], %[[VAL_6]] : index, index, index, i1, i1
+// CHECK:               %[[VAL_99:.*]]:5 = scf.if %[[VAL_94]] -> (index, index, index, i1, i1) {
+// CHECK:                 scf.yield %[[VAL_76]], %[[VAL_96]], %[[VAL_78]], %[[VAL_5]], %[[VAL_6]] : index, index, index, i1, i1
 // CHECK:               } else {
-// CHECK:                 memref.store %[[VAL_88]]#0, %[[VAL_57]]{{\[}}%[[VAL_74]]] : memref<?xi64>
-// CHECK:                 %[[VAL_96:.*]] = mulf %[[VAL_88]]#1, %[[VAL_89]]#1 : f64
-// CHECK:                 memref.store %[[VAL_96]], %[[VAL_58]]{{\[}}%[[VAL_74]]] : memref<?xf64>
-// CHECK:                 scf.yield %[[VAL_91]], %[[VAL_92]], %[[VAL_93]], %[[VAL_6]], %[[VAL_6]] : index, index, index, i1, i1
+// CHECK:                 memref.store %[[VAL_92]]#0, %[[VAL_61]]{{\[}}%[[VAL_78]]] : memref<?xi64>
+// CHECK:                 %[[VAL_100:.*]] = mulf %[[VAL_92]]#1, %[[VAL_93]]#1 : f64
+// CHECK:                 memref.store %[[VAL_100]], %[[VAL_62]]{{\[}}%[[VAL_78]]] : memref<?xf64>
+// CHECK:                 scf.yield %[[VAL_95]], %[[VAL_96]], %[[VAL_97]], %[[VAL_6]], %[[VAL_6]] : index, index, index, i1, i1
 // CHECK:               }
-// CHECK:               scf.yield %[[VAL_97:.*]]#0, %[[VAL_97]]#1, %[[VAL_97]]#2, %[[VAL_97]]#3, %[[VAL_97]]#4 : index, index, index, i1, i1
+// CHECK:               scf.yield %[[VAL_101:.*]]#0, %[[VAL_101]]#1, %[[VAL_101]]#2, %[[VAL_101]]#3, %[[VAL_101]]#4 : index, index, index, i1, i1
 // CHECK:             }
-// CHECK:             scf.yield %[[VAL_98:.*]]#0, %[[VAL_98]]#1, %[[VAL_98]]#2, %[[VAL_88]]#0, %[[VAL_89]]#0, %[[VAL_88]]#1, %[[VAL_89]]#1, %[[VAL_98]]#3, %[[VAL_98]]#4 : index, index, index, i64, i64, f64, f64, i1, i1
+// CHECK:             scf.yield %[[VAL_102:.*]]#0, %[[VAL_102]]#1, %[[VAL_102]]#2, %[[VAL_92]]#0, %[[VAL_93]]#0, %[[VAL_92]]#1, %[[VAL_93]]#1, %[[VAL_102]]#3, %[[VAL_102]]#4 : index, index, index, i64, i64, f64, f64, i1, i1
 // CHECK:           }
-// CHECK:           return %[[VAL_8]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           return %[[VAL_10]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
 
 func @vector_intersect(%a: tensor<?xf64, #CV64>, %b: tensor<?xf64, #CV64>) -> tensor<?xf64, #CV64> {
@@ -138,154 +142,156 @@ func @vector_intersect(%a: tensor<?xf64, #CV64>, %b: tensor<?xf64, #CV64>) -> te
 // CHECK-DAG:       %[[VAL_5:.*]] = constant false
 // CHECK-DAG:       %[[VAL_6:.*]] = constant true
 // CHECK-DAG:       %[[VAL_7:.*]] = constant 0.000000e+00 : f64
-// CHECK:           %[[VAL_8:.*]] = call @cast_csr_to_csx(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_9:.*]] = call @matrix_empty_like(%[[VAL_8]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_10:.*]] = tensor.dim %[[VAL_9]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_11:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_12:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_13:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_14:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_15:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_16:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_17:.*]] = sparse_tensor.pointers %[[VAL_9]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           scf.parallel (%[[VAL_18:.*]]) = (%[[VAL_2]]) to (%[[VAL_10]]) step (%[[VAL_3]]) {
-// CHECK:             %[[VAL_19:.*]] = addi %[[VAL_18]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_20:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_18]]] : memref<?xi64>
-// CHECK:             %[[VAL_21:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_19]]] : memref<?xi64>
-// CHECK:             %[[VAL_22:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_18]]] : memref<?xi64>
-// CHECK:             %[[VAL_23:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_19]]] : memref<?xi64>
-// CHECK:             %[[VAL_24:.*]] = cmpi eq, %[[VAL_20]], %[[VAL_21]] : i64
-// CHECK:             %[[VAL_25:.*]] = cmpi eq, %[[VAL_22]], %[[VAL_23]] : i64
-// CHECK:             %[[VAL_26:.*]] = or %[[VAL_24]], %[[VAL_25]] : i1
-// CHECK:             %[[VAL_27:.*]] = scf.if %[[VAL_26]] -> (i64) {
+// CHECK:           %[[VAL_8:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_9:.*]] = call @empty_like(%[[VAL_8]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_10:.*]] = call @ptr8_to_matrix_csr_f64_p64i64(%[[VAL_9]]) : (!llvm.ptr<i8>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_11:.*]] = tensor.dim %[[VAL_10]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_12:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_13:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_14:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_15:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_16:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_17:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_18:.*]] = sparse_tensor.pointers %[[VAL_10]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           scf.parallel (%[[VAL_19:.*]]) = (%[[VAL_2]]) to (%[[VAL_11]]) step (%[[VAL_3]]) {
+// CHECK:             %[[VAL_20:.*]] = addi %[[VAL_19]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_21:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_19]]] : memref<?xi64>
+// CHECK:             %[[VAL_22:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_20]]] : memref<?xi64>
+// CHECK:             %[[VAL_23:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_19]]] : memref<?xi64>
+// CHECK:             %[[VAL_24:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_20]]] : memref<?xi64>
+// CHECK:             %[[VAL_25:.*]] = cmpi eq, %[[VAL_21]], %[[VAL_22]] : i64
+// CHECK:             %[[VAL_26:.*]] = cmpi eq, %[[VAL_23]], %[[VAL_24]] : i64
+// CHECK:             %[[VAL_27:.*]] = or %[[VAL_25]], %[[VAL_26]] : i1
+// CHECK:             %[[VAL_28:.*]] = scf.if %[[VAL_27]] -> (i64) {
 // CHECK:               scf.yield %[[VAL_4]] : i64
 // CHECK:             } else {
-// CHECK:               %[[VAL_28:.*]] = index_cast %[[VAL_20]] : i64 to index
 // CHECK:               %[[VAL_29:.*]] = index_cast %[[VAL_21]] : i64 to index
 // CHECK:               %[[VAL_30:.*]] = index_cast %[[VAL_22]] : i64 to index
 // CHECK:               %[[VAL_31:.*]] = index_cast %[[VAL_23]] : i64 to index
-// CHECK:               %[[VAL_32:.*]]:7 = scf.while (%[[VAL_33:.*]] = %[[VAL_28]], %[[VAL_34:.*]] = %[[VAL_30]], %[[VAL_35:.*]] = %[[VAL_2]], %[[VAL_36:.*]] = %[[VAL_2]], %[[VAL_37:.*]] = %[[VAL_6]], %[[VAL_38:.*]] = %[[VAL_6]], %[[VAL_39:.*]] = %[[VAL_2]]) : (index, index, index, index, i1, i1, index) -> (index, index, index, index, i1, i1, index) {
-// CHECK:                 %[[VAL_40:.*]] = cmpi ult, %[[VAL_33]], %[[VAL_29]] : index
-// CHECK:                 %[[VAL_41:.*]] = cmpi ult, %[[VAL_34]], %[[VAL_31]] : index
-// CHECK:                 %[[VAL_42:.*]] = and %[[VAL_40]], %[[VAL_41]] : i1
-// CHECK:                 scf.condition(%[[VAL_42]]) %[[VAL_33]], %[[VAL_34]], %[[VAL_35]], %[[VAL_36]], %[[VAL_37]], %[[VAL_38]], %[[VAL_39]] : index, index, index, index, i1, i1, index
+// CHECK:               %[[VAL_32:.*]] = index_cast %[[VAL_24]] : i64 to index
+// CHECK:               %[[VAL_33:.*]]:7 = scf.while (%[[VAL_34:.*]] = %[[VAL_29]], %[[VAL_35:.*]] = %[[VAL_31]], %[[VAL_36:.*]] = %[[VAL_2]], %[[VAL_37:.*]] = %[[VAL_2]], %[[VAL_38:.*]] = %[[VAL_6]], %[[VAL_39:.*]] = %[[VAL_6]], %[[VAL_40:.*]] = %[[VAL_2]]) : (index, index, index, index, i1, i1, index) -> (index, index, index, index, i1, i1, index) {
+// CHECK:                 %[[VAL_41:.*]] = cmpi ult, %[[VAL_34]], %[[VAL_30]] : index
+// CHECK:                 %[[VAL_42:.*]] = cmpi ult, %[[VAL_35]], %[[VAL_32]] : index
+// CHECK:                 %[[VAL_43:.*]] = and %[[VAL_41]], %[[VAL_42]] : i1
+// CHECK:                 scf.condition(%[[VAL_43]]) %[[VAL_34]], %[[VAL_35]], %[[VAL_36]], %[[VAL_37]], %[[VAL_38]], %[[VAL_39]], %[[VAL_40]] : index, index, index, index, i1, i1, index
 // CHECK:               } do {
-// CHECK:               ^bb0(%[[VAL_43:.*]]: index, %[[VAL_44:.*]]: index, %[[VAL_45:.*]]: index, %[[VAL_46:.*]]: index, %[[VAL_47:.*]]: i1, %[[VAL_48:.*]]: i1, %[[VAL_49:.*]]: index):
-// CHECK:                 %[[VAL_50:.*]] = scf.if %[[VAL_47]] -> (index) {
-// CHECK:                   %[[VAL_51:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_43]]] : memref<?xi64>
-// CHECK:                   %[[VAL_52:.*]] = index_cast %[[VAL_51]] : i64 to index
-// CHECK:                   scf.yield %[[VAL_52]] : index
-// CHECK:                 } else {
-// CHECK:                   scf.yield %[[VAL_45]] : index
-// CHECK:                 }
-// CHECK:                 %[[VAL_53:.*]] = scf.if %[[VAL_48]] -> (index) {
-// CHECK:                   %[[VAL_54:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_44]]] : memref<?xi64>
-// CHECK:                   %[[VAL_55:.*]] = index_cast %[[VAL_54]] : i64 to index
-// CHECK:                   scf.yield %[[VAL_55]] : index
+// CHECK:               ^bb0(%[[VAL_44:.*]]: index, %[[VAL_45:.*]]: index, %[[VAL_46:.*]]: index, %[[VAL_47:.*]]: index, %[[VAL_48:.*]]: i1, %[[VAL_49:.*]]: i1, %[[VAL_50:.*]]: index):
+// CHECK:                 %[[VAL_51:.*]] = scf.if %[[VAL_48]] -> (index) {
+// CHECK:                   %[[VAL_52:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_44]]] : memref<?xi64>
+// CHECK:                   %[[VAL_53:.*]] = index_cast %[[VAL_52]] : i64 to index
+// CHECK:                   scf.yield %[[VAL_53]] : index
 // CHECK:                 } else {
 // CHECK:                   scf.yield %[[VAL_46]] : index
 // CHECK:                 }
-// CHECK:                 %[[VAL_56:.*]] = cmpi ult, %[[VAL_57:.*]], %[[VAL_58:.*]] : index
-// CHECK:                 %[[VAL_59:.*]] = cmpi ugt, %[[VAL_57]], %[[VAL_58]] : index
-// CHECK:                 %[[VAL_60:.*]] = addi %[[VAL_43]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_61:.*]] = addi %[[VAL_44]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_62:.*]] = addi %[[VAL_49]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_63:.*]]:5 = scf.if %[[VAL_56]] -> (index, index, i1, i1, index) {
-// CHECK:                   scf.yield %[[VAL_60]], %[[VAL_44]], %[[VAL_6]], %[[VAL_5]], %[[VAL_49]] : index, index, i1, i1, index
+// CHECK:                 %[[VAL_54:.*]] = scf.if %[[VAL_49]] -> (index) {
+// CHECK:                   %[[VAL_55:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_45]]] : memref<?xi64>
+// CHECK:                   %[[VAL_56:.*]] = index_cast %[[VAL_55]] : i64 to index
+// CHECK:                   scf.yield %[[VAL_56]] : index
 // CHECK:                 } else {
-// CHECK:                   %[[VAL_64:.*]]:5 = scf.if %[[VAL_59]] -> (index, index, i1, i1, index) {
-// CHECK:                     scf.yield %[[VAL_43]], %[[VAL_61]], %[[VAL_5]], %[[VAL_6]], %[[VAL_49]] : index, index, i1, i1, index
-// CHECK:                   } else {
-// CHECK:                     scf.yield %[[VAL_60]], %[[VAL_61]], %[[VAL_6]], %[[VAL_6]], %[[VAL_62]] : index, index, i1, i1, index
-// CHECK:                   }
-// CHECK:                   scf.yield %[[VAL_65:.*]]#0, %[[VAL_65]]#1, %[[VAL_65]]#2, %[[VAL_65]]#3, %[[VAL_65]]#4 : index, index, i1, i1, index
+// CHECK:                   scf.yield %[[VAL_47]] : index
 // CHECK:                 }
-// CHECK:                 scf.yield %[[VAL_66:.*]]#0, %[[VAL_66]]#1, %[[VAL_57]], %[[VAL_58]], %[[VAL_66]]#2, %[[VAL_66]]#3, %[[VAL_66]]#4 : index, index, index, index, i1, i1, index
+// CHECK:                 %[[VAL_57:.*]] = cmpi ult, %[[VAL_58:.*]], %[[VAL_59:.*]] : index
+// CHECK:                 %[[VAL_60:.*]] = cmpi ugt, %[[VAL_58]], %[[VAL_59]] : index
+// CHECK:                 %[[VAL_61:.*]] = addi %[[VAL_44]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_62:.*]] = addi %[[VAL_45]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_63:.*]] = addi %[[VAL_50]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_64:.*]]:5 = scf.if %[[VAL_57]] -> (index, index, i1, i1, index) {
+// CHECK:                   scf.yield %[[VAL_61]], %[[VAL_45]], %[[VAL_6]], %[[VAL_5]], %[[VAL_50]] : index, index, i1, i1, index
+// CHECK:                 } else {
+// CHECK:                   %[[VAL_65:.*]]:5 = scf.if %[[VAL_60]] -> (index, index, i1, i1, index) {
+// CHECK:                     scf.yield %[[VAL_44]], %[[VAL_62]], %[[VAL_5]], %[[VAL_6]], %[[VAL_50]] : index, index, i1, i1, index
+// CHECK:                   } else {
+// CHECK:                     scf.yield %[[VAL_61]], %[[VAL_62]], %[[VAL_6]], %[[VAL_6]], %[[VAL_63]] : index, index, i1, i1, index
+// CHECK:                   }
+// CHECK:                   scf.yield %[[VAL_66:.*]]#0, %[[VAL_66]]#1, %[[VAL_66]]#2, %[[VAL_66]]#3, %[[VAL_66]]#4 : index, index, i1, i1, index
+// CHECK:                 }
+// CHECK:                 scf.yield %[[VAL_67:.*]]#0, %[[VAL_67]]#1, %[[VAL_58]], %[[VAL_59]], %[[VAL_67]]#2, %[[VAL_67]]#3, %[[VAL_67]]#4 : index, index, index, index, i1, i1, index
 // CHECK:               }
-// CHECK:               %[[VAL_67:.*]] = index_cast %[[VAL_68:.*]]#6 : index to i64
-// CHECK:               scf.yield %[[VAL_67]] : i64
+// CHECK:               %[[VAL_68:.*]] = index_cast %[[VAL_69:.*]]#6 : index to i64
+// CHECK:               scf.yield %[[VAL_68]] : i64
 // CHECK:             }
-// CHECK:             memref.store %[[VAL_69:.*]], %[[VAL_17]]{{\[}}%[[VAL_18]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_70:.*]], %[[VAL_18]]{{\[}}%[[VAL_19]]] : memref<?xi64>
 // CHECK:             scf.yield
 // CHECK:           }
-// CHECK:           memref.store %[[VAL_4]], %[[VAL_17]]{{\[}}%[[VAL_10]]] : memref<?xi64>
-// CHECK:           scf.for %[[VAL_70:.*]] = %[[VAL_2]] to %[[VAL_10]] step %[[VAL_3]] {
-// CHECK:             %[[VAL_71:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_70]]] : memref<?xi64>
-// CHECK:             %[[VAL_72:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_10]]] : memref<?xi64>
-// CHECK:             memref.store %[[VAL_72]], %[[VAL_17]]{{\[}}%[[VAL_70]]] : memref<?xi64>
-// CHECK:             %[[VAL_73:.*]] = addi %[[VAL_72]], %[[VAL_71]] : i64
-// CHECK:             memref.store %[[VAL_73]], %[[VAL_17]]{{\[}}%[[VAL_10]]] : memref<?xi64>
+// CHECK:           memref.store %[[VAL_4]], %[[VAL_18]]{{\[}}%[[VAL_11]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_71:.*]] = %[[VAL_2]] to %[[VAL_11]] step %[[VAL_3]] {
+// CHECK:             %[[VAL_72:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_71]]] : memref<?xi64>
+// CHECK:             %[[VAL_73:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_11]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_73]], %[[VAL_18]]{{\[}}%[[VAL_71]]] : memref<?xi64>
+// CHECK:             %[[VAL_74:.*]] = addi %[[VAL_73]], %[[VAL_72]] : i64
+// CHECK:             memref.store %[[VAL_74]], %[[VAL_18]]{{\[}}%[[VAL_11]]] : memref<?xi64>
 // CHECK:           }
-// CHECK:           %[[VAL_74:.*]] = sparse_tensor.pointers %[[VAL_9]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_75:.*]] = tensor.dim %[[VAL_9]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_76:.*]] = memref.load %[[VAL_74]]{{\[}}%[[VAL_75]]] : memref<?xi64>
-// CHECK:           %[[VAL_77:.*]] = index_cast %[[VAL_76]] : i64 to index
-// CHECK:           call @matrix_resize_index(%[[VAL_9]], %[[VAL_3]], %[[VAL_77]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @matrix_resize_values(%[[VAL_9]], %[[VAL_77]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
-// CHECK:           %[[VAL_78:.*]] = sparse_tensor.indices %[[VAL_9]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_79:.*]] = sparse_tensor.values %[[VAL_9]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           scf.parallel (%[[VAL_80:.*]]) = (%[[VAL_2]]) to (%[[VAL_10]]) step (%[[VAL_3]]) {
-// CHECK:             %[[VAL_81:.*]] = addi %[[VAL_80]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_82:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_80]]] : memref<?xi64>
-// CHECK:             %[[VAL_83:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_81]]] : memref<?xi64>
-// CHECK:             %[[VAL_84:.*]] = cmpi ne, %[[VAL_82]], %[[VAL_83]] : i64
-// CHECK:             scf.if %[[VAL_84]] {
-// CHECK:               %[[VAL_85:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_80]]] : memref<?xi64>
-// CHECK:               %[[VAL_86:.*]] = index_cast %[[VAL_85]] : i64 to index
-// CHECK:               %[[VAL_87:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_80]]] : memref<?xi64>
-// CHECK:               %[[VAL_88:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_81]]] : memref<?xi64>
-// CHECK:               %[[VAL_89:.*]] = index_cast %[[VAL_87]] : i64 to index
-// CHECK:               %[[VAL_90:.*]] = index_cast %[[VAL_88]] : i64 to index
-// CHECK:               %[[VAL_91:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_80]]] : memref<?xi64>
-// CHECK:               %[[VAL_92:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_81]]] : memref<?xi64>
+// CHECK:           %[[VAL_75:.*]] = sparse_tensor.pointers %[[VAL_10]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_76:.*]] = tensor.dim %[[VAL_10]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_77:.*]] = memref.load %[[VAL_75]]{{\[}}%[[VAL_76]]] : memref<?xi64>
+// CHECK:           %[[VAL_78:.*]] = index_cast %[[VAL_77]] : i64 to index
+// CHECK:           %[[VAL_79:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_10]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_index(%[[VAL_79]], %[[VAL_3]], %[[VAL_78]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_80:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_10]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_values(%[[VAL_80]], %[[VAL_78]]) : (!llvm.ptr<i8>, index) -> ()
+// CHECK:           %[[VAL_81:.*]] = sparse_tensor.indices %[[VAL_10]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_82:.*]] = sparse_tensor.values %[[VAL_10]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           scf.parallel (%[[VAL_83:.*]]) = (%[[VAL_2]]) to (%[[VAL_11]]) step (%[[VAL_3]]) {
+// CHECK:             %[[VAL_84:.*]] = addi %[[VAL_83]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_85:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_83]]] : memref<?xi64>
+// CHECK:             %[[VAL_86:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_84]]] : memref<?xi64>
+// CHECK:             %[[VAL_87:.*]] = cmpi ne, %[[VAL_85]], %[[VAL_86]] : i64
+// CHECK:             scf.if %[[VAL_87]] {
+// CHECK:               %[[VAL_88:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_83]]] : memref<?xi64>
+// CHECK:               %[[VAL_89:.*]] = index_cast %[[VAL_88]] : i64 to index
+// CHECK:               %[[VAL_90:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_83]]] : memref<?xi64>
+// CHECK:               %[[VAL_91:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_84]]] : memref<?xi64>
+// CHECK:               %[[VAL_92:.*]] = index_cast %[[VAL_90]] : i64 to index
 // CHECK:               %[[VAL_93:.*]] = index_cast %[[VAL_91]] : i64 to index
-// CHECK:               %[[VAL_94:.*]] = index_cast %[[VAL_92]] : i64 to index
-// CHECK:               %[[VAL_95:.*]]:9 = scf.while (%[[VAL_96:.*]] = %[[VAL_89]], %[[VAL_97:.*]] = %[[VAL_93]], %[[VAL_98:.*]] = %[[VAL_86]], %[[VAL_99:.*]] = %[[VAL_4]], %[[VAL_100:.*]] = %[[VAL_4]], %[[VAL_101:.*]] = %[[VAL_7]], %[[VAL_102:.*]] = %[[VAL_7]], %[[VAL_103:.*]] = %[[VAL_6]], %[[VAL_104:.*]] = %[[VAL_6]]) : (index, index, index, i64, i64, f64, f64, i1, i1) -> (index, index, index, i64, i64, f64, f64, i1, i1) {
-// CHECK:                 %[[VAL_105:.*]] = cmpi ult, %[[VAL_96]], %[[VAL_90]] : index
-// CHECK:                 %[[VAL_106:.*]] = cmpi ult, %[[VAL_97]], %[[VAL_94]] : index
-// CHECK:                 %[[VAL_107:.*]] = and %[[VAL_105]], %[[VAL_106]] : i1
-// CHECK:                 scf.condition(%[[VAL_107]]) %[[VAL_96]], %[[VAL_97]], %[[VAL_98]], %[[VAL_99]], %[[VAL_100]], %[[VAL_101]], %[[VAL_102]], %[[VAL_103]], %[[VAL_104]] : index, index, index, i64, i64, f64, f64, i1, i1
+// CHECK:               %[[VAL_94:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_83]]] : memref<?xi64>
+// CHECK:               %[[VAL_95:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_84]]] : memref<?xi64>
+// CHECK:               %[[VAL_96:.*]] = index_cast %[[VAL_94]] : i64 to index
+// CHECK:               %[[VAL_97:.*]] = index_cast %[[VAL_95]] : i64 to index
+// CHECK:               %[[VAL_98:.*]]:9 = scf.while (%[[VAL_99:.*]] = %[[VAL_92]], %[[VAL_100:.*]] = %[[VAL_96]], %[[VAL_101:.*]] = %[[VAL_89]], %[[VAL_102:.*]] = %[[VAL_4]], %[[VAL_103:.*]] = %[[VAL_4]], %[[VAL_104:.*]] = %[[VAL_7]], %[[VAL_105:.*]] = %[[VAL_7]], %[[VAL_106:.*]] = %[[VAL_6]], %[[VAL_107:.*]] = %[[VAL_6]]) : (index, index, index, i64, i64, f64, f64, i1, i1) -> (index, index, index, i64, i64, f64, f64, i1, i1) {
+// CHECK:                 %[[VAL_108:.*]] = cmpi ult, %[[VAL_99]], %[[VAL_93]] : index
+// CHECK:                 %[[VAL_109:.*]] = cmpi ult, %[[VAL_100]], %[[VAL_97]] : index
+// CHECK:                 %[[VAL_110:.*]] = and %[[VAL_108]], %[[VAL_109]] : i1
+// CHECK:                 scf.condition(%[[VAL_110]]) %[[VAL_99]], %[[VAL_100]], %[[VAL_101]], %[[VAL_102]], %[[VAL_103]], %[[VAL_104]], %[[VAL_105]], %[[VAL_106]], %[[VAL_107]] : index, index, index, i64, i64, f64, f64, i1, i1
 // CHECK:               } do {
-// CHECK:               ^bb0(%[[VAL_108:.*]]: index, %[[VAL_109:.*]]: index, %[[VAL_110:.*]]: index, %[[VAL_111:.*]]: i64, %[[VAL_112:.*]]: i64, %[[VAL_113:.*]]: f64, %[[VAL_114:.*]]: f64, %[[VAL_115:.*]]: i1, %[[VAL_116:.*]]: i1):
-// CHECK:                 %[[VAL_117:.*]]:2 = scf.if %[[VAL_115]] -> (i64, f64) {
-// CHECK:                   %[[VAL_118:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_108]]] : memref<?xi64>
-// CHECK:                   %[[VAL_119:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_108]]] : memref<?xf64>
-// CHECK:                   scf.yield %[[VAL_118]], %[[VAL_119]] : i64, f64
-// CHECK:                 } else {
-// CHECK:                   scf.yield %[[VAL_111]], %[[VAL_113]] : i64, f64
-// CHECK:                 }
-// CHECK:                 %[[VAL_120:.*]]:2 = scf.if %[[VAL_116]] -> (i64, f64) {
-// CHECK:                   %[[VAL_121:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_109]]] : memref<?xi64>
-// CHECK:                   %[[VAL_122:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_109]]] : memref<?xf64>
+// CHECK:               ^bb0(%[[VAL_111:.*]]: index, %[[VAL_112:.*]]: index, %[[VAL_113:.*]]: index, %[[VAL_114:.*]]: i64, %[[VAL_115:.*]]: i64, %[[VAL_116:.*]]: f64, %[[VAL_117:.*]]: f64, %[[VAL_118:.*]]: i1, %[[VAL_119:.*]]: i1):
+// CHECK:                 %[[VAL_120:.*]]:2 = scf.if %[[VAL_118]] -> (i64, f64) {
+// CHECK:                   %[[VAL_121:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_111]]] : memref<?xi64>
+// CHECK:                   %[[VAL_122:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_111]]] : memref<?xf64>
 // CHECK:                   scf.yield %[[VAL_121]], %[[VAL_122]] : i64, f64
 // CHECK:                 } else {
-// CHECK:                   scf.yield %[[VAL_112]], %[[VAL_114]] : i64, f64
+// CHECK:                   scf.yield %[[VAL_114]], %[[VAL_116]] : i64, f64
 // CHECK:                 }
-// CHECK:                 %[[VAL_123:.*]] = cmpi ult, %[[VAL_124:.*]]#0, %[[VAL_125:.*]]#0 : i64
-// CHECK:                 %[[VAL_126:.*]] = cmpi ugt, %[[VAL_124]]#0, %[[VAL_125]]#0 : i64
-// CHECK:                 %[[VAL_127:.*]] = addi %[[VAL_108]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_128:.*]] = addi %[[VAL_109]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_129:.*]] = addi %[[VAL_110]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_130:.*]]:5 = scf.if %[[VAL_123]] -> (index, index, index, i1, i1) {
-// CHECK:                   scf.yield %[[VAL_127]], %[[VAL_109]], %[[VAL_110]], %[[VAL_6]], %[[VAL_5]] : index, index, index, i1, i1
+// CHECK:                 %[[VAL_123:.*]]:2 = scf.if %[[VAL_119]] -> (i64, f64) {
+// CHECK:                   %[[VAL_124:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_112]]] : memref<?xi64>
+// CHECK:                   %[[VAL_125:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_112]]] : memref<?xf64>
+// CHECK:                   scf.yield %[[VAL_124]], %[[VAL_125]] : i64, f64
 // CHECK:                 } else {
-// CHECK:                   %[[VAL_131:.*]]:5 = scf.if %[[VAL_126]] -> (index, index, index, i1, i1) {
-// CHECK:                     scf.yield %[[VAL_108]], %[[VAL_128]], %[[VAL_110]], %[[VAL_5]], %[[VAL_6]] : index, index, index, i1, i1
-// CHECK:                   } else {
-// CHECK:                     memref.store %[[VAL_124]]#0, %[[VAL_78]]{{\[}}%[[VAL_110]]] : memref<?xi64>
-// CHECK:                     %[[VAL_132:.*]] = mulf %[[VAL_124]]#1, %[[VAL_125]]#1 : f64
-// CHECK:                     memref.store %[[VAL_132]], %[[VAL_79]]{{\[}}%[[VAL_110]]] : memref<?xf64>
-// CHECK:                     scf.yield %[[VAL_127]], %[[VAL_128]], %[[VAL_129]], %[[VAL_6]], %[[VAL_6]] : index, index, index, i1, i1
-// CHECK:                   }
-// CHECK:                   scf.yield %[[VAL_133:.*]]#0, %[[VAL_133]]#1, %[[VAL_133]]#2, %[[VAL_133]]#3, %[[VAL_133]]#4 : index, index, index, i1, i1
+// CHECK:                   scf.yield %[[VAL_115]], %[[VAL_117]] : i64, f64
 // CHECK:                 }
-// CHECK:                 scf.yield %[[VAL_134:.*]]#0, %[[VAL_134]]#1, %[[VAL_134]]#2, %[[VAL_124]]#0, %[[VAL_125]]#0, %[[VAL_124]]#1, %[[VAL_125]]#1, %[[VAL_134]]#3, %[[VAL_134]]#4 : index, index, index, i64, i64, f64, f64, i1, i1
+// CHECK:                 %[[VAL_126:.*]] = cmpi ult, %[[VAL_127:.*]]#0, %[[VAL_128:.*]]#0 : i64
+// CHECK:                 %[[VAL_129:.*]] = cmpi ugt, %[[VAL_127]]#0, %[[VAL_128]]#0 : i64
+// CHECK:                 %[[VAL_130:.*]] = addi %[[VAL_111]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_131:.*]] = addi %[[VAL_112]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_132:.*]] = addi %[[VAL_113]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_133:.*]]:5 = scf.if %[[VAL_126]] -> (index, index, index, i1, i1) {
+// CHECK:                   scf.yield %[[VAL_130]], %[[VAL_112]], %[[VAL_113]], %[[VAL_6]], %[[VAL_5]] : index, index, index, i1, i1
+// CHECK:                 } else {
+// CHECK:                   %[[VAL_134:.*]]:5 = scf.if %[[VAL_129]] -> (index, index, index, i1, i1) {
+// CHECK:                     scf.yield %[[VAL_111]], %[[VAL_131]], %[[VAL_113]], %[[VAL_5]], %[[VAL_6]] : index, index, index, i1, i1
+// CHECK:                   } else {
+// CHECK:                     memref.store %[[VAL_127]]#0, %[[VAL_81]]{{\[}}%[[VAL_113]]] : memref<?xi64>
+// CHECK:                     %[[VAL_135:.*]] = mulf %[[VAL_127]]#1, %[[VAL_128]]#1 : f64
+// CHECK:                     memref.store %[[VAL_135]], %[[VAL_82]]{{\[}}%[[VAL_113]]] : memref<?xf64>
+// CHECK:                     scf.yield %[[VAL_130]], %[[VAL_131]], %[[VAL_132]], %[[VAL_6]], %[[VAL_6]] : index, index, index, i1, i1
+// CHECK:                   }
+// CHECK:                   scf.yield %[[VAL_136:.*]]#0, %[[VAL_136]]#1, %[[VAL_136]]#2, %[[VAL_136]]#3, %[[VAL_136]]#4 : index, index, index, i1, i1
+// CHECK:                 }
+// CHECK:                 scf.yield %[[VAL_137:.*]]#0, %[[VAL_137]]#1, %[[VAL_137]]#2, %[[VAL_127]]#0, %[[VAL_128]]#0, %[[VAL_127]]#1, %[[VAL_128]]#1, %[[VAL_137]]#3, %[[VAL_137]]#4 : index, index, index, i64, i64, f64, f64, i1, i1
 // CHECK:               }
 // CHECK:             }
 // CHECK:             scf.yield
 // CHECK:           }
-// CHECK:           %[[VAL_135:.*]] = call @cast_csx_to_csr(%[[VAL_9]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           return %[[VAL_135]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           return %[[VAL_10]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
 
 func @matrix_intersect(%a: tensor<?x?xf64, #CSR64>, %b: tensor<?x?xf64, #CSR64>) -> tensor<?x?xf64, #CSR64> {

--- a/mlir_graphblas/src/test/GraphBLAS/lower_matrix_multiply_full.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_matrix_multiply_full.mlir
@@ -14,177 +14,175 @@
   indexBitWidth = 64
 }>
 
-// CHECK-DAG:     func private @matrix_resize_values(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index)
-// CHECK-DAG:     func private @matrix_resize_index(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK-DAG:     func private @cast_csx_to_csr(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK-DAG:     func private @matrix_resize_pointers(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK-DAG:     func private @matrix_resize_dim(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK-DAG:     func private @matrix_empty_like(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK-DAG:     func private @cast_csr_to_csx(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-
 // CHECK-LABEL:   func @matrix_multiply_plus_times(
 // CHECK-SAME:                                     %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                                     %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK-DAG:       %[[VAL_2:.*]] = constant 0 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_4:.*]] = constant 0 : i64
-// CHECK-DAG:       %[[VAL_5:.*]] = constant 1 : i64
-// CHECK-DAG:       %[[VAL_6:.*]] = constant 0.000000e+00 : f64
-// CHECK-DAG:       %[[VAL_7:.*]] = constant true
-// CHECK-DAG:       %[[VAL_8:.*]] = constant false
-// CHECK:           %[[VAL_15:.*]] = tensor.dim %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_16:.*]] = tensor.dim %[[VAL_1]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_17:.*]] = tensor.dim %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_18:.*]] = addi %[[VAL_15]], %[[VAL_3]] : index
-// CHECK:           %[[VAL_19:.*]] = call @cast_csr_to_csx(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_20:.*]] = call @matrix_empty_like(%[[VAL_19]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @matrix_resize_dim(%[[VAL_20]], %[[VAL_2]], %[[VAL_15]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @matrix_resize_dim(%[[VAL_20]], %[[VAL_3]], %[[VAL_16]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @matrix_resize_pointers(%[[VAL_20]], %[[VAL_3]], %[[VAL_18]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           %[[VAL_21:.*]] = call @cast_csx_to_csr(%[[VAL_20]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_9:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_10:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_11:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_12:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_13:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_14:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_22:.*]] = sparse_tensor.pointers %[[VAL_21]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           scf.parallel (%[[VAL_23:.*]]) = (%[[VAL_2]]) to (%[[VAL_15]]) step (%[[VAL_3]]) {
-// CHECK:             %[[VAL_24:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_23]]] : memref<?xi64>
-// CHECK:             %[[VAL_25:.*]] = addi %[[VAL_23]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_26:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_25]]] : memref<?xi64>
-// CHECK:             %[[VAL_27:.*]] = cmpi eq, %[[VAL_24]], %[[VAL_26]] : i64
-// CHECK:             %[[VAL_28:.*]] = scf.if %[[VAL_27]] -> (i64) {
-// CHECK:               scf.yield %[[VAL_4]] : i64
+// CHECK-DAG:       %[[VAL_2:.*]] = constant 0 : i64
+// CHECK-DAG:       %[[VAL_3:.*]] = constant 1 : i64
+// CHECK-DAG:       %[[VAL_4:.*]] = constant 0 : index
+// CHECK-DAG:       %[[VAL_5:.*]] = constant 1 : index
+// CHECK-DAG:       %[[VAL_6:.*]] = constant true
+// CHECK-DAG:       %[[VAL_7:.*]] = constant false
+// CHECK-DAG:       %[[VAL_8:.*]] = constant 0.000000e+00 : f64
+// CHECK:           %[[VAL_9:.*]] = tensor.dim %[[VAL_0]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_10:.*]] = tensor.dim %[[VAL_1]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_11:.*]] = tensor.dim %[[VAL_0]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_12:.*]] = addi %[[VAL_9]], %[[VAL_5]] : index
+// CHECK:           %[[VAL_13:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_14:.*]] = call @empty_like(%[[VAL_13]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_15:.*]] = call @ptr8_to_matrix_csr_f64_p64i64(%[[VAL_14]]) : (!llvm.ptr<i8>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_16:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_15]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_dim(%[[VAL_16]], %[[VAL_4]], %[[VAL_9]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_17:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_15]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_dim(%[[VAL_17]], %[[VAL_5]], %[[VAL_10]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_18:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_15]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_pointers(%[[VAL_18]], %[[VAL_5]], %[[VAL_12]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_19:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_20:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_21:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_22:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_23:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_24:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_25:.*]] = sparse_tensor.pointers %[[VAL_15]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           scf.parallel (%[[VAL_26:.*]]) = (%[[VAL_4]]) to (%[[VAL_9]]) step (%[[VAL_5]]) {
+// CHECK:             %[[VAL_27:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_26]]] : memref<?xi64>
+// CHECK:             %[[VAL_28:.*]] = addi %[[VAL_26]], %[[VAL_5]] : index
+// CHECK:             %[[VAL_29:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_28]]] : memref<?xi64>
+// CHECK:             %[[VAL_30:.*]] = cmpi eq, %[[VAL_27]], %[[VAL_29]] : i64
+// CHECK:             %[[VAL_31:.*]] = scf.if %[[VAL_30]] -> (i64) {
+// CHECK:               scf.yield %[[VAL_2]] : i64
 // CHECK:             } else {
-// CHECK:               %[[VAL_29:.*]] = index_cast %[[VAL_24]] : i64 to index
-// CHECK:               %[[VAL_30:.*]] = index_cast %[[VAL_26]] : i64 to index
-// CHECK:               %[[VAL_31:.*]] = memref.alloc(%[[VAL_17]]) : memref<?xi1>
-// CHECK:               linalg.fill(%[[VAL_8]], %[[VAL_31]]) : i1, memref<?xi1>
-// CHECK:               scf.parallel (%[[VAL_32:.*]]) = (%[[VAL_29]]) to (%[[VAL_30]]) step (%[[VAL_3]]) {
-// CHECK:                 %[[VAL_33:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_32]]] : memref<?xi64>
-// CHECK:                 %[[VAL_34:.*]] = index_cast %[[VAL_33]] : i64 to index
-// CHECK:                 memref.store %[[VAL_7]], %[[VAL_31]]{{\[}}%[[VAL_34]]] : memref<?xi1>
+// CHECK:               %[[VAL_32:.*]] = index_cast %[[VAL_27]] : i64 to index
+// CHECK:               %[[VAL_33:.*]] = index_cast %[[VAL_29]] : i64 to index
+// CHECK:               %[[VAL_34:.*]] = memref.alloc(%[[VAL_11]]) : memref<?xi1>
+// CHECK:               linalg.fill(%[[VAL_7]], %[[VAL_34]]) : i1, memref<?xi1>
+// CHECK:               scf.parallel (%[[VAL_35:.*]]) = (%[[VAL_32]]) to (%[[VAL_33]]) step (%[[VAL_5]]) {
+// CHECK:                 %[[VAL_36:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_35]]] : memref<?xi64>
+// CHECK:                 %[[VAL_37:.*]] = index_cast %[[VAL_36]] : i64 to index
+// CHECK:                 memref.store %[[VAL_6]], %[[VAL_34]]{{\[}}%[[VAL_37]]] : memref<?xi1>
 // CHECK:                 scf.yield
 // CHECK:               }
-// CHECK:               %[[VAL_35:.*]] = scf.parallel (%[[VAL_36:.*]]) = (%[[VAL_2]]) to (%[[VAL_16]]) step (%[[VAL_3]]) init (%[[VAL_4]]) -> i64 {
-// CHECK:                 %[[VAL_37:.*]] = addi %[[VAL_36]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_38:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_36]]] : memref<?xi64>
-// CHECK:                 %[[VAL_39:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_37]]] : memref<?xi64>
-// CHECK:                 %[[VAL_40:.*]] = cmpi eq, %[[VAL_38]], %[[VAL_39]] : i64
-// CHECK:                 %[[VAL_41:.*]] = scf.if %[[VAL_40]] -> (i64) {
-// CHECK:                   scf.yield %[[VAL_4]] : i64
+// CHECK:               %[[VAL_38:.*]] = scf.parallel (%[[VAL_39:.*]]) = (%[[VAL_4]]) to (%[[VAL_10]]) step (%[[VAL_5]]) init (%[[VAL_2]]) -> i64 {
+// CHECK:                 %[[VAL_40:.*]] = addi %[[VAL_39]], %[[VAL_5]] : index
+// CHECK:                 %[[VAL_41:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_39]]] : memref<?xi64>
+// CHECK:                 %[[VAL_42:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_40]]] : memref<?xi64>
+// CHECK:                 %[[VAL_43:.*]] = cmpi eq, %[[VAL_41]], %[[VAL_42]] : i64
+// CHECK:                 %[[VAL_44:.*]] = scf.if %[[VAL_43]] -> (i64) {
+// CHECK:                   scf.yield %[[VAL_2]] : i64
 // CHECK:                 } else {
-// CHECK:                   %[[VAL_42:.*]] = scf.while (%[[VAL_43:.*]] = %[[VAL_38]]) : (i64) -> i64 {
-// CHECK:                     %[[VAL_44:.*]] = cmpi uge, %[[VAL_43]], %[[VAL_39]] : i64
-// CHECK:                     %[[VAL_45:.*]]:2 = scf.if %[[VAL_44]] -> (i1, i64) {
-// CHECK:                       scf.yield %[[VAL_8]], %[[VAL_4]] : i1, i64
+// CHECK:                   %[[VAL_45:.*]] = scf.while (%[[VAL_46:.*]] = %[[VAL_41]]) : (i64) -> i64 {
+// CHECK:                     %[[VAL_47:.*]] = cmpi uge, %[[VAL_46]], %[[VAL_42]] : i64
+// CHECK:                     %[[VAL_48:.*]]:2 = scf.if %[[VAL_47]] -> (i1, i64) {
+// CHECK:                       scf.yield %[[VAL_7]], %[[VAL_2]] : i1, i64
 // CHECK:                     } else {
-// CHECK:                       %[[VAL_46:.*]] = index_cast %[[VAL_43]] : i64 to index
-// CHECK:                       %[[VAL_47:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_46]]] : memref<?xi64>
-// CHECK:                       %[[VAL_48:.*]] = index_cast %[[VAL_47]] : i64 to index
-// CHECK:                       %[[VAL_49:.*]] = memref.load %[[VAL_31]]{{\[}}%[[VAL_48]]] : memref<?xi1>
-// CHECK:                       %[[VAL_50:.*]] = select %[[VAL_49]], %[[VAL_8]], %[[VAL_7]] : i1
-// CHECK:                       %[[VAL_51:.*]] = select %[[VAL_49]], %[[VAL_5]], %[[VAL_43]] : i64
-// CHECK:                       scf.yield %[[VAL_50]], %[[VAL_51]] : i1, i64
+// CHECK:                       %[[VAL_49:.*]] = index_cast %[[VAL_46]] : i64 to index
+// CHECK:                       %[[VAL_50:.*]] = memref.load %[[VAL_23]]{{\[}}%[[VAL_49]]] : memref<?xi64>
+// CHECK:                       %[[VAL_51:.*]] = index_cast %[[VAL_50]] : i64 to index
+// CHECK:                       %[[VAL_52:.*]] = memref.load %[[VAL_34]]{{\[}}%[[VAL_51]]] : memref<?xi1>
+// CHECK:                       %[[VAL_53:.*]] = select %[[VAL_52]], %[[VAL_7]], %[[VAL_6]] : i1
+// CHECK:                       %[[VAL_54:.*]] = select %[[VAL_52]], %[[VAL_3]], %[[VAL_46]] : i64
+// CHECK:                       scf.yield %[[VAL_53]], %[[VAL_54]] : i1, i64
 // CHECK:                     }
-// CHECK:                     scf.condition(%[[VAL_52:.*]]#0) %[[VAL_52]]#1 : i64
+// CHECK:                     scf.condition(%[[VAL_55:.*]]#0) %[[VAL_55]]#1 : i64
 // CHECK:                   } do {
-// CHECK:                   ^bb0(%[[VAL_53:.*]]: i64):
-// CHECK:                     %[[VAL_54:.*]] = addi %[[VAL_53]], %[[VAL_5]] : i64
-// CHECK:                     scf.yield %[[VAL_54]] : i64
+// CHECK:                   ^bb0(%[[VAL_56:.*]]: i64):
+// CHECK:                     %[[VAL_57:.*]] = addi %[[VAL_56]], %[[VAL_3]] : i64
+// CHECK:                     scf.yield %[[VAL_57]] : i64
 // CHECK:                   }
-// CHECK:                   scf.yield %[[VAL_55:.*]] : i64
+// CHECK:                   scf.yield %[[VAL_58:.*]] : i64
 // CHECK:                 }
-// CHECK:                 scf.reduce(%[[VAL_56:.*]])  : i64 {
-// CHECK:                 ^bb0(%[[VAL_57:.*]]: i64, %[[VAL_58:.*]]: i64):
-// CHECK:                   %[[VAL_59:.*]] = addi %[[VAL_57]], %[[VAL_58]] : i64
-// CHECK:                   scf.reduce.return %[[VAL_59]] : i64
+// CHECK:                 scf.reduce(%[[VAL_59:.*]])  : i64 {
+// CHECK:                 ^bb0(%[[VAL_60:.*]]: i64, %[[VAL_61:.*]]: i64):
+// CHECK:                   %[[VAL_62:.*]] = addi %[[VAL_60]], %[[VAL_61]] : i64
+// CHECK:                   scf.reduce.return %[[VAL_62]] : i64
 // CHECK:                 }
 // CHECK:                 scf.yield
 // CHECK:               }
-// CHECK:               scf.yield %[[VAL_60:.*]] : i64
+// CHECK:               memref.dealloc %[[VAL_34]] : memref<?xi1>
+// CHECK:               scf.yield %[[VAL_63:.*]] : i64
 // CHECK:             }
-// CHECK:             memref.store %[[VAL_61:.*]], %[[VAL_22]]{{\[}}%[[VAL_23]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_64:.*]], %[[VAL_25]]{{\[}}%[[VAL_26]]] : memref<?xi64>
 // CHECK:             scf.yield
 // CHECK:           }
-// CHECK:           scf.for %[[VAL_62:.*]] = %[[VAL_2]] to %[[VAL_15]] step %[[VAL_3]] {
-// CHECK:             %[[VAL_63:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_62]]] : memref<?xi64>
-// CHECK:             %[[VAL_64:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_15]]] : memref<?xi64>
-// CHECK:             memref.store %[[VAL_64]], %[[VAL_22]]{{\[}}%[[VAL_62]]] : memref<?xi64>
-// CHECK:             %[[VAL_65:.*]] = addi %[[VAL_64]], %[[VAL_63]] : i64
-// CHECK:             memref.store %[[VAL_65]], %[[VAL_22]]{{\[}}%[[VAL_15]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_65:.*]] = %[[VAL_4]] to %[[VAL_9]] step %[[VAL_5]] {
+// CHECK:             %[[VAL_66:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_65]]] : memref<?xi64>
+// CHECK:             %[[VAL_67:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_67]], %[[VAL_25]]{{\[}}%[[VAL_65]]] : memref<?xi64>
+// CHECK:             %[[VAL_68:.*]] = addi %[[VAL_67]], %[[VAL_66]] : i64
+// CHECK:             memref.store %[[VAL_68]], %[[VAL_25]]{{\[}}%[[VAL_9]]] : memref<?xi64>
 // CHECK:           }
-// CHECK:           %[[VAL_200:.*]] = sparse_tensor.pointers %[[VAL_21]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_201:.*]] = tensor.dim %[[VAL_21]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_66:.*]] = memref.load %[[VAL_200]]{{\[}}%[[VAL_201]]] : memref<?xi64>
-// CHECK:           %[[VAL_67:.*]] = index_cast %[[VAL_66]] : i64 to index
-// CHECK:           %[[VAL_68:.*]] = call @cast_csr_to_csx(%[[VAL_21]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @matrix_resize_index(%[[VAL_68]], %[[VAL_3]], %[[VAL_67]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           %[[VAL_69:.*]] = call @cast_csr_to_csx(%[[VAL_21]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @matrix_resize_values(%[[VAL_69]], %[[VAL_67]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
-// CHECK:           %[[VAL_70:.*]] = sparse_tensor.indices %[[VAL_21]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_71:.*]] = sparse_tensor.values %[[VAL_21]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           scf.parallel (%[[VAL_72:.*]]) = (%[[VAL_2]]) to (%[[VAL_15]]) step (%[[VAL_3]]) {
-// CHECK:             %[[VAL_73:.*]] = addi %[[VAL_72]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_74:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_72]]] : memref<?xi64>
-// CHECK:             %[[VAL_75:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_73]]] : memref<?xi64>
-// CHECK:             %[[VAL_76:.*]] = cmpi ne, %[[VAL_74]], %[[VAL_75]] : i64
-// CHECK:             scf.if %[[VAL_76]] {
-// CHECK:               %[[VAL_77:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_72]]] : memref<?xi64>
-// CHECK:               %[[VAL_78:.*]] = index_cast %[[VAL_77]] : i64 to index
-// CHECK:               %[[VAL_79:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_72]]] : memref<?xi64>
-// CHECK:               %[[VAL_80:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_73]]] : memref<?xi64>
-// CHECK:               %[[VAL_81:.*]] = index_cast %[[VAL_79]] : i64 to index
-// CHECK:               %[[VAL_82:.*]] = index_cast %[[VAL_80]] : i64 to index
-// CHECK:               %[[VAL_83:.*]] = memref.alloc(%[[VAL_17]]) : memref<?xf64>
-// CHECK:               %[[VAL_84:.*]] = memref.alloc(%[[VAL_17]]) : memref<?xi1>
-// CHECK:               linalg.fill(%[[VAL_8]], %[[VAL_84]]) : i1, memref<?xi1>
-// CHECK:               scf.parallel (%[[VAL_85:.*]]) = (%[[VAL_81]]) to (%[[VAL_82]]) step (%[[VAL_3]]) {
-// CHECK:                 %[[VAL_86:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_85]]] : memref<?xi64>
-// CHECK:                 %[[VAL_87:.*]] = index_cast %[[VAL_86]] : i64 to index
-// CHECK:                 memref.store %[[VAL_7]], %[[VAL_84]]{{\[}}%[[VAL_87]]] : memref<?xi1>
-// CHECK:                 %[[VAL_88:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_85]]] : memref<?xf64>
-// CHECK:                 memref.store %[[VAL_88]], %[[VAL_83]]{{\[}}%[[VAL_87]]] : memref<?xf64>
+// CHECK:           %[[VAL_69:.*]] = sparse_tensor.pointers %[[VAL_15]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_70:.*]] = tensor.dim %[[VAL_15]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_71:.*]] = memref.load %[[VAL_69]]{{\[}}%[[VAL_70]]] : memref<?xi64>
+// CHECK:           %[[VAL_72:.*]] = index_cast %[[VAL_71]] : i64 to index
+// CHECK:           %[[VAL_73:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_15]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_index(%[[VAL_73]], %[[VAL_5]], %[[VAL_72]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_74:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_15]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_values(%[[VAL_74]], %[[VAL_72]]) : (!llvm.ptr<i8>, index) -> ()
+// CHECK:           %[[VAL_75:.*]] = sparse_tensor.indices %[[VAL_15]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_76:.*]] = sparse_tensor.values %[[VAL_15]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           scf.parallel (%[[VAL_77:.*]]) = (%[[VAL_4]]) to (%[[VAL_9]]) step (%[[VAL_5]]) {
+// CHECK:             %[[VAL_78:.*]] = addi %[[VAL_77]], %[[VAL_5]] : index
+// CHECK:             %[[VAL_79:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_77]]] : memref<?xi64>
+// CHECK:             %[[VAL_80:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_78]]] : memref<?xi64>
+// CHECK:             %[[VAL_81:.*]] = cmpi ne, %[[VAL_79]], %[[VAL_80]] : i64
+// CHECK:             scf.if %[[VAL_81]] {
+// CHECK:               %[[VAL_82:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_77]]] : memref<?xi64>
+// CHECK:               %[[VAL_83:.*]] = index_cast %[[VAL_82]] : i64 to index
+// CHECK:               %[[VAL_84:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_77]]] : memref<?xi64>
+// CHECK:               %[[VAL_85:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_78]]] : memref<?xi64>
+// CHECK:               %[[VAL_86:.*]] = index_cast %[[VAL_84]] : i64 to index
+// CHECK:               %[[VAL_87:.*]] = index_cast %[[VAL_85]] : i64 to index
+// CHECK:               %[[VAL_88:.*]] = memref.alloc(%[[VAL_11]]) : memref<?xf64>
+// CHECK:               %[[VAL_89:.*]] = memref.alloc(%[[VAL_11]]) : memref<?xi1>
+// CHECK:               linalg.fill(%[[VAL_7]], %[[VAL_89]]) : i1, memref<?xi1>
+// CHECK:               scf.parallel (%[[VAL_90:.*]]) = (%[[VAL_86]]) to (%[[VAL_87]]) step (%[[VAL_5]]) {
+// CHECK:                 %[[VAL_91:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_90]]] : memref<?xi64>
+// CHECK:                 %[[VAL_92:.*]] = index_cast %[[VAL_91]] : i64 to index
+// CHECK:                 memref.store %[[VAL_6]], %[[VAL_89]]{{\[}}%[[VAL_92]]] : memref<?xi1>
+// CHECK:                 %[[VAL_93:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_90]]] : memref<?xf64>
+// CHECK:                 memref.store %[[VAL_93]], %[[VAL_88]]{{\[}}%[[VAL_92]]] : memref<?xf64>
 // CHECK:                 scf.yield
 // CHECK:               }
-// CHECK:               %[[VAL_89:.*]] = scf.for %[[VAL_90:.*]] = %[[VAL_2]] to %[[VAL_16]] step %[[VAL_3]] iter_args(%[[VAL_91:.*]] = %[[VAL_2]]) -> (index) {
-// CHECK:                 %[[VAL_92:.*]] = index_cast %[[VAL_90]] : index to i64
-// CHECK:                 %[[VAL_93:.*]] = addi %[[VAL_90]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_94:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_90]]] : memref<?xi64>
-// CHECK:                 %[[VAL_95:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_93]]] : memref<?xi64>
-// CHECK:                 %[[VAL_96:.*]] = index_cast %[[VAL_94]] : i64 to index
-// CHECK:                 %[[VAL_97:.*]] = index_cast %[[VAL_95]] : i64 to index
-// CHECK:                 %[[VAL_98:.*]]:2 = scf.for %[[VAL_99:.*]] = %[[VAL_96]] to %[[VAL_97]] step %[[VAL_3]] iter_args(%[[VAL_100:.*]] = %[[VAL_6]], %[[VAL_101:.*]] = %[[VAL_8]]) -> (f64, i1) {
-// CHECK:                   %[[VAL_102:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_99]]] : memref<?xi64>
-// CHECK:                   %[[VAL_103:.*]] = index_cast %[[VAL_102]] : i64 to index
-// CHECK:                   %[[VAL_104:.*]] = memref.load %[[VAL_84]]{{\[}}%[[VAL_103]]] : memref<?xi1>
-// CHECK:                   %[[VAL_105:.*]]:2 = scf.if %[[VAL_104]] -> (f64, i1) {
-// CHECK:                     %[[VAL_106:.*]] = memref.load %[[VAL_83]]{{\[}}%[[VAL_103]]] : memref<?xf64>
-// CHECK:                     %[[VAL_107:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_99]]] : memref<?xf64>
-// CHECK:                     %[[VAL_108:.*]] = mulf %[[VAL_106]], %[[VAL_107]] : f64
-// CHECK:                     %[[VAL_109:.*]] = addf %[[VAL_100]], %[[VAL_108]] : f64
-// CHECK:                     scf.yield %[[VAL_109]], %[[VAL_7]] : f64, i1
+// CHECK:               %[[VAL_94:.*]] = scf.for %[[VAL_95:.*]] = %[[VAL_4]] to %[[VAL_10]] step %[[VAL_5]] iter_args(%[[VAL_96:.*]] = %[[VAL_4]]) -> (index) {
+// CHECK:                 %[[VAL_97:.*]] = index_cast %[[VAL_95]] : index to i64
+// CHECK:                 %[[VAL_98:.*]] = addi %[[VAL_95]], %[[VAL_5]] : index
+// CHECK:                 %[[VAL_99:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_95]]] : memref<?xi64>
+// CHECK:                 %[[VAL_100:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_98]]] : memref<?xi64>
+// CHECK:                 %[[VAL_101:.*]] = index_cast %[[VAL_99]] : i64 to index
+// CHECK:                 %[[VAL_102:.*]] = index_cast %[[VAL_100]] : i64 to index
+// CHECK:                 %[[VAL_103:.*]]:2 = scf.for %[[VAL_104:.*]] = %[[VAL_101]] to %[[VAL_102]] step %[[VAL_5]] iter_args(%[[VAL_105:.*]] = %[[VAL_8]], %[[VAL_106:.*]] = %[[VAL_7]]) -> (f64, i1) {
+// CHECK:                   %[[VAL_107:.*]] = memref.load %[[VAL_23]]{{\[}}%[[VAL_104]]] : memref<?xi64>
+// CHECK:                   %[[VAL_108:.*]] = index_cast %[[VAL_107]] : i64 to index
+// CHECK:                   %[[VAL_109:.*]] = memref.load %[[VAL_89]]{{\[}}%[[VAL_108]]] : memref<?xi1>
+// CHECK:                   %[[VAL_110:.*]]:2 = scf.if %[[VAL_109]] -> (f64, i1) {
+// CHECK:                     %[[VAL_111:.*]] = memref.load %[[VAL_88]]{{\[}}%[[VAL_108]]] : memref<?xf64>
+// CHECK:                     %[[VAL_112:.*]] = memref.load %[[VAL_24]]{{\[}}%[[VAL_104]]] : memref<?xf64>
+// CHECK:                     %[[VAL_113:.*]] = mulf %[[VAL_111]], %[[VAL_112]] : f64
+// CHECK:                     %[[VAL_114:.*]] = addf %[[VAL_105]], %[[VAL_113]] : f64
+// CHECK:                     scf.yield %[[VAL_114]], %[[VAL_6]] : f64, i1
 // CHECK:                   } else {
-// CHECK:                     scf.yield %[[VAL_100]], %[[VAL_101]] : f64, i1
+// CHECK:                     scf.yield %[[VAL_105]], %[[VAL_106]] : f64, i1
 // CHECK:                   }
-// CHECK:                   scf.yield %[[VAL_110:.*]]#0, %[[VAL_110]]#1 : f64, i1
+// CHECK:                   scf.yield %[[VAL_115:.*]]#0, %[[VAL_115]]#1 : f64, i1
 // CHECK:                 }
-// CHECK:                 %[[VAL_111:.*]] = scf.if %[[VAL_112:.*]]#1 -> (index) {
-// CHECK:                   %[[VAL_113:.*]] = addi %[[VAL_78]], %[[VAL_91]] : index
-// CHECK:                   memref.store %[[VAL_92]], %[[VAL_70]]{{\[}}%[[VAL_113]]] : memref<?xi64>
-// CHECK:                   memref.store %[[VAL_112]]#0, %[[VAL_71]]{{\[}}%[[VAL_113]]] : memref<?xf64>
-// CHECK:                   %[[VAL_114:.*]] = addi %[[VAL_91]], %[[VAL_3]] : index
-// CHECK:                   scf.yield %[[VAL_114]] : index
+// CHECK:                 %[[VAL_116:.*]] = scf.if %[[VAL_117:.*]]#1 -> (index) {
+// CHECK:                   %[[VAL_118:.*]] = addi %[[VAL_83]], %[[VAL_96]] : index
+// CHECK:                   memref.store %[[VAL_97]], %[[VAL_75]]{{\[}}%[[VAL_118]]] : memref<?xi64>
+// CHECK:                   memref.store %[[VAL_117]]#0, %[[VAL_76]]{{\[}}%[[VAL_118]]] : memref<?xf64>
+// CHECK:                   %[[VAL_119:.*]] = addi %[[VAL_96]], %[[VAL_5]] : index
+// CHECK:                   scf.yield %[[VAL_119]] : index
 // CHECK:                 } else {
-// CHECK:                   scf.yield %[[VAL_91]] : index
+// CHECK:                   scf.yield %[[VAL_96]] : index
 // CHECK:                 }
-// CHECK:                 scf.yield %[[VAL_115:.*]] : index
+// CHECK:                 scf.yield %[[VAL_120:.*]] : index
 // CHECK:               }
+// CHECK:               memref.dealloc %[[VAL_88]] : memref<?xf64>
+// CHECK:               memref.dealloc %[[VAL_89]] : memref<?xi1>
 // CHECK:             }
 // CHECK:             scf.yield
 // CHECK:           }
-// CHECK:           return %[[VAL_21]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           return %[[VAL_15]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
 
 func @matrix_multiply_plus_times(%a: tensor<?x?xf64, #CSR64>, %b: tensor<?x?xf64, #CSC64>) -> tensor<?x?xf64, #CSR64> {

--- a/mlir_graphblas/src/test/GraphBLAS/lower_matrix_multiply_mask.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_matrix_multiply_mask.mlir
@@ -14,188 +14,186 @@
   indexBitWidth = 64
 }>
 
-// CHECK-DAG:     func private @matrix_resize_values(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index)
-// CHECK-DAG:     func private @matrix_resize_index(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK-DAG:     func private @cast_csx_to_csr(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK-DAG:     func private @matrix_resize_pointers(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK-DAG:     func private @matrix_resize_dim(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK-DAG:     func private @matrix_empty_like(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK-DAG:     func private @cast_csr_to_csx(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-
 // CHECK-LABEL:   func @matrix_multiply_mask_plus_pair(
 // CHECK-SAME:                                         %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                                         %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                                         %[[VAL_2:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 0 : index
-// CHECK-DAG:       %[[VAL_4:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_5:.*]] = constant 0 : i64
-// CHECK-DAG:       %[[VAL_6:.*]] = constant 1 : i64
-// CHECK-DAG:       %[[VAL_7:.*]] = constant 0.000000e+00 : f64
-// CHECK-DAG:       %[[VAL_8:.*]] = constant 1.000000e+00 : f64
-// CHECK-DAG:       %[[VAL_9:.*]] = constant true
-// CHECK-DAG:       %[[VAL_10:.*]] = constant false
-// CHECK:           %[[VAL_16:.*]] = tensor.dim %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_17:.*]] = tensor.dim %[[VAL_1]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_18:.*]] = tensor.dim %[[VAL_0]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_19:.*]] = addi %[[VAL_16]], %[[VAL_4]] : index
-// CHECK:           %[[VAL_22:.*]] = call @cast_csr_to_csx(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_23:.*]] = call @matrix_empty_like(%[[VAL_22]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @matrix_resize_dim(%[[VAL_23]], %[[VAL_3]], %[[VAL_16]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @matrix_resize_dim(%[[VAL_23]], %[[VAL_4]], %[[VAL_17]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @matrix_resize_pointers(%[[VAL_23]], %[[VAL_4]], %[[VAL_19]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           %[[VAL_24:.*]] = call @cast_csx_to_csr(%[[VAL_23]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_11:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_12:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_13:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_14:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_15:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_25:.*]] = sparse_tensor.pointers %[[VAL_24]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_20:.*]] = sparse_tensor.pointers %[[VAL_2]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_21:.*]] = sparse_tensor.indices %[[VAL_2]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           scf.parallel (%[[VAL_26:.*]]) = (%[[VAL_3]]) to (%[[VAL_16]]) step (%[[VAL_4]]) {
-// CHECK:             %[[VAL_27:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_26]]] : memref<?xi64>
-// CHECK:             %[[VAL_28:.*]] = addi %[[VAL_26]], %[[VAL_4]] : index
-// CHECK:             %[[VAL_29:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_28]]] : memref<?xi64>
-// CHECK:             %[[VAL_30:.*]] = cmpi eq, %[[VAL_27]], %[[VAL_29]] : i64
-// CHECK:             %[[VAL_31:.*]] = scf.if %[[VAL_30]] -> (i64) {
-// CHECK:               scf.yield %[[VAL_5]] : i64
+// CHECK-DAG:       %[[VAL_3:.*]] = constant 0 : i64
+// CHECK-DAG:       %[[VAL_4:.*]] = constant 1 : i64
+// CHECK-DAG:       %[[VAL_5:.*]] = constant 0 : index
+// CHECK-DAG:       %[[VAL_6:.*]] = constant 1 : index
+// CHECK-DAG:       %[[VAL_7:.*]] = constant true
+// CHECK-DAG:       %[[VAL_8:.*]] = constant false
+// CHECK-DAG:       %[[VAL_9:.*]] = constant 0.000000e+00 : f64
+// CHECK-DAG:       %[[VAL_10:.*]] = constant 1.000000e+00 : f64
+// CHECK:           %[[VAL_11:.*]] = tensor.dim %[[VAL_0]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_12:.*]] = tensor.dim %[[VAL_1]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_13:.*]] = tensor.dim %[[VAL_0]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_14:.*]] = addi %[[VAL_11]], %[[VAL_6]] : index
+// CHECK:           %[[VAL_15:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_16:.*]] = call @empty_like(%[[VAL_15]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_17:.*]] = call @ptr8_to_matrix_csr_f64_p64i64(%[[VAL_16]]) : (!llvm.ptr<i8>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_18:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_17]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_dim(%[[VAL_18]], %[[VAL_5]], %[[VAL_11]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_19:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_17]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_dim(%[[VAL_19]], %[[VAL_6]], %[[VAL_12]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_20:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_17]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_pointers(%[[VAL_20]], %[[VAL_6]], %[[VAL_14]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_21:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_22:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_23:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_24:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_25:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_26:.*]] = sparse_tensor.pointers %[[VAL_17]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_27:.*]] = sparse_tensor.pointers %[[VAL_2]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_28:.*]] = sparse_tensor.indices %[[VAL_2]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           scf.parallel (%[[VAL_29:.*]]) = (%[[VAL_5]]) to (%[[VAL_11]]) step (%[[VAL_6]]) {
+// CHECK:             %[[VAL_30:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_29]]] : memref<?xi64>
+// CHECK:             %[[VAL_31:.*]] = addi %[[VAL_29]], %[[VAL_6]] : index
+// CHECK:             %[[VAL_32:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_31]]] : memref<?xi64>
+// CHECK:             %[[VAL_33:.*]] = cmpi eq, %[[VAL_30]], %[[VAL_32]] : i64
+// CHECK:             %[[VAL_34:.*]] = scf.if %[[VAL_33]] -> (i64) {
+// CHECK:               scf.yield %[[VAL_3]] : i64
 // CHECK:             } else {
-// CHECK:               %[[VAL_32:.*]] = index_cast %[[VAL_27]] : i64 to index
-// CHECK:               %[[VAL_33:.*]] = index_cast %[[VAL_29]] : i64 to index
-// CHECK:               %[[VAL_38:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_26]]] : memref<?xi64>
-// CHECK:               %[[VAL_39:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_28]]] : memref<?xi64>
+// CHECK:               %[[VAL_35:.*]] = index_cast %[[VAL_30]] : i64 to index
+// CHECK:               %[[VAL_36:.*]] = index_cast %[[VAL_32]] : i64 to index
+// CHECK:               %[[VAL_37:.*]] = memref.load %[[VAL_27]]{{\[}}%[[VAL_29]]] : memref<?xi64>
+// CHECK:               %[[VAL_38:.*]] = memref.load %[[VAL_27]]{{\[}}%[[VAL_31]]] : memref<?xi64>
+// CHECK:               %[[VAL_39:.*]] = index_cast %[[VAL_37]] : i64 to index
 // CHECK:               %[[VAL_40:.*]] = index_cast %[[VAL_38]] : i64 to index
-// CHECK:               %[[VAL_41:.*]] = index_cast %[[VAL_39]] : i64 to index
-// CHECK:               %[[VAL_34:.*]] = memref.alloc(%[[VAL_18]]) : memref<?xi1>
-// CHECK:               linalg.fill(%[[VAL_10]], %[[VAL_34]]) : i1, memref<?xi1>
-// CHECK:               scf.parallel (%[[VAL_35:.*]]) = (%[[VAL_32]]) to (%[[VAL_33]]) step (%[[VAL_4]]) {
-// CHECK:                 %[[VAL_36:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_35]]] : memref<?xi64>
-// CHECK:                 %[[VAL_37:.*]] = index_cast %[[VAL_36]] : i64 to index
-// CHECK:                 memref.store %[[VAL_9]], %[[VAL_34]]{{\[}}%[[VAL_37]]] : memref<?xi1>
+// CHECK:               %[[VAL_41:.*]] = memref.alloc(%[[VAL_13]]) : memref<?xi1>
+// CHECK:               linalg.fill(%[[VAL_8]], %[[VAL_41]]) : i1, memref<?xi1>
+// CHECK:               scf.parallel (%[[VAL_42:.*]]) = (%[[VAL_35]]) to (%[[VAL_36]]) step (%[[VAL_6]]) {
+// CHECK:                 %[[VAL_43:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_42]]] : memref<?xi64>
+// CHECK:                 %[[VAL_44:.*]] = index_cast %[[VAL_43]] : i64 to index
+// CHECK:                 memref.store %[[VAL_7]], %[[VAL_41]]{{\[}}%[[VAL_44]]] : memref<?xi1>
 // CHECK:                 scf.yield
 // CHECK:               }
-// CHECK:               %[[VAL_42:.*]] = scf.parallel (%[[VAL_43:.*]]) = (%[[VAL_40]]) to (%[[VAL_41]]) step (%[[VAL_4]]) init (%[[VAL_5]]) -> i64 {
-// CHECK:                 %[[VAL_44:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_43]]] : memref<?xi64>
-// CHECK:                 %[[VAL_45:.*]] = index_cast %[[VAL_44]] : i64 to index
-// CHECK:                 %[[VAL_46:.*]] = addi %[[VAL_45]], %[[VAL_4]] : index
-// CHECK:                 %[[VAL_47:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_45]]] : memref<?xi64>
-// CHECK:                 %[[VAL_48:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_46]]] : memref<?xi64>
-// CHECK:                 %[[VAL_49:.*]] = cmpi eq, %[[VAL_47]], %[[VAL_48]] : i64
-// CHECK:                 %[[VAL_50:.*]] = scf.if %[[VAL_49]] -> (i64) {
-// CHECK:                   scf.yield %[[VAL_5]] : i64
+// CHECK:               %[[VAL_45:.*]] = scf.parallel (%[[VAL_46:.*]]) = (%[[VAL_39]]) to (%[[VAL_40]]) step (%[[VAL_6]]) init (%[[VAL_3]]) -> i64 {
+// CHECK:                 %[[VAL_47:.*]] = memref.load %[[VAL_28]]{{\[}}%[[VAL_46]]] : memref<?xi64>
+// CHECK:                 %[[VAL_48:.*]] = index_cast %[[VAL_47]] : i64 to index
+// CHECK:                 %[[VAL_49:.*]] = addi %[[VAL_48]], %[[VAL_6]] : index
+// CHECK:                 %[[VAL_50:.*]] = memref.load %[[VAL_24]]{{\[}}%[[VAL_48]]] : memref<?xi64>
+// CHECK:                 %[[VAL_51:.*]] = memref.load %[[VAL_24]]{{\[}}%[[VAL_49]]] : memref<?xi64>
+// CHECK:                 %[[VAL_52:.*]] = cmpi eq, %[[VAL_50]], %[[VAL_51]] : i64
+// CHECK:                 %[[VAL_53:.*]] = scf.if %[[VAL_52]] -> (i64) {
+// CHECK:                   scf.yield %[[VAL_3]] : i64
 // CHECK:                 } else {
-// CHECK:                   %[[VAL_51:.*]] = scf.while (%[[VAL_52:.*]] = %[[VAL_47]]) : (i64) -> i64 {
-// CHECK:                     %[[VAL_53:.*]] = cmpi uge, %[[VAL_52]], %[[VAL_48]] : i64
-// CHECK:                     %[[VAL_54:.*]]:2 = scf.if %[[VAL_53]] -> (i1, i64) {
-// CHECK:                       scf.yield %[[VAL_10]], %[[VAL_5]] : i1, i64
+// CHECK:                   %[[VAL_54:.*]] = scf.while (%[[VAL_55:.*]] = %[[VAL_50]]) : (i64) -> i64 {
+// CHECK:                     %[[VAL_56:.*]] = cmpi uge, %[[VAL_55]], %[[VAL_51]] : i64
+// CHECK:                     %[[VAL_57:.*]]:2 = scf.if %[[VAL_56]] -> (i1, i64) {
+// CHECK:                       scf.yield %[[VAL_8]], %[[VAL_3]] : i1, i64
 // CHECK:                     } else {
-// CHECK:                       %[[VAL_55:.*]] = index_cast %[[VAL_52]] : i64 to index
-// CHECK:                       %[[VAL_56:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_55]]] : memref<?xi64>
-// CHECK:                       %[[VAL_57:.*]] = index_cast %[[VAL_56]] : i64 to index
-// CHECK:                       %[[VAL_58:.*]] = memref.load %[[VAL_34]]{{\[}}%[[VAL_57]]] : memref<?xi1>
-// CHECK:                       %[[VAL_59:.*]] = select %[[VAL_58]], %[[VAL_10]], %[[VAL_9]] : i1
-// CHECK:                       %[[VAL_60:.*]] = select %[[VAL_58]], %[[VAL_6]], %[[VAL_52]] : i64
-// CHECK:                       scf.yield %[[VAL_59]], %[[VAL_60]] : i1, i64
+// CHECK:                       %[[VAL_58:.*]] = index_cast %[[VAL_55]] : i64 to index
+// CHECK:                       %[[VAL_59:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_58]]] : memref<?xi64>
+// CHECK:                       %[[VAL_60:.*]] = index_cast %[[VAL_59]] : i64 to index
+// CHECK:                       %[[VAL_61:.*]] = memref.load %[[VAL_41]]{{\[}}%[[VAL_60]]] : memref<?xi1>
+// CHECK:                       %[[VAL_62:.*]] = select %[[VAL_61]], %[[VAL_8]], %[[VAL_7]] : i1
+// CHECK:                       %[[VAL_63:.*]] = select %[[VAL_61]], %[[VAL_4]], %[[VAL_55]] : i64
+// CHECK:                       scf.yield %[[VAL_62]], %[[VAL_63]] : i1, i64
 // CHECK:                     }
-// CHECK:                     scf.condition(%[[VAL_61:.*]]#0) %[[VAL_61]]#1 : i64
+// CHECK:                     scf.condition(%[[VAL_64:.*]]#0) %[[VAL_64]]#1 : i64
 // CHECK:                   } do {
-// CHECK:                   ^bb0(%[[VAL_62:.*]]: i64):
-// CHECK:                     %[[VAL_63:.*]] = addi %[[VAL_62]], %[[VAL_6]] : i64
-// CHECK:                     scf.yield %[[VAL_63]] : i64
+// CHECK:                   ^bb0(%[[VAL_65:.*]]: i64):
+// CHECK:                     %[[VAL_66:.*]] = addi %[[VAL_65]], %[[VAL_4]] : i64
+// CHECK:                     scf.yield %[[VAL_66]] : i64
 // CHECK:                   }
-// CHECK:                   scf.yield %[[VAL_64:.*]] : i64
+// CHECK:                   scf.yield %[[VAL_67:.*]] : i64
 // CHECK:                 }
-// CHECK:                 scf.reduce(%[[VAL_65:.*]])  : i64 {
-// CHECK:                 ^bb0(%[[VAL_66:.*]]: i64, %[[VAL_67:.*]]: i64):
-// CHECK:                   %[[VAL_68:.*]] = addi %[[VAL_66]], %[[VAL_67]] : i64
-// CHECK:                   scf.reduce.return %[[VAL_68]] : i64
+// CHECK:                 scf.reduce(%[[VAL_68:.*]])  : i64 {
+// CHECK:                 ^bb0(%[[VAL_69:.*]]: i64, %[[VAL_70:.*]]: i64):
+// CHECK:                   %[[VAL_71:.*]] = addi %[[VAL_69]], %[[VAL_70]] : i64
+// CHECK:                   scf.reduce.return %[[VAL_71]] : i64
 // CHECK:                 }
 // CHECK:                 scf.yield
 // CHECK:               }
-// CHECK:               scf.yield %[[VAL_69:.*]] : i64
+// CHECK:               memref.dealloc %[[VAL_41]] : memref<?xi1>
+// CHECK:               scf.yield %[[VAL_72:.*]] : i64
 // CHECK:             }
-// CHECK:             memref.store %[[VAL_70:.*]], %[[VAL_25]]{{\[}}%[[VAL_26]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_73:.*]], %[[VAL_26]]{{\[}}%[[VAL_29]]] : memref<?xi64>
 // CHECK:             scf.yield
 // CHECK:           }
-// CHECK:           scf.for %[[VAL_71:.*]] = %[[VAL_3]] to %[[VAL_16]] step %[[VAL_4]] {
-// CHECK:             %[[VAL_72:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_71]]] : memref<?xi64>
-// CHECK:             %[[VAL_73:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_16]]] : memref<?xi64>
-// CHECK:             memref.store %[[VAL_73]], %[[VAL_25]]{{\[}}%[[VAL_71]]] : memref<?xi64>
-// CHECK:             %[[VAL_74:.*]] = addi %[[VAL_73]], %[[VAL_72]] : i64
-// CHECK:             memref.store %[[VAL_74]], %[[VAL_25]]{{\[}}%[[VAL_16]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_74:.*]] = %[[VAL_5]] to %[[VAL_11]] step %[[VAL_6]] {
+// CHECK:             %[[VAL_75:.*]] = memref.load %[[VAL_26]]{{\[}}%[[VAL_74]]] : memref<?xi64>
+// CHECK:             %[[VAL_76:.*]] = memref.load %[[VAL_26]]{{\[}}%[[VAL_11]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_76]], %[[VAL_26]]{{\[}}%[[VAL_74]]] : memref<?xi64>
+// CHECK:             %[[VAL_77:.*]] = addi %[[VAL_76]], %[[VAL_75]] : i64
+// CHECK:             memref.store %[[VAL_77]], %[[VAL_26]]{{\[}}%[[VAL_11]]] : memref<?xi64>
 // CHECK:           }
-// CHECK:           %[[VAL_200:.*]] = sparse_tensor.pointers %[[VAL_24]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_201:.*]] = tensor.dim %[[VAL_24]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_75:.*]] = memref.load %[[VAL_200]]{{\[}}%[[VAL_201]]] : memref<?xi64>
-// CHECK:           %[[VAL_76:.*]] = index_cast %[[VAL_75]] : i64 to index
-// CHECK:           %[[VAL_77:.*]] = call @cast_csr_to_csx(%[[VAL_24]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @matrix_resize_index(%[[VAL_77]], %[[VAL_4]], %[[VAL_76]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           %[[VAL_78:.*]] = call @cast_csr_to_csx(%[[VAL_24]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @matrix_resize_values(%[[VAL_78]], %[[VAL_76]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
-// CHECK:           %[[VAL_79:.*]] = sparse_tensor.indices %[[VAL_24]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_80:.*]] = sparse_tensor.values %[[VAL_24]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           scf.parallel (%[[VAL_81:.*]]) = (%[[VAL_3]]) to (%[[VAL_16]]) step (%[[VAL_4]]) {
-// CHECK:             %[[VAL_82:.*]] = addi %[[VAL_81]], %[[VAL_4]] : index
-// CHECK:             %[[VAL_83:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_81]]] : memref<?xi64>
-// CHECK:             %[[VAL_84:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_82]]] : memref<?xi64>
-// CHECK:             %[[VAL_85:.*]] = cmpi ne, %[[VAL_83]], %[[VAL_84]] : i64
-// CHECK:             scf.if %[[VAL_85]] {
-// CHECK:               %[[VAL_86:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_81]]] : memref<?xi64>
-// CHECK:               %[[VAL_87:.*]] = index_cast %[[VAL_86]] : i64 to index
-// CHECK:               %[[VAL_88:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_81]]] : memref<?xi64>
-// CHECK:               %[[VAL_89:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_82]]] : memref<?xi64>
-// CHECK:               %[[VAL_90:.*]] = index_cast %[[VAL_88]] : i64 to index
-// CHECK:               %[[VAL_91:.*]] = index_cast %[[VAL_89]] : i64 to index
-// CHECK:               %[[VAL_98:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_81]]] : memref<?xi64>
-// CHECK:               %[[VAL_99:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_82]]] : memref<?xi64>
+// CHECK:           %[[VAL_78:.*]] = sparse_tensor.pointers %[[VAL_17]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_79:.*]] = tensor.dim %[[VAL_17]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_80:.*]] = memref.load %[[VAL_78]]{{\[}}%[[VAL_79]]] : memref<?xi64>
+// CHECK:           %[[VAL_81:.*]] = index_cast %[[VAL_80]] : i64 to index
+// CHECK:           %[[VAL_82:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_17]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_index(%[[VAL_82]], %[[VAL_6]], %[[VAL_81]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_83:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_17]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_values(%[[VAL_83]], %[[VAL_81]]) : (!llvm.ptr<i8>, index) -> ()
+// CHECK:           %[[VAL_84:.*]] = sparse_tensor.indices %[[VAL_17]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_85:.*]] = sparse_tensor.values %[[VAL_17]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           scf.parallel (%[[VAL_86:.*]]) = (%[[VAL_5]]) to (%[[VAL_11]]) step (%[[VAL_6]]) {
+// CHECK:             %[[VAL_87:.*]] = addi %[[VAL_86]], %[[VAL_6]] : index
+// CHECK:             %[[VAL_88:.*]] = memref.load %[[VAL_26]]{{\[}}%[[VAL_86]]] : memref<?xi64>
+// CHECK:             %[[VAL_89:.*]] = memref.load %[[VAL_26]]{{\[}}%[[VAL_87]]] : memref<?xi64>
+// CHECK:             %[[VAL_90:.*]] = cmpi ne, %[[VAL_88]], %[[VAL_89]] : i64
+// CHECK:             scf.if %[[VAL_90]] {
+// CHECK:               %[[VAL_91:.*]] = memref.load %[[VAL_26]]{{\[}}%[[VAL_86]]] : memref<?xi64>
+// CHECK:               %[[VAL_92:.*]] = index_cast %[[VAL_91]] : i64 to index
+// CHECK:               %[[VAL_93:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_86]]] : memref<?xi64>
+// CHECK:               %[[VAL_94:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_87]]] : memref<?xi64>
+// CHECK:               %[[VAL_95:.*]] = index_cast %[[VAL_93]] : i64 to index
+// CHECK:               %[[VAL_96:.*]] = index_cast %[[VAL_94]] : i64 to index
+// CHECK:               %[[VAL_97:.*]] = memref.load %[[VAL_27]]{{\[}}%[[VAL_86]]] : memref<?xi64>
+// CHECK:               %[[VAL_98:.*]] = memref.load %[[VAL_27]]{{\[}}%[[VAL_87]]] : memref<?xi64>
+// CHECK:               %[[VAL_99:.*]] = index_cast %[[VAL_97]] : i64 to index
 // CHECK:               %[[VAL_100:.*]] = index_cast %[[VAL_98]] : i64 to index
-// CHECK:               %[[VAL_101:.*]] = index_cast %[[VAL_99]] : i64 to index
-// CHECK:               %[[VAL_92:.*]] = memref.alloc(%[[VAL_18]]) : memref<?xf64>
-// CHECK:               %[[VAL_93:.*]] = memref.alloc(%[[VAL_18]]) : memref<?xi1>
-// CHECK:               linalg.fill(%[[VAL_10]], %[[VAL_93]]) : i1, memref<?xi1>
-// CHECK:               scf.parallel (%[[VAL_94:.*]]) = (%[[VAL_90]]) to (%[[VAL_91]]) step (%[[VAL_4]]) {
-// CHECK:                 %[[VAL_95:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_94]]] : memref<?xi64>
-// CHECK:                 %[[VAL_96:.*]] = index_cast %[[VAL_95]] : i64 to index
-// CHECK:                 memref.store %[[VAL_9]], %[[VAL_93]]{{\[}}%[[VAL_96]]] : memref<?xi1>
-// CHECK:                 %[[VAL_97:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_94]]] : memref<?xf64>
-// CHECK:                 memref.store %[[VAL_97]], %[[VAL_92]]{{\[}}%[[VAL_96]]] : memref<?xf64>
+// CHECK:               %[[VAL_101:.*]] = memref.alloc(%[[VAL_13]]) : memref<?xf64>
+// CHECK:               %[[VAL_102:.*]] = memref.alloc(%[[VAL_13]]) : memref<?xi1>
+// CHECK:               linalg.fill(%[[VAL_8]], %[[VAL_102]]) : i1, memref<?xi1>
+// CHECK:               scf.parallel (%[[VAL_103:.*]]) = (%[[VAL_95]]) to (%[[VAL_96]]) step (%[[VAL_6]]) {
+// CHECK:                 %[[VAL_104:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_103]]] : memref<?xi64>
+// CHECK:                 %[[VAL_105:.*]] = index_cast %[[VAL_104]] : i64 to index
+// CHECK:                 memref.store %[[VAL_7]], %[[VAL_102]]{{\[}}%[[VAL_105]]] : memref<?xi1>
+// CHECK:                 %[[VAL_106:.*]] = memref.load %[[VAL_23]]{{\[}}%[[VAL_103]]] : memref<?xf64>
+// CHECK:                 memref.store %[[VAL_106]], %[[VAL_101]]{{\[}}%[[VAL_105]]] : memref<?xf64>
 // CHECK:                 scf.yield
 // CHECK:               }
-// CHECK:               %[[VAL_102:.*]] = scf.for %[[VAL_103:.*]] = %[[VAL_100]] to %[[VAL_101]] step %[[VAL_4]] iter_args(%[[VAL_104:.*]] = %[[VAL_3]]) -> (index) {
-// CHECK:                 %[[VAL_105:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_103]]] : memref<?xi64>
-// CHECK:                 %[[VAL_106:.*]] = index_cast %[[VAL_105]] : i64 to index
-// CHECK:                 %[[VAL_107:.*]] = addi %[[VAL_106]], %[[VAL_4]] : index
-// CHECK:                 %[[VAL_108:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_106]]] : memref<?xi64>
-// CHECK:                 %[[VAL_109:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_107]]] : memref<?xi64>
-// CHECK:                 %[[VAL_110:.*]] = index_cast %[[VAL_108]] : i64 to index
-// CHECK:                 %[[VAL_111:.*]] = index_cast %[[VAL_109]] : i64 to index
-// CHECK:                 %[[VAL_112:.*]]:2 = scf.for %[[VAL_113:.*]] = %[[VAL_110]] to %[[VAL_111]] step %[[VAL_4]] iter_args(%[[VAL_114:.*]] = %[[VAL_7]], %[[VAL_115:.*]] = %[[VAL_10]]) -> (f64, i1) {
-// CHECK:                   %[[VAL_116:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_113]]] : memref<?xi64>
-// CHECK:                   %[[VAL_117:.*]] = index_cast %[[VAL_116]] : i64 to index
-// CHECK:                   %[[VAL_118:.*]] = memref.load %[[VAL_93]]{{\[}}%[[VAL_117]]] : memref<?xi1>
-// CHECK:                   %[[VAL_119:.*]]:2 = scf.if %[[VAL_118]] -> (f64, i1) {
-// CHECK:                     %[[VAL_120:.*]] = addf %[[VAL_114]], %[[VAL_8]] : f64
-// CHECK:                     scf.yield %[[VAL_120]], %[[VAL_9]] : f64, i1
+// CHECK:               %[[VAL_107:.*]] = scf.for %[[VAL_108:.*]] = %[[VAL_99]] to %[[VAL_100]] step %[[VAL_6]] iter_args(%[[VAL_109:.*]] = %[[VAL_5]]) -> (index) {
+// CHECK:                 %[[VAL_110:.*]] = memref.load %[[VAL_28]]{{\[}}%[[VAL_108]]] : memref<?xi64>
+// CHECK:                 %[[VAL_111:.*]] = index_cast %[[VAL_110]] : i64 to index
+// CHECK:                 %[[VAL_112:.*]] = addi %[[VAL_111]], %[[VAL_6]] : index
+// CHECK:                 %[[VAL_113:.*]] = memref.load %[[VAL_24]]{{\[}}%[[VAL_111]]] : memref<?xi64>
+// CHECK:                 %[[VAL_114:.*]] = memref.load %[[VAL_24]]{{\[}}%[[VAL_112]]] : memref<?xi64>
+// CHECK:                 %[[VAL_115:.*]] = index_cast %[[VAL_113]] : i64 to index
+// CHECK:                 %[[VAL_116:.*]] = index_cast %[[VAL_114]] : i64 to index
+// CHECK:                 %[[VAL_117:.*]]:2 = scf.for %[[VAL_118:.*]] = %[[VAL_115]] to %[[VAL_116]] step %[[VAL_6]] iter_args(%[[VAL_119:.*]] = %[[VAL_9]], %[[VAL_120:.*]] = %[[VAL_8]]) -> (f64, i1) {
+// CHECK:                   %[[VAL_121:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_118]]] : memref<?xi64>
+// CHECK:                   %[[VAL_122:.*]] = index_cast %[[VAL_121]] : i64 to index
+// CHECK:                   %[[VAL_123:.*]] = memref.load %[[VAL_102]]{{\[}}%[[VAL_122]]] : memref<?xi1>
+// CHECK:                   %[[VAL_124:.*]]:2 = scf.if %[[VAL_123]] -> (f64, i1) {
+// CHECK:                     %[[VAL_125:.*]] = addf %[[VAL_119]], %[[VAL_10]] : f64
+// CHECK:                     scf.yield %[[VAL_125]], %[[VAL_7]] : f64, i1
 // CHECK:                   } else {
-// CHECK:                     scf.yield %[[VAL_114]], %[[VAL_115]] : f64, i1
+// CHECK:                     scf.yield %[[VAL_119]], %[[VAL_120]] : f64, i1
 // CHECK:                   }
-// CHECK:                   scf.yield %[[VAL_121:.*]]#0, %[[VAL_121]]#1 : f64, i1
+// CHECK:                   scf.yield %[[VAL_126:.*]]#0, %[[VAL_126]]#1 : f64, i1
 // CHECK:                 }
-// CHECK:                 %[[VAL_122:.*]] = scf.if %[[VAL_123:.*]]#1 -> (index) {
-// CHECK:                   %[[VAL_124:.*]] = addi %[[VAL_87]], %[[VAL_104]] : index
-// CHECK:                   memref.store %[[VAL_105]], %[[VAL_79]]{{\[}}%[[VAL_124]]] : memref<?xi64>
-// CHECK:                   memref.store %[[VAL_123]]#0, %[[VAL_80]]{{\[}}%[[VAL_124]]] : memref<?xf64>
-// CHECK:                   %[[VAL_125:.*]] = addi %[[VAL_104]], %[[VAL_4]] : index
-// CHECK:                   scf.yield %[[VAL_125]] : index
+// CHECK:                 %[[VAL_127:.*]] = scf.if %[[VAL_128:.*]]#1 -> (index) {
+// CHECK:                   %[[VAL_129:.*]] = addi %[[VAL_92]], %[[VAL_109]] : index
+// CHECK:                   memref.store %[[VAL_110]], %[[VAL_84]]{{\[}}%[[VAL_129]]] : memref<?xi64>
+// CHECK:                   memref.store %[[VAL_128]]#0, %[[VAL_85]]{{\[}}%[[VAL_129]]] : memref<?xf64>
+// CHECK:                   %[[VAL_130:.*]] = addi %[[VAL_109]], %[[VAL_6]] : index
+// CHECK:                   scf.yield %[[VAL_130]] : index
 // CHECK:                 } else {
-// CHECK:                   scf.yield %[[VAL_104]] : index
+// CHECK:                   scf.yield %[[VAL_109]] : index
 // CHECK:                 }
-// CHECK:                 scf.yield %[[VAL_126:.*]] : index
+// CHECK:                 scf.yield %[[VAL_131:.*]] : index
 // CHECK:               }
+// CHECK:               memref.dealloc %[[VAL_101]] : memref<?xf64>
+// CHECK:               memref.dealloc %[[VAL_102]] : memref<?xi1>
 // CHECK:             }
 // CHECK:             scf.yield
 // CHECK:           }
-// CHECK:           return %[[VAL_24]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           return %[[VAL_17]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
 
 func @matrix_multiply_mask_plus_pair(%a: tensor<?x?xf64, #CSR64>, %b: tensor<?x?xf64, #CSC64>, %m: tensor<?x?xf64, #CSR64>) -> tensor<?x?xf64, #CSR64> {

--- a/mlir_graphblas/src/test/GraphBLAS/lower_matrix_update_accumulate.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_matrix_update_accumulate.mlir
@@ -7,219 +7,215 @@
   indexBitWidth = 64
 }>
 
-// CHECK-DAG:     func private @delSparseMatrix(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>)
-// CHECK-DAG:     func private @matrix_resize_values(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index)
-// CHECK-DAG:     func private @matrix_resize_index(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK-DAG:     func private @dup_matrix(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK-DAG:     func private @cast_csr_to_csx(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-
-// CHECK-LABEL:   func @matrix_update_accumulate(
-// CHECK-SAME:                                   %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
-// CHECK-SAME:                                   %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> index {
+// CHECK-LABEL:   .func @matrix_update_accumulate(
+// CHECK-SAME:                                    %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
+// CHECK-SAME:                                    %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> index {
 // CHECK-DAG:       %[[VAL_2:.*]] = constant 0 : index
 // CHECK-DAG:       %[[VAL_3:.*]] = constant 1 : index
 // CHECK-DAG:       %[[VAL_4:.*]] = constant 0 : i64
 // CHECK-DAG:       %[[VAL_5:.*]] = constant false
 // CHECK-DAG:       %[[VAL_6:.*]] = constant true
 // CHECK-DAG:       %[[VAL_7:.*]] = constant 0.000000e+00 : f64
-// CHECK:           %[[VAL_9:.*]] = call @cast_csr_to_csx(%[[VAL_1]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_10:.*]] = call @dup_matrix(%[[VAL_9]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_8:.*]] = tensor.dim %[[VAL_1]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_11:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_12:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_13:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_14:.*]] = sparse_tensor.pointers %[[VAL_10]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_15:.*]] = sparse_tensor.indices %[[VAL_10]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_16:.*]] = sparse_tensor.values %[[VAL_10]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_17:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           scf.parallel (%[[VAL_18:.*]]) = (%[[VAL_2]]) to (%[[VAL_8]]) step (%[[VAL_3]]) {
-// CHECK:             %[[VAL_19:.*]] = addi %[[VAL_18]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_20:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_18]]] : memref<?xi64>
-// CHECK:             %[[VAL_21:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_19]]] : memref<?xi64>
-// CHECK:             %[[VAL_22:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_18]]] : memref<?xi64>
-// CHECK:             %[[VAL_23:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_19]]] : memref<?xi64>
-// CHECK:             %[[VAL_24:.*]] = cmpi eq, %[[VAL_20]], %[[VAL_21]] : i64
-// CHECK:             %[[VAL_25:.*]] = cmpi eq, %[[VAL_22]], %[[VAL_23]] : i64
-// CHECK:             %[[VAL_26:.*]] = and %[[VAL_24]], %[[VAL_25]] : i1
-// CHECK:             %[[VAL_27:.*]] = scf.if %[[VAL_26]] -> (i64) {
+// CHECK:           %[[VAL_8:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_1]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_9:.*]] = call @dup_tensor(%[[VAL_8]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_10:.*]] = call @ptr8_to_matrix_csr_f64_p64i64(%[[VAL_9]]) : (!llvm.ptr<i8>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_11:.*]] = tensor.dim %[[VAL_1]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_12:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_13:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_14:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_15:.*]] = sparse_tensor.pointers %[[VAL_10]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_16:.*]] = sparse_tensor.indices %[[VAL_10]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_17:.*]] = sparse_tensor.values %[[VAL_10]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_18:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           scf.parallel (%[[VAL_19:.*]]) = (%[[VAL_2]]) to (%[[VAL_11]]) step (%[[VAL_3]]) {
+// CHECK:             %[[VAL_20:.*]] = addi %[[VAL_19]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_21:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_19]]] : memref<?xi64>
+// CHECK:             %[[VAL_22:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_20]]] : memref<?xi64>
+// CHECK:             %[[VAL_23:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_19]]] : memref<?xi64>
+// CHECK:             %[[VAL_24:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_20]]] : memref<?xi64>
+// CHECK:             %[[VAL_25:.*]] = cmpi eq, %[[VAL_21]], %[[VAL_22]] : i64
+// CHECK:             %[[VAL_26:.*]] = cmpi eq, %[[VAL_23]], %[[VAL_24]] : i64
+// CHECK:             %[[VAL_27:.*]] = and %[[VAL_25]], %[[VAL_26]] : i1
+// CHECK:             %[[VAL_28:.*]] = scf.if %[[VAL_27]] -> (i64) {
 // CHECK:               scf.yield %[[VAL_4]] : i64
 // CHECK:             } else {
-// CHECK:               %[[VAL_28:.*]] = index_cast %[[VAL_20]] : i64 to index
 // CHECK:               %[[VAL_29:.*]] = index_cast %[[VAL_21]] : i64 to index
 // CHECK:               %[[VAL_30:.*]] = index_cast %[[VAL_22]] : i64 to index
 // CHECK:               %[[VAL_31:.*]] = index_cast %[[VAL_23]] : i64 to index
-// CHECK:               %[[VAL_32:.*]]:7 = scf.while (%[[VAL_33:.*]] = %[[VAL_28]], %[[VAL_34:.*]] = %[[VAL_30]], %[[VAL_35:.*]] = %[[VAL_2]], %[[VAL_36:.*]] = %[[VAL_2]], %[[VAL_37:.*]] = %[[VAL_6]], %[[VAL_38:.*]] = %[[VAL_6]], %[[VAL_39:.*]] = %[[VAL_2]]) : (index, index, index, index, i1, i1, index) -> (index, index, index, index, i1, i1, index) {
-// CHECK:                 %[[VAL_40:.*]] = cmpi ult, %[[VAL_33]], %[[VAL_29]] : index
-// CHECK:                 %[[VAL_41:.*]] = cmpi ult, %[[VAL_34]], %[[VAL_31]] : index
-// CHECK:                 %[[VAL_42:.*]] = and %[[VAL_40]], %[[VAL_41]] : i1
-// CHECK:                 scf.condition(%[[VAL_42]]) %[[VAL_33]], %[[VAL_34]], %[[VAL_35]], %[[VAL_36]], %[[VAL_37]], %[[VAL_38]], %[[VAL_39]] : index, index, index, index, i1, i1, index
+// CHECK:               %[[VAL_32:.*]] = index_cast %[[VAL_24]] : i64 to index
+// CHECK:               %[[VAL_33:.*]]:7 = scf.while (%[[VAL_34:.*]] = %[[VAL_29]], %[[VAL_35:.*]] = %[[VAL_31]], %[[VAL_36:.*]] = %[[VAL_2]], %[[VAL_37:.*]] = %[[VAL_2]], %[[VAL_38:.*]] = %[[VAL_6]], %[[VAL_39:.*]] = %[[VAL_6]], %[[VAL_40:.*]] = %[[VAL_2]]) : (index, index, index, index, i1, i1, index) -> (index, index, index, index, i1, i1, index) {
+// CHECK:                 %[[VAL_41:.*]] = cmpi ult, %[[VAL_34]], %[[VAL_30]] : index
+// CHECK:                 %[[VAL_42:.*]] = cmpi ult, %[[VAL_35]], %[[VAL_32]] : index
+// CHECK:                 %[[VAL_43:.*]] = and %[[VAL_41]], %[[VAL_42]] : i1
+// CHECK:                 scf.condition(%[[VAL_43]]) %[[VAL_34]], %[[VAL_35]], %[[VAL_36]], %[[VAL_37]], %[[VAL_38]], %[[VAL_39]], %[[VAL_40]] : index, index, index, index, i1, i1, index
 // CHECK:               } do {
-// CHECK:               ^bb0(%[[VAL_43:.*]]: index, %[[VAL_44:.*]]: index, %[[VAL_45:.*]]: index, %[[VAL_46:.*]]: index, %[[VAL_47:.*]]: i1, %[[VAL_48:.*]]: i1, %[[VAL_49:.*]]: index):
-// CHECK:                 %[[VAL_50:.*]] = scf.if %[[VAL_47]] -> (index) {
-// CHECK:                   %[[VAL_51:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_43]]] : memref<?xi64>
-// CHECK:                   %[[VAL_52:.*]] = index_cast %[[VAL_51]] : i64 to index
-// CHECK:                   scf.yield %[[VAL_52]] : index
-// CHECK:                 } else {
-// CHECK:                   scf.yield %[[VAL_45]] : index
-// CHECK:                 }
-// CHECK:                 %[[VAL_53:.*]] = scf.if %[[VAL_48]] -> (index) {
-// CHECK:                   %[[VAL_54:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_44]]] : memref<?xi64>
-// CHECK:                   %[[VAL_55:.*]] = index_cast %[[VAL_54]] : i64 to index
-// CHECK:                   scf.yield %[[VAL_55]] : index
+// CHECK:               ^bb0(%[[VAL_44:.*]]: index, %[[VAL_45:.*]]: index, %[[VAL_46:.*]]: index, %[[VAL_47:.*]]: index, %[[VAL_48:.*]]: i1, %[[VAL_49:.*]]: i1, %[[VAL_50:.*]]: index):
+// CHECK:                 %[[VAL_51:.*]] = scf.if %[[VAL_48]] -> (index) {
+// CHECK:                   %[[VAL_52:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_44]]] : memref<?xi64>
+// CHECK:                   %[[VAL_53:.*]] = index_cast %[[VAL_52]] : i64 to index
+// CHECK:                   scf.yield %[[VAL_53]] : index
 // CHECK:                 } else {
 // CHECK:                   scf.yield %[[VAL_46]] : index
 // CHECK:                 }
-// CHECK:                 %[[VAL_56:.*]] = cmpi ult, %[[VAL_57:.*]], %[[VAL_58:.*]] : index
-// CHECK:                 %[[VAL_59:.*]] = cmpi ugt, %[[VAL_57]], %[[VAL_58]] : index
-// CHECK:                 %[[VAL_60:.*]] = addi %[[VAL_43]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_54:.*]] = scf.if %[[VAL_49]] -> (index) {
+// CHECK:                   %[[VAL_55:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_45]]] : memref<?xi64>
+// CHECK:                   %[[VAL_56:.*]] = index_cast %[[VAL_55]] : i64 to index
+// CHECK:                   scf.yield %[[VAL_56]] : index
+// CHECK:                 } else {
+// CHECK:                   scf.yield %[[VAL_47]] : index
+// CHECK:                 }
+// CHECK:                 %[[VAL_57:.*]] = cmpi ult, %[[VAL_58:.*]], %[[VAL_59:.*]] : index
+// CHECK:                 %[[VAL_60:.*]] = cmpi ugt, %[[VAL_58]], %[[VAL_59]] : index
 // CHECK:                 %[[VAL_61:.*]] = addi %[[VAL_44]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_62:.*]] = addi %[[VAL_49]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_63:.*]]:5 = scf.if %[[VAL_56]] -> (index, index, i1, i1, index) {
-// CHECK:                   scf.yield %[[VAL_60]], %[[VAL_44]], %[[VAL_6]], %[[VAL_5]], %[[VAL_62]] : index, index, i1, i1, index
+// CHECK:                 %[[VAL_62:.*]] = addi %[[VAL_45]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_63:.*]] = addi %[[VAL_50]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_64:.*]]:5 = scf.if %[[VAL_57]] -> (index, index, i1, i1, index) {
+// CHECK:                   scf.yield %[[VAL_61]], %[[VAL_45]], %[[VAL_6]], %[[VAL_5]], %[[VAL_63]] : index, index, i1, i1, index
 // CHECK:                 } else {
-// CHECK:                   %[[VAL_64:.*]]:5 = scf.if %[[VAL_59]] -> (index, index, i1, i1, index) {
-// CHECK:                     scf.yield %[[VAL_43]], %[[VAL_61]], %[[VAL_5]], %[[VAL_6]], %[[VAL_62]] : index, index, i1, i1, index
+// CHECK:                   %[[VAL_65:.*]]:5 = scf.if %[[VAL_60]] -> (index, index, i1, i1, index) {
+// CHECK:                     scf.yield %[[VAL_44]], %[[VAL_62]], %[[VAL_5]], %[[VAL_6]], %[[VAL_63]] : index, index, i1, i1, index
 // CHECK:                   } else {
-// CHECK:                     scf.yield %[[VAL_60]], %[[VAL_61]], %[[VAL_6]], %[[VAL_6]], %[[VAL_62]] : index, index, i1, i1, index
+// CHECK:                     scf.yield %[[VAL_61]], %[[VAL_62]], %[[VAL_6]], %[[VAL_6]], %[[VAL_63]] : index, index, i1, i1, index
 // CHECK:                   }
-// CHECK:                   scf.yield %[[VAL_65:.*]]#0, %[[VAL_65]]#1, %[[VAL_65]]#2, %[[VAL_65]]#3, %[[VAL_65]]#4 : index, index, i1, i1, index
+// CHECK:                   scf.yield %[[VAL_66:.*]]#0, %[[VAL_66]]#1, %[[VAL_66]]#2, %[[VAL_66]]#3, %[[VAL_66]]#4 : index, index, i1, i1, index
 // CHECK:                 }
-// CHECK:                 scf.yield %[[VAL_66:.*]]#0, %[[VAL_66]]#1, %[[VAL_57]], %[[VAL_58]], %[[VAL_66]]#2, %[[VAL_66]]#3, %[[VAL_66]]#4 : index, index, index, index, i1, i1, index
+// CHECK:                 scf.yield %[[VAL_67:.*]]#0, %[[VAL_67]]#1, %[[VAL_58]], %[[VAL_59]], %[[VAL_67]]#2, %[[VAL_67]]#3, %[[VAL_67]]#4 : index, index, index, index, i1, i1, index
 // CHECK:               }
-// CHECK:               %[[VAL_67:.*]] = cmpi ult, %[[VAL_68:.*]]#0, %[[VAL_29]] : index
-// CHECK:               %[[VAL_69:.*]] = scf.if %[[VAL_67]] -> (index) {
-// CHECK:                 %[[VAL_70:.*]] = subi %[[VAL_29]], %[[VAL_68]]#0 : index
-// CHECK:                 %[[VAL_71:.*]] = addi %[[VAL_68]]#6, %[[VAL_70]] : index
-// CHECK:                 scf.yield %[[VAL_71]] : index
+// CHECK:               %[[VAL_68:.*]] = cmpi ult, %[[VAL_69:.*]]#0, %[[VAL_30]] : index
+// CHECK:               %[[VAL_70:.*]] = scf.if %[[VAL_68]] -> (index) {
+// CHECK:                 %[[VAL_71:.*]] = subi %[[VAL_30]], %[[VAL_69]]#0 : index
+// CHECK:                 %[[VAL_72:.*]] = addi %[[VAL_69]]#6, %[[VAL_71]] : index
+// CHECK:                 scf.yield %[[VAL_72]] : index
 // CHECK:               } else {
-// CHECK:                 %[[VAL_72:.*]] = cmpi ult, %[[VAL_68]]#1, %[[VAL_31]] : index
-// CHECK:                 %[[VAL_73:.*]] = scf.if %[[VAL_72]] -> (index) {
-// CHECK:                   %[[VAL_74:.*]] = subi %[[VAL_31]], %[[VAL_68]]#1 : index
-// CHECK:                   %[[VAL_75:.*]] = addi %[[VAL_68]]#6, %[[VAL_74]] : index
-// CHECK:                   scf.yield %[[VAL_75]] : index
+// CHECK:                 %[[VAL_73:.*]] = cmpi ult, %[[VAL_69]]#1, %[[VAL_32]] : index
+// CHECK:                 %[[VAL_74:.*]] = scf.if %[[VAL_73]] -> (index) {
+// CHECK:                   %[[VAL_75:.*]] = subi %[[VAL_32]], %[[VAL_69]]#1 : index
+// CHECK:                   %[[VAL_76:.*]] = addi %[[VAL_69]]#6, %[[VAL_75]] : index
+// CHECK:                   scf.yield %[[VAL_76]] : index
 // CHECK:                 } else {
-// CHECK:                   scf.yield %[[VAL_68]]#6 : index
+// CHECK:                   scf.yield %[[VAL_69]]#6 : index
 // CHECK:                 }
-// CHECK:                 scf.yield %[[VAL_76:.*]] : index
+// CHECK:                 scf.yield %[[VAL_77:.*]] : index
 // CHECK:               }
-// CHECK:               %[[VAL_77:.*]] = index_cast %[[VAL_78:.*]] : index to i64
-// CHECK:               scf.yield %[[VAL_77]] : i64
+// CHECK:               %[[VAL_78:.*]] = index_cast %[[VAL_79:.*]] : index to i64
+// CHECK:               scf.yield %[[VAL_78]] : i64
 // CHECK:             }
-// CHECK:             memref.store %[[VAL_27]], %[[VAL_17]]{{\[}}%[[VAL_18]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_80:.*]], %[[VAL_18]]{{\[}}%[[VAL_19]]] : memref<?xi64>
 // CHECK:             scf.yield
 // CHECK:           }
-// CHECK:           memref.store %[[VAL_4]], %[[VAL_17]]{{\[}}%[[VAL_8]]] : memref<?xi64>
-// CHECK:           scf.for %[[VAL_80:.*]] = %[[VAL_2]] to %[[VAL_8]] step %[[VAL_3]] {
-// CHECK:             %[[VAL_81:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_80]]] : memref<?xi64>
-// CHECK:             %[[VAL_82:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_8]]] : memref<?xi64>
-// CHECK:             memref.store %[[VAL_82]], %[[VAL_17]]{{\[}}%[[VAL_80]]] : memref<?xi64>
-// CHECK:             %[[VAL_83:.*]] = addi %[[VAL_82]], %[[VAL_81]] : i64
-// CHECK:             memref.store %[[VAL_83]], %[[VAL_17]]{{\[}}%[[VAL_8]]] : memref<?xi64>
+// CHECK:           memref.store %[[VAL_4]], %[[VAL_18]]{{\[}}%[[VAL_11]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_81:.*]] = %[[VAL_2]] to %[[VAL_11]] step %[[VAL_3]] {
+// CHECK:             %[[VAL_82:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_81]]] : memref<?xi64>
+// CHECK:             %[[VAL_83:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_11]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_83]], %[[VAL_18]]{{\[}}%[[VAL_81]]] : memref<?xi64>
+// CHECK:             %[[VAL_84:.*]] = addi %[[VAL_83]], %[[VAL_82]] : i64
+// CHECK:             memref.store %[[VAL_84]], %[[VAL_18]]{{\[}}%[[VAL_11]]] : memref<?xi64>
 // CHECK:           }
-// CHECK:           %[[VAL_84:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_85:.*]] = tensor.dim %[[VAL_1]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_86:.*]] = memref.load %[[VAL_84]]{{\[}}%[[VAL_85]]] : memref<?xi64>
-// CHECK:           %[[VAL_87:.*]] = index_cast %[[VAL_86]] : i64 to index
-// CHECK:           %[[VAL_88:.*]] = call @cast_csr_to_csx(%[[VAL_1]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @matrix_resize_index(%[[VAL_88]], %[[VAL_3]], %[[VAL_87]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           %[[VAL_89:.*]] = call @cast_csr_to_csx(%[[VAL_1]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @matrix_resize_values(%[[VAL_89]], %[[VAL_87]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
-// CHECK:           %[[VAL_90:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_91:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           scf.parallel (%[[VAL_92:.*]]) = (%[[VAL_2]]) to (%[[VAL_8]]) step (%[[VAL_3]]) {
-// CHECK:             %[[VAL_93:.*]] = addi %[[VAL_92]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_94:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_92]]] : memref<?xi64>
-// CHECK:             %[[VAL_95:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_93]]] : memref<?xi64>
-// CHECK:             %[[VAL_96:.*]] = cmpi ne, %[[VAL_94]], %[[VAL_95]] : i64
-// CHECK:             scf.if %[[VAL_96]] {
-// CHECK:               %[[VAL_97:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_92]]] : memref<?xi64>
-// CHECK:               %[[VAL_98:.*]] = index_cast %[[VAL_97]] : i64 to index
-// CHECK:               %[[VAL_99:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_92]]] : memref<?xi64>
-// CHECK:               %[[VAL_100:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_93]]] : memref<?xi64>
-// CHECK:               %[[VAL_101:.*]] = index_cast %[[VAL_99]] : i64 to index
+// CHECK:           %[[VAL_85:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_86:.*]] = tensor.dim %[[VAL_1]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_87:.*]] = memref.load %[[VAL_85]]{{\[}}%[[VAL_86]]] : memref<?xi64>
+// CHECK:           %[[VAL_88:.*]] = index_cast %[[VAL_87]] : i64 to index
+// CHECK:           %[[VAL_89:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_1]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_index(%[[VAL_89]], %[[VAL_3]], %[[VAL_88]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_90:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_1]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_values(%[[VAL_90]], %[[VAL_88]]) : (!llvm.ptr<i8>, index) -> ()
+// CHECK:           %[[VAL_91:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_92:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           scf.parallel (%[[VAL_93:.*]]) = (%[[VAL_2]]) to (%[[VAL_11]]) step (%[[VAL_3]]) {
+// CHECK:             %[[VAL_94:.*]] = addi %[[VAL_93]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_95:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_93]]] : memref<?xi64>
+// CHECK:             %[[VAL_96:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_94]]] : memref<?xi64>
+// CHECK:             %[[VAL_97:.*]] = cmpi ne, %[[VAL_95]], %[[VAL_96]] : i64
+// CHECK:             scf.if %[[VAL_97]] {
+// CHECK:               %[[VAL_98:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_93]]] : memref<?xi64>
+// CHECK:               %[[VAL_99:.*]] = index_cast %[[VAL_98]] : i64 to index
+// CHECK:               %[[VAL_100:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_93]]] : memref<?xi64>
+// CHECK:               %[[VAL_101:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_94]]] : memref<?xi64>
 // CHECK:               %[[VAL_102:.*]] = index_cast %[[VAL_100]] : i64 to index
-// CHECK:               %[[VAL_103:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_92]]] : memref<?xi64>
-// CHECK:               %[[VAL_104:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_93]]] : memref<?xi64>
-// CHECK:               %[[VAL_105:.*]] = index_cast %[[VAL_103]] : i64 to index
+// CHECK:               %[[VAL_103:.*]] = index_cast %[[VAL_101]] : i64 to index
+// CHECK:               %[[VAL_104:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_93]]] : memref<?xi64>
+// CHECK:               %[[VAL_105:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_94]]] : memref<?xi64>
 // CHECK:               %[[VAL_106:.*]] = index_cast %[[VAL_104]] : i64 to index
-// CHECK:               %[[VAL_107:.*]]:9 = scf.while (%[[VAL_108:.*]] = %[[VAL_101]], %[[VAL_109:.*]] = %[[VAL_105]], %[[VAL_110:.*]] = %[[VAL_98]], %[[VAL_111:.*]] = %[[VAL_4]], %[[VAL_112:.*]] = %[[VAL_4]], %[[VAL_113:.*]] = %[[VAL_7]], %[[VAL_114:.*]] = %[[VAL_7]], %[[VAL_115:.*]] = %[[VAL_6]], %[[VAL_116:.*]] = %[[VAL_6]]) : (index, index, index, i64, i64, f64, f64, i1, i1) -> (index, index, index, i64, i64, f64, f64, i1, i1) {
-// CHECK:                 %[[VAL_117:.*]] = cmpi ult, %[[VAL_108]], %[[VAL_102]] : index
-// CHECK:                 %[[VAL_118:.*]] = cmpi ult, %[[VAL_109]], %[[VAL_106]] : index
-// CHECK:                 %[[VAL_119:.*]] = and %[[VAL_117]], %[[VAL_118]] : i1
-// CHECK:                 scf.condition(%[[VAL_119]]) %[[VAL_108]], %[[VAL_109]], %[[VAL_110]], %[[VAL_111]], %[[VAL_112]], %[[VAL_113]], %[[VAL_114]], %[[VAL_115]], %[[VAL_116]] : index, index, index, i64, i64, f64, f64, i1, i1
+// CHECK:               %[[VAL_107:.*]] = index_cast %[[VAL_105]] : i64 to index
+// CHECK:               %[[VAL_108:.*]]:9 = scf.while (%[[VAL_109:.*]] = %[[VAL_102]], %[[VAL_110:.*]] = %[[VAL_106]], %[[VAL_111:.*]] = %[[VAL_99]], %[[VAL_112:.*]] = %[[VAL_4]], %[[VAL_113:.*]] = %[[VAL_4]], %[[VAL_114:.*]] = %[[VAL_7]], %[[VAL_115:.*]] = %[[VAL_7]], %[[VAL_116:.*]] = %[[VAL_6]], %[[VAL_117:.*]] = %[[VAL_6]]) : (index, index, index, i64, i64, f64, f64, i1, i1) -> (index, index, index, i64, i64, f64, f64, i1, i1) {
+// CHECK:                 %[[VAL_118:.*]] = cmpi ult, %[[VAL_109]], %[[VAL_103]] : index
+// CHECK:                 %[[VAL_119:.*]] = cmpi ult, %[[VAL_110]], %[[VAL_107]] : index
+// CHECK:                 %[[VAL_120:.*]] = and %[[VAL_118]], %[[VAL_119]] : i1
+// CHECK:                 scf.condition(%[[VAL_120]]) %[[VAL_109]], %[[VAL_110]], %[[VAL_111]], %[[VAL_112]], %[[VAL_113]], %[[VAL_114]], %[[VAL_115]], %[[VAL_116]], %[[VAL_117]] : index, index, index, i64, i64, f64, f64, i1, i1
 // CHECK:               } do {
-// CHECK:               ^bb0(%[[VAL_120:.*]]: index, %[[VAL_121:.*]]: index, %[[VAL_122:.*]]: index, %[[VAL_123:.*]]: i64, %[[VAL_124:.*]]: i64, %[[VAL_125:.*]]: f64, %[[VAL_126:.*]]: f64, %[[VAL_127:.*]]: i1, %[[VAL_128:.*]]: i1):
-// CHECK:                 %[[VAL_129:.*]]:2 = scf.if %[[VAL_127]] -> (i64, f64) {
-// CHECK:                   %[[VAL_130:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_120]]] : memref<?xi64>
-// CHECK:                   %[[VAL_131:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_120]]] : memref<?xf64>
-// CHECK:                   scf.yield %[[VAL_130]], %[[VAL_131]] : i64, f64
-// CHECK:                 } else {
-// CHECK:                   scf.yield %[[VAL_123]], %[[VAL_125]] : i64, f64
-// CHECK:                 }
-// CHECK:                 %[[VAL_132:.*]]:2 = scf.if %[[VAL_128]] -> (i64, f64) {
-// CHECK:                   %[[VAL_133:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_121]]] : memref<?xi64>
-// CHECK:                   %[[VAL_134:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_121]]] : memref<?xf64>
-// CHECK:                   scf.yield %[[VAL_133]], %[[VAL_134]] : i64, f64
+// CHECK:               ^bb0(%[[VAL_121:.*]]: index, %[[VAL_122:.*]]: index, %[[VAL_123:.*]]: index, %[[VAL_124:.*]]: i64, %[[VAL_125:.*]]: i64, %[[VAL_126:.*]]: f64, %[[VAL_127:.*]]: f64, %[[VAL_128:.*]]: i1, %[[VAL_129:.*]]: i1):
+// CHECK:                 %[[VAL_130:.*]]:2 = scf.if %[[VAL_128]] -> (i64, f64) {
+// CHECK:                   %[[VAL_131:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_121]]] : memref<?xi64>
+// CHECK:                   %[[VAL_132:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_121]]] : memref<?xf64>
+// CHECK:                   scf.yield %[[VAL_131]], %[[VAL_132]] : i64, f64
 // CHECK:                 } else {
 // CHECK:                   scf.yield %[[VAL_124]], %[[VAL_126]] : i64, f64
 // CHECK:                 }
-// CHECK:                 %[[VAL_135:.*]] = cmpi ult, %[[VAL_136:.*]]#0, %[[VAL_137:.*]]#0 : i64
-// CHECK:                 %[[VAL_138:.*]] = cmpi ugt, %[[VAL_136]]#0, %[[VAL_137]]#0 : i64
-// CHECK:                 %[[VAL_139:.*]] = addi %[[VAL_120]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_133:.*]]:2 = scf.if %[[VAL_129]] -> (i64, f64) {
+// CHECK:                   %[[VAL_134:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_122]]] : memref<?xi64>
+// CHECK:                   %[[VAL_135:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_122]]] : memref<?xf64>
+// CHECK:                   scf.yield %[[VAL_134]], %[[VAL_135]] : i64, f64
+// CHECK:                 } else {
+// CHECK:                   scf.yield %[[VAL_125]], %[[VAL_127]] : i64, f64
+// CHECK:                 }
+// CHECK:                 %[[VAL_136:.*]] = cmpi ult, %[[VAL_137:.*]]#0, %[[VAL_138:.*]]#0 : i64
+// CHECK:                 %[[VAL_139:.*]] = cmpi ugt, %[[VAL_137]]#0, %[[VAL_138]]#0 : i64
 // CHECK:                 %[[VAL_140:.*]] = addi %[[VAL_121]], %[[VAL_3]] : index
 // CHECK:                 %[[VAL_141:.*]] = addi %[[VAL_122]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_142:.*]]:5 = scf.if %[[VAL_135]] -> (index, index, index, i1, i1) {
-// CHECK:                   memref.store %[[VAL_136]]#0, %[[VAL_90]]{{\[}}%[[VAL_122]]] : memref<?xi64>
-// CHECK:                   memref.store %[[VAL_136]]#1, %[[VAL_91]]{{\[}}%[[VAL_122]]] : memref<?xf64>
-// CHECK:                   scf.yield %[[VAL_139]], %[[VAL_121]], %[[VAL_141]], %[[VAL_6]], %[[VAL_5]] : index, index, index, i1, i1
+// CHECK:                 %[[VAL_142:.*]] = addi %[[VAL_123]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_143:.*]]:5 = scf.if %[[VAL_136]] -> (index, index, index, i1, i1) {
+// CHECK:                   memref.store %[[VAL_137]]#0, %[[VAL_91]]{{\[}}%[[VAL_123]]] : memref<?xi64>
+// CHECK:                   memref.store %[[VAL_137]]#1, %[[VAL_92]]{{\[}}%[[VAL_123]]] : memref<?xf64>
+// CHECK:                   scf.yield %[[VAL_140]], %[[VAL_122]], %[[VAL_142]], %[[VAL_6]], %[[VAL_5]] : index, index, index, i1, i1
 // CHECK:                 } else {
-// CHECK:                   %[[VAL_143:.*]]:5 = scf.if %[[VAL_138]] -> (index, index, index, i1, i1) {
-// CHECK:                     memref.store %[[VAL_137]]#0, %[[VAL_90]]{{\[}}%[[VAL_122]]] : memref<?xi64>
-// CHECK:                     memref.store %[[VAL_137]]#1, %[[VAL_91]]{{\[}}%[[VAL_122]]] : memref<?xf64>
-// CHECK:                     scf.yield %[[VAL_120]], %[[VAL_140]], %[[VAL_141]], %[[VAL_5]], %[[VAL_6]] : index, index, index, i1, i1
+// CHECK:                   %[[VAL_144:.*]]:5 = scf.if %[[VAL_139]] -> (index, index, index, i1, i1) {
+// CHECK:                     memref.store %[[VAL_138]]#0, %[[VAL_91]]{{\[}}%[[VAL_123]]] : memref<?xi64>
+// CHECK:                     memref.store %[[VAL_138]]#1, %[[VAL_92]]{{\[}}%[[VAL_123]]] : memref<?xf64>
+// CHECK:                     scf.yield %[[VAL_121]], %[[VAL_141]], %[[VAL_142]], %[[VAL_5]], %[[VAL_6]] : index, index, index, i1, i1
 // CHECK:                   } else {
-// CHECK:                     memref.store %[[VAL_136]]#0, %[[VAL_90]]{{\[}}%[[VAL_122]]] : memref<?xi64>
-// CHECK:                     %[[VAL_144:.*]] = cmpf olt, %[[VAL_136]]#1, %[[VAL_137]]#1 : f64
-// CHECK:                     %[[VAL_145:.*]] = select %[[VAL_144]], %[[VAL_136]]#1, %[[VAL_137]]#1 : f64
-// CHECK:                     memref.store %[[VAL_145]], %[[VAL_91]]{{\[}}%[[VAL_122]]] : memref<?xf64>
-// CHECK:                     scf.yield %[[VAL_139]], %[[VAL_140]], %[[VAL_141]], %[[VAL_6]], %[[VAL_6]] : index, index, index, i1, i1
+// CHECK:                     memref.store %[[VAL_137]]#0, %[[VAL_91]]{{\[}}%[[VAL_123]]] : memref<?xi64>
+// CHECK:                     %[[VAL_145:.*]] = cmpf olt, %[[VAL_137]]#1, %[[VAL_138]]#1 : f64
+// CHECK:                     %[[VAL_146:.*]] = select %[[VAL_145]], %[[VAL_137]]#1, %[[VAL_138]]#1 : f64
+// CHECK:                     memref.store %[[VAL_146]], %[[VAL_92]]{{\[}}%[[VAL_123]]] : memref<?xf64>
+// CHECK:                     scf.yield %[[VAL_140]], %[[VAL_141]], %[[VAL_142]], %[[VAL_6]], %[[VAL_6]] : index, index, index, i1, i1
 // CHECK:                   }
-// CHECK:                   scf.yield %[[VAL_146:.*]]#0, %[[VAL_146]]#1, %[[VAL_146]]#2, %[[VAL_146]]#3, %[[VAL_146]]#4 : index, index, index, i1, i1
+// CHECK:                   scf.yield %[[VAL_147:.*]]#0, %[[VAL_147]]#1, %[[VAL_147]]#2, %[[VAL_147]]#3, %[[VAL_147]]#4 : index, index, index, i1, i1
 // CHECK:                 }
-// CHECK:                 scf.yield %[[VAL_147:.*]]#0, %[[VAL_147]]#1, %[[VAL_147]]#2, %[[VAL_136]]#0, %[[VAL_137]]#0, %[[VAL_136]]#1, %[[VAL_137]]#1, %[[VAL_147]]#3, %[[VAL_147]]#4 : index, index, index, i64, i64, f64, f64, i1, i1
+// CHECK:                 scf.yield %[[VAL_148:.*]]#0, %[[VAL_148]]#1, %[[VAL_148]]#2, %[[VAL_137]]#0, %[[VAL_138]]#0, %[[VAL_137]]#1, %[[VAL_138]]#1, %[[VAL_148]]#3, %[[VAL_148]]#4 : index, index, index, i64, i64, f64, f64, i1, i1
 // CHECK:               }
-// CHECK:               %[[VAL_148:.*]] = cmpi ult, %[[VAL_149:.*]]#0, %[[VAL_102]] : index
-// CHECK:               %[[VAL_150:.*]] = scf.if %[[VAL_148]] -> (index) {
-// CHECK:                 %[[VAL_151:.*]] = scf.for %[[VAL_152:.*]] = %[[VAL_149]]#0 to %[[VAL_102]] step %[[VAL_3]] iter_args(%[[VAL_153:.*]] = %[[VAL_149]]#2) -> (index) {
-// CHECK:                   %[[VAL_154:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_152]]] : memref<?xi64>
-// CHECK:                   %[[VAL_155:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_152]]] : memref<?xf64>
-// CHECK:                   memref.store %[[VAL_154]], %[[VAL_90]]{{\[}}%[[VAL_153]]] : memref<?xi64>
-// CHECK:                   memref.store %[[VAL_155]], %[[VAL_91]]{{\[}}%[[VAL_153]]] : memref<?xf64>
-// CHECK:                   %[[VAL_156:.*]] = addi %[[VAL_153]], %[[VAL_3]] : index
-// CHECK:                   scf.yield %[[VAL_156]] : index
+// CHECK:               %[[VAL_149:.*]] = cmpi ult, %[[VAL_150:.*]]#0, %[[VAL_103]] : index
+// CHECK:               %[[VAL_151:.*]] = scf.if %[[VAL_149]] -> (index) {
+// CHECK:                 %[[VAL_152:.*]] = scf.for %[[VAL_153:.*]] = %[[VAL_150]]#0 to %[[VAL_103]] step %[[VAL_3]] iter_args(%[[VAL_154:.*]] = %[[VAL_150]]#2) -> (index) {
+// CHECK:                   %[[VAL_155:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_153]]] : memref<?xi64>
+// CHECK:                   %[[VAL_156:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_153]]] : memref<?xf64>
+// CHECK:                   memref.store %[[VAL_155]], %[[VAL_91]]{{\[}}%[[VAL_154]]] : memref<?xi64>
+// CHECK:                   memref.store %[[VAL_156]], %[[VAL_92]]{{\[}}%[[VAL_154]]] : memref<?xf64>
+// CHECK:                   %[[VAL_157:.*]] = addi %[[VAL_154]], %[[VAL_3]] : index
+// CHECK:                   scf.yield %[[VAL_157]] : index
 // CHECK:                 }
-// CHECK:                 scf.yield %[[VAL_157:.*]] : index
+// CHECK:                 scf.yield %[[VAL_158:.*]] : index
 // CHECK:               } else {
-// CHECK:                 %[[VAL_158:.*]] = cmpi ult, %[[VAL_149]]#1, %[[VAL_106]] : index
-// CHECK:                 %[[VAL_159:.*]] = scf.if %[[VAL_158]] -> (index) {
-// CHECK:                   %[[VAL_160:.*]] = scf.for %[[VAL_161:.*]] = %[[VAL_149]]#1 to %[[VAL_106]] step %[[VAL_3]] iter_args(%[[VAL_162:.*]] = %[[VAL_149]]#2) -> (index) {
-// CHECK:                     %[[VAL_163:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_161]]] : memref<?xi64>
-// CHECK:                     %[[VAL_164:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_161]]] : memref<?xf64>
-// CHECK:                     memref.store %[[VAL_163]], %[[VAL_90]]{{\[}}%[[VAL_162]]] : memref<?xi64>
-// CHECK:                     memref.store %[[VAL_164]], %[[VAL_91]]{{\[}}%[[VAL_162]]] : memref<?xf64>
-// CHECK:                     %[[VAL_165:.*]] = addi %[[VAL_162]], %[[VAL_3]] : index
-// CHECK:                     scf.yield %[[VAL_165]] : index
+// CHECK:                 %[[VAL_159:.*]] = cmpi ult, %[[VAL_150]]#1, %[[VAL_107]] : index
+// CHECK:                 %[[VAL_160:.*]] = scf.if %[[VAL_159]] -> (index) {
+// CHECK:                   %[[VAL_161:.*]] = scf.for %[[VAL_162:.*]] = %[[VAL_150]]#1 to %[[VAL_107]] step %[[VAL_3]] iter_args(%[[VAL_163:.*]] = %[[VAL_150]]#2) -> (index) {
+// CHECK:                     %[[VAL_164:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_162]]] : memref<?xi64>
+// CHECK:                     %[[VAL_165:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_162]]] : memref<?xf64>
+// CHECK:                     memref.store %[[VAL_164]], %[[VAL_91]]{{\[}}%[[VAL_163]]] : memref<?xi64>
+// CHECK:                     memref.store %[[VAL_165]], %[[VAL_92]]{{\[}}%[[VAL_163]]] : memref<?xf64>
+// CHECK:                     %[[VAL_166:.*]] = addi %[[VAL_163]], %[[VAL_3]] : index
+// CHECK:                     scf.yield %[[VAL_166]] : index
 // CHECK:                   }
-// CHECK:                   scf.yield %[[VAL_166:.*]] : index
+// CHECK:                   scf.yield %[[VAL_167:.*]] : index
 // CHECK:                 } else {
-// CHECK:                   scf.yield %[[VAL_149]]#2 : index
+// CHECK:                   scf.yield %[[VAL_150]]#2 : index
 // CHECK:                 }
-// CHECK:                 scf.yield %[[VAL_167:.*]] : index
+// CHECK:                 scf.yield %[[VAL_168:.*]] : index
 // CHECK:               }
 // CHECK:             }
 // CHECK:             scf.yield
 // CHECK:           }
-// CHECK:           call @delSparseMatrix(%[[VAL_10]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> ()
+// CHECK:           %[[VAL_169:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_10]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @delSparseTensor(%[[VAL_169]]) : (!llvm.ptr<i8>) -> ()
 // CHECK:           return %[[VAL_2]] : index
 // CHECK:         }
 

--- a/mlir_graphblas/src/test/GraphBLAS/lower_matrix_vector_multiply_full.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_matrix_vector_multiply_full.mlir
@@ -14,12 +14,6 @@
 }>
 
 
-// CHECK-DAG:     func private @vector_resize_values(tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index)
-// CHECK-DAG:     func private @vector_resize_index(tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK-DAG:     func private @vector_resize_pointers(tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK-DAG:     func private @vector_resize_dim(tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK-DAG:     func private @vector_empty_like(tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-
 // CHECK-LABEL:   func @matrix_vector_multiply_plus_times(
 // CHECK-SAME:                                            %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                                            %[[VAL_1:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
@@ -33,124 +27,130 @@
 // CHECK-DAG:       %[[VAL_9:.*]] = constant 0.000000e+00 : f64
 // CHECK:           %[[VAL_10:.*]] = tensor.dim %[[VAL_0]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_11:.*]] = tensor.dim %[[VAL_1]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_12:.*]] = call @vector_empty_like(%[[VAL_1]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @vector_resize_dim(%[[VAL_12]], %[[VAL_5]], %[[VAL_10]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @vector_resize_pointers(%[[VAL_12]], %[[VAL_5]], %[[VAL_2]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           %[[VAL_13:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_14:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_15:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_16:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_17:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_18:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_19:.*]] = sparse_tensor.pointers %[[VAL_12]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_20:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_6]]] : memref<?xi64>
-// CHECK:           %[[VAL_21:.*]] = index_cast %[[VAL_20]] : i64 to index
-// CHECK:           %[[VAL_22:.*]] = cmpi eq, %[[VAL_5]], %[[VAL_21]] : index
-// CHECK:           %[[VAL_23:.*]] = scf.if %[[VAL_22]] -> (i64) {
+// CHECK:           %[[VAL_12:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_1]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_13:.*]] = call @empty_like(%[[VAL_12]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_14:.*]] = call @ptr8_to_vector_f64_p64i64(%[[VAL_13]]) : (!llvm.ptr<i8>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_15:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_14]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_dim(%[[VAL_15]], %[[VAL_5]], %[[VAL_10]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_16:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_14]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_pointers(%[[VAL_16]], %[[VAL_5]], %[[VAL_2]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_17:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_18:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_19:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_20:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_21:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_22:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_23:.*]] = sparse_tensor.pointers %[[VAL_14]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_24:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_6]]] : memref<?xi64>
+// CHECK:           %[[VAL_25:.*]] = index_cast %[[VAL_24]] : i64 to index
+// CHECK:           %[[VAL_26:.*]] = cmpi eq, %[[VAL_5]], %[[VAL_25]] : index
+// CHECK:           %[[VAL_27:.*]] = scf.if %[[VAL_26]] -> (i64) {
 // CHECK:             scf.yield %[[VAL_3]] : i64
 // CHECK:           } else {
-// CHECK:             %[[VAL_24:.*]] = memref.alloc(%[[VAL_11]]) : memref<?xi1>
-// CHECK:             linalg.fill(%[[VAL_8]], %[[VAL_24]]) : i1, memref<?xi1>
-// CHECK:             scf.parallel (%[[VAL_25:.*]]) = (%[[VAL_5]]) to (%[[VAL_21]]) step (%[[VAL_6]]) {
-// CHECK:               %[[VAL_26:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_25]]] : memref<?xi64>
-// CHECK:               %[[VAL_27:.*]] = index_cast %[[VAL_26]] : i64 to index
-// CHECK:               memref.store %[[VAL_7]], %[[VAL_24]]{{\[}}%[[VAL_27]]] : memref<?xi1>
+// CHECK:             %[[VAL_28:.*]] = memref.alloc(%[[VAL_11]]) : memref<?xi1>
+// CHECK:             linalg.fill(%[[VAL_8]], %[[VAL_28]]) : i1, memref<?xi1>
+// CHECK:             scf.parallel (%[[VAL_29:.*]]) = (%[[VAL_5]]) to (%[[VAL_25]]) step (%[[VAL_6]]) {
+// CHECK:               %[[VAL_30:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_29]]] : memref<?xi64>
+// CHECK:               %[[VAL_31:.*]] = index_cast %[[VAL_30]] : i64 to index
+// CHECK:               memref.store %[[VAL_7]], %[[VAL_28]]{{\[}}%[[VAL_31]]] : memref<?xi1>
 // CHECK:               scf.yield
 // CHECK:             }
-// CHECK:             %[[VAL_28:.*]] = scf.parallel (%[[VAL_29:.*]]) = (%[[VAL_5]]) to (%[[VAL_10]]) step (%[[VAL_6]]) init (%[[VAL_3]]) -> i64 {
-// CHECK:               %[[VAL_30:.*]] = addi %[[VAL_29]], %[[VAL_6]] : index
-// CHECK:               %[[VAL_31:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_29]]] : memref<?xi64>
-// CHECK:               %[[VAL_32:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_30]]] : memref<?xi64>
-// CHECK:               %[[VAL_33:.*]] = cmpi eq, %[[VAL_31]], %[[VAL_32]] : i64
-// CHECK:               %[[VAL_34:.*]] = scf.if %[[VAL_33]] -> (i64) {
+// CHECK:             %[[VAL_32:.*]] = scf.parallel (%[[VAL_33:.*]]) = (%[[VAL_5]]) to (%[[VAL_10]]) step (%[[VAL_6]]) init (%[[VAL_3]]) -> i64 {
+// CHECK:               %[[VAL_34:.*]] = addi %[[VAL_33]], %[[VAL_6]] : index
+// CHECK:               %[[VAL_35:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_33]]] : memref<?xi64>
+// CHECK:               %[[VAL_36:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_34]]] : memref<?xi64>
+// CHECK:               %[[VAL_37:.*]] = cmpi eq, %[[VAL_35]], %[[VAL_36]] : i64
+// CHECK:               %[[VAL_38:.*]] = scf.if %[[VAL_37]] -> (i64) {
 // CHECK:                 scf.yield %[[VAL_3]] : i64
 // CHECK:               } else {
-// CHECK:                 %[[VAL_35:.*]] = scf.while (%[[VAL_36:.*]] = %[[VAL_31]]) : (i64) -> i64 {
-// CHECK:                   %[[VAL_37:.*]] = cmpi uge, %[[VAL_36]], %[[VAL_32]] : i64
-// CHECK:                   %[[VAL_38:.*]]:2 = scf.if %[[VAL_37]] -> (i1, i64) {
+// CHECK:                 %[[VAL_39:.*]] = scf.while (%[[VAL_40:.*]] = %[[VAL_35]]) : (i64) -> i64 {
+// CHECK:                   %[[VAL_41:.*]] = cmpi uge, %[[VAL_40]], %[[VAL_36]] : i64
+// CHECK:                   %[[VAL_42:.*]]:2 = scf.if %[[VAL_41]] -> (i1, i64) {
 // CHECK:                     scf.yield %[[VAL_8]], %[[VAL_3]] : i1, i64
 // CHECK:                   } else {
-// CHECK:                     %[[VAL_39:.*]] = index_cast %[[VAL_36]] : i64 to index
-// CHECK:                     %[[VAL_40:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_39]]] : memref<?xi64>
-// CHECK:                     %[[VAL_41:.*]] = index_cast %[[VAL_40]] : i64 to index
-// CHECK:                     %[[VAL_42:.*]] = memref.load %[[VAL_24]]{{\[}}%[[VAL_41]]] : memref<?xi1>
-// CHECK:                     %[[VAL_43:.*]] = select %[[VAL_42]], %[[VAL_8]], %[[VAL_7]] : i1
-// CHECK:                     %[[VAL_44:.*]] = select %[[VAL_42]], %[[VAL_4]], %[[VAL_36]] : i64
-// CHECK:                     scf.yield %[[VAL_43]], %[[VAL_44]] : i1, i64
+// CHECK:                     %[[VAL_43:.*]] = index_cast %[[VAL_40]] : i64 to index
+// CHECK:                     %[[VAL_44:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_43]]] : memref<?xi64>
+// CHECK:                     %[[VAL_45:.*]] = index_cast %[[VAL_44]] : i64 to index
+// CHECK:                     %[[VAL_46:.*]] = memref.load %[[VAL_28]]{{\[}}%[[VAL_45]]] : memref<?xi1>
+// CHECK:                     %[[VAL_47:.*]] = select %[[VAL_46]], %[[VAL_8]], %[[VAL_7]] : i1
+// CHECK:                     %[[VAL_48:.*]] = select %[[VAL_46]], %[[VAL_4]], %[[VAL_40]] : i64
+// CHECK:                     scf.yield %[[VAL_47]], %[[VAL_48]] : i1, i64
 // CHECK:                   }
-// CHECK:                   scf.condition(%[[VAL_45:.*]]#0) %[[VAL_45]]#1 : i64
+// CHECK:                   scf.condition(%[[VAL_49:.*]]#0) %[[VAL_49]]#1 : i64
 // CHECK:                 } do {
-// CHECK:                 ^bb0(%[[VAL_46:.*]]: i64):
-// CHECK:                   %[[VAL_47:.*]] = addi %[[VAL_46]], %[[VAL_4]] : i64
-// CHECK:                   scf.yield %[[VAL_47]] : i64
+// CHECK:                 ^bb0(%[[VAL_50:.*]]: i64):
+// CHECK:                   %[[VAL_51:.*]] = addi %[[VAL_50]], %[[VAL_4]] : i64
+// CHECK:                   scf.yield %[[VAL_51]] : i64
 // CHECK:                 }
-// CHECK:                 scf.yield %[[VAL_48:.*]] : i64
+// CHECK:                 scf.yield %[[VAL_52:.*]] : i64
 // CHECK:               }
-// CHECK:               scf.reduce(%[[VAL_49:.*]])  : i64 {
-// CHECK:               ^bb0(%[[VAL_50:.*]]: i64, %[[VAL_51:.*]]: i64):
-// CHECK:                 %[[VAL_52:.*]] = addi %[[VAL_50]], %[[VAL_51]] : i64
-// CHECK:                 scf.reduce.return %[[VAL_52]] : i64
+// CHECK:               scf.reduce(%[[VAL_53:.*]])  : i64 {
+// CHECK:               ^bb0(%[[VAL_54:.*]]: i64, %[[VAL_55:.*]]: i64):
+// CHECK:                 %[[VAL_56:.*]] = addi %[[VAL_54]], %[[VAL_55]] : i64
+// CHECK:                 scf.reduce.return %[[VAL_56]] : i64
 // CHECK:               }
 // CHECK:               scf.yield
 // CHECK:             }
-// CHECK:             memref.dealloc %[[VAL_24]] : memref<?xi1>
-// CHECK:             scf.yield %[[VAL_28]] : i64
+// CHECK:             memref.dealloc %[[VAL_28]] : memref<?xi1>
+// CHECK:             scf.yield %[[VAL_57:.*]] : i64
 // CHECK:           }
-// CHECK:           %[[VAL_54:.*]] = index_cast %[[VAL_23]] : i64 to index
-// CHECK:           memref.store %[[VAL_23]], %[[VAL_19]]{{\[}}%[[VAL_6]]] : memref<?xi64>
-// CHECK:           call @vector_resize_index(%[[VAL_12]], %[[VAL_5]], %[[VAL_54]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @vector_resize_values(%[[VAL_12]], %[[VAL_54]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
-// CHECK:           %[[VAL_56:.*]] = sparse_tensor.indices %[[VAL_12]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_57:.*]] = sparse_tensor.values %[[VAL_12]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_58:.*]] = cmpi ne, %[[VAL_5]], %[[VAL_54]] : index
-// CHECK:           scf.if %[[VAL_58]] {
-// CHECK:             %[[VAL_59:.*]] = memref.alloc(%[[VAL_11]]) : memref<?xf64>
-// CHECK:             %[[VAL_60:.*]] = memref.alloc(%[[VAL_11]]) : memref<?xi1>
-// CHECK:             linalg.fill(%[[VAL_8]], %[[VAL_60]]) : i1, memref<?xi1>
-// CHECK:             scf.parallel (%[[VAL_61:.*]]) = (%[[VAL_5]]) to (%[[VAL_21]]) step (%[[VAL_6]]) {
-// CHECK:               %[[VAL_62:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_61]]] : memref<?xi64>
-// CHECK:               %[[VAL_63:.*]] = index_cast %[[VAL_62]] : i64 to index
-// CHECK:               memref.store %[[VAL_7]], %[[VAL_60]]{{\[}}%[[VAL_63]]] : memref<?xi1>
-// CHECK:               %[[VAL_64:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_61]]] : memref<?xf64>
-// CHECK:               memref.store %[[VAL_64]], %[[VAL_59]]{{\[}}%[[VAL_63]]] : memref<?xf64>
+// CHECK:           %[[VAL_58:.*]] = index_cast %[[VAL_59:.*]] : i64 to index
+// CHECK:           memref.store %[[VAL_59]], %[[VAL_23]]{{\[}}%[[VAL_6]]] : memref<?xi64>
+// CHECK:           %[[VAL_60:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_14]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_index(%[[VAL_60]], %[[VAL_5]], %[[VAL_58]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_61:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_14]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_values(%[[VAL_61]], %[[VAL_58]]) : (!llvm.ptr<i8>, index) -> ()
+// CHECK:           %[[VAL_62:.*]] = sparse_tensor.indices %[[VAL_14]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_63:.*]] = sparse_tensor.values %[[VAL_14]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_64:.*]] = cmpi ne, %[[VAL_5]], %[[VAL_58]] : index
+// CHECK:           scf.if %[[VAL_64]] {
+// CHECK:             %[[VAL_65:.*]] = memref.alloc(%[[VAL_11]]) : memref<?xf64>
+// CHECK:             %[[VAL_66:.*]] = memref.alloc(%[[VAL_11]]) : memref<?xi1>
+// CHECK:             linalg.fill(%[[VAL_8]], %[[VAL_66]]) : i1, memref<?xi1>
+// CHECK:             scf.parallel (%[[VAL_67:.*]]) = (%[[VAL_5]]) to (%[[VAL_25]]) step (%[[VAL_6]]) {
+// CHECK:               %[[VAL_68:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_67]]] : memref<?xi64>
+// CHECK:               %[[VAL_69:.*]] = index_cast %[[VAL_68]] : i64 to index
+// CHECK:               memref.store %[[VAL_7]], %[[VAL_66]]{{\[}}%[[VAL_69]]] : memref<?xi1>
+// CHECK:               %[[VAL_70:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_67]]] : memref<?xf64>
+// CHECK:               memref.store %[[VAL_70]], %[[VAL_65]]{{\[}}%[[VAL_69]]] : memref<?xf64>
 // CHECK:               scf.yield
 // CHECK:             }
-// CHECK:             %[[VAL_65:.*]] = scf.for %[[VAL_66:.*]] = %[[VAL_5]] to %[[VAL_10]] step %[[VAL_6]] iter_args(%[[VAL_67:.*]] = %[[VAL_5]]) -> (index) {
-// CHECK:               %[[VAL_68:.*]] = index_cast %[[VAL_66]] : index to i64
-// CHECK:               %[[VAL_69:.*]] = addi %[[VAL_66]], %[[VAL_6]] : index
-// CHECK:               %[[VAL_70:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_66]]] : memref<?xi64>
-// CHECK:               %[[VAL_71:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_69]]] : memref<?xi64>
-// CHECK:               %[[VAL_72:.*]] = index_cast %[[VAL_70]] : i64 to index
-// CHECK:               %[[VAL_73:.*]] = index_cast %[[VAL_71]] : i64 to index
-// CHECK:               %[[VAL_74:.*]]:2 = scf.for %[[VAL_75:.*]] = %[[VAL_72]] to %[[VAL_73]] step %[[VAL_6]] iter_args(%[[VAL_76:.*]] = %[[VAL_9]], %[[VAL_77:.*]] = %[[VAL_8]]) -> (f64, i1) {
-// CHECK:                 %[[VAL_78:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_75]]] : memref<?xi64>
-// CHECK:                 %[[VAL_79:.*]] = index_cast %[[VAL_78]] : i64 to index
-// CHECK:                 %[[VAL_80:.*]] = memref.load %[[VAL_60]]{{\[}}%[[VAL_79]]] : memref<?xi1>
-// CHECK:                 %[[VAL_81:.*]]:2 = scf.if %[[VAL_80]] -> (f64, i1) {
-// CHECK:                   %[[VAL_82:.*]] = memref.load %[[VAL_59]]{{\[}}%[[VAL_79]]] : memref<?xf64>
-// CHECK:                   %[[VAL_83:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_75]]] : memref<?xf64>
-// CHECK:                   %[[VAL_84:.*]] = mulf %[[VAL_83]], %[[VAL_82]] : f64
-// CHECK:                   %[[VAL_85:.*]] = addf %[[VAL_76]], %[[VAL_84]] : f64
-// CHECK:                   scf.yield %[[VAL_85]], %[[VAL_7]] : f64, i1
+// CHECK:             %[[VAL_71:.*]] = scf.for %[[VAL_72:.*]] = %[[VAL_5]] to %[[VAL_10]] step %[[VAL_6]] iter_args(%[[VAL_73:.*]] = %[[VAL_5]]) -> (index) {
+// CHECK:               %[[VAL_74:.*]] = index_cast %[[VAL_72]] : index to i64
+// CHECK:               %[[VAL_75:.*]] = addi %[[VAL_72]], %[[VAL_6]] : index
+// CHECK:               %[[VAL_76:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_72]]] : memref<?xi64>
+// CHECK:               %[[VAL_77:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_75]]] : memref<?xi64>
+// CHECK:               %[[VAL_78:.*]] = index_cast %[[VAL_76]] : i64 to index
+// CHECK:               %[[VAL_79:.*]] = index_cast %[[VAL_77]] : i64 to index
+// CHECK:               %[[VAL_80:.*]]:2 = scf.for %[[VAL_81:.*]] = %[[VAL_78]] to %[[VAL_79]] step %[[VAL_6]] iter_args(%[[VAL_82:.*]] = %[[VAL_9]], %[[VAL_83:.*]] = %[[VAL_8]]) -> (f64, i1) {
+// CHECK:                 %[[VAL_84:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_81]]] : memref<?xi64>
+// CHECK:                 %[[VAL_85:.*]] = index_cast %[[VAL_84]] : i64 to index
+// CHECK:                 %[[VAL_86:.*]] = memref.load %[[VAL_66]]{{\[}}%[[VAL_85]]] : memref<?xi1>
+// CHECK:                 %[[VAL_87:.*]]:2 = scf.if %[[VAL_86]] -> (f64, i1) {
+// CHECK:                   %[[VAL_88:.*]] = memref.load %[[VAL_65]]{{\[}}%[[VAL_85]]] : memref<?xf64>
+// CHECK:                   %[[VAL_89:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_81]]] : memref<?xf64>
+// CHECK:                   %[[VAL_90:.*]] = mulf %[[VAL_89]], %[[VAL_88]] : f64
+// CHECK:                   %[[VAL_91:.*]] = addf %[[VAL_82]], %[[VAL_90]] : f64
+// CHECK:                   scf.yield %[[VAL_91]], %[[VAL_7]] : f64, i1
 // CHECK:                 } else {
-// CHECK:                   scf.yield %[[VAL_76]], %[[VAL_77]] : f64, i1
+// CHECK:                   scf.yield %[[VAL_82]], %[[VAL_83]] : f64, i1
 // CHECK:                 }
-// CHECK:                 scf.yield %[[VAL_86:.*]]#0, %[[VAL_86]]#1 : f64, i1
+// CHECK:                 scf.yield %[[VAL_92:.*]]#0, %[[VAL_92]]#1 : f64, i1
 // CHECK:               }
-// CHECK:               %[[VAL_87:.*]] = scf.if %[[VAL_88:.*]]#1 -> (index) {
-// CHECK:                 memref.store %[[VAL_68]], %[[VAL_56]]{{\[}}%[[VAL_67]]] : memref<?xi64>
-// CHECK:                 memref.store %[[VAL_88]]#0, %[[VAL_57]]{{\[}}%[[VAL_67]]] : memref<?xf64>
-// CHECK:                 %[[VAL_89:.*]] = addi %[[VAL_67]], %[[VAL_6]] : index
-// CHECK:                 scf.yield %[[VAL_89]] : index
+// CHECK:               %[[VAL_93:.*]] = scf.if %[[VAL_94:.*]]#1 -> (index) {
+// CHECK:                 memref.store %[[VAL_74]], %[[VAL_62]]{{\[}}%[[VAL_73]]] : memref<?xi64>
+// CHECK:                 memref.store %[[VAL_94]]#0, %[[VAL_63]]{{\[}}%[[VAL_73]]] : memref<?xf64>
+// CHECK:                 %[[VAL_95:.*]] = addi %[[VAL_73]], %[[VAL_6]] : index
+// CHECK:                 scf.yield %[[VAL_95]] : index
 // CHECK:               } else {
-// CHECK:                 scf.yield %[[VAL_67]] : index
+// CHECK:                 scf.yield %[[VAL_73]] : index
 // CHECK:               }
-// CHECK:               scf.yield %[[VAL_90:.*]] : index
+// CHECK:               scf.yield %[[VAL_96:.*]] : index
 // CHECK:             }
-// CHECK:             memref.dealloc %[[VAL_59]] : memref<?xf64>
-// CHECK:             memref.dealloc %[[VAL_60]] : memref<?xi1>
+// CHECK:             memref.dealloc %[[VAL_65]] : memref<?xf64>
+// CHECK:             memref.dealloc %[[VAL_66]] : memref<?xi1>
 // CHECK:           }
-// CHECK:           return %[[VAL_12]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           return %[[VAL_14]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
 
 

--- a/mlir_graphblas/src/test/GraphBLAS/lower_random_select.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_random_select.mlir
@@ -12,19 +12,19 @@
 func private @uniform_choose_n(!llvm.ptr<i8>, i64, i64, memref<?xi64, #map>, memref<?xf64, #map>)
 
 // CHECK-LABEL:   func @select_random_uniform(
-// CHECK-SAME:                                        %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
-// CHECK-SAME:                                        %[[VAL_1:.*]]: i64,
-// CHECK-SAME:                                        %[[VAL_2:.*]]: !llvm.ptr<i8>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:           %[[VAL_3:.*]] = constant 0 : i64
-// CHECK:           %[[VAL_4:.*]] = constant 1 : index
-// CHECK:           %[[VAL_5:.*]] = constant 0 : index
+// CHECK-SAME:                                %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
+// CHECK-SAME:                                %[[VAL_1:.*]]: i64,
+// CHECK-SAME:                                %[[VAL_2:.*]]: !llvm.ptr<i8>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK-DAG:       %[[VAL_3:.*]] = constant 0 : i64
+// CHECK-DAG:       %[[VAL_4:.*]] = constant 1 : index
+// CHECK-DAG:       %[[VAL_5:.*]] = constant 0 : index
 // CHECK:           %[[VAL_6:.*]] = tensor.dim %[[VAL_0]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_7:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_8:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_9:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_10:.*]] = call @cast_csr_to_csx(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_11:.*]] = call @dup_matrix(%[[VAL_10]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_12:.*]] = call @cast_csx_to_csr(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_10:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_11:.*]] = call @dup_tensor(%[[VAL_10]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_12:.*]] = call @ptr8_to_matrix_csr_f64_p64i64(%[[VAL_11]]) : (!llvm.ptr<i8>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_13:.*]] = sparse_tensor.pointers %[[VAL_12]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_14:.*]] = sparse_tensor.indices %[[VAL_12]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_15:.*]] = sparse_tensor.values %[[VAL_12]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>

--- a/mlir_graphblas/src/test/GraphBLAS/lower_select_gt.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_select_gt.mlir
@@ -7,26 +7,20 @@
   indexBitWidth = 64
 }>
 
-// CHECK-LABEL:   func private @cast_csx_to_csr(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:         func private @dup_matrix(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:         func private @matrix_resize_values(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index)
-// CHECK:         func private @matrix_resize_index(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK:         func private @cast_csr_to_csx(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-
 // CHECK-LABEL:   func @select_gt(
-// CHECK-SAME:                             %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:           %[[VAL_1:.*]] = constant 0.000000e+00 : f64
-// CHECK:           %[[VAL_2:.*]] = constant 0 : i64
-// CHECK:           %[[VAL_3:.*]] = constant 1 : i64
-// CHECK:           %[[VAL_4:.*]] = constant 1 : index
-// CHECK:           %[[VAL_5:.*]] = constant 0 : index
+// CHECK-SAME:                    %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK-DAG:       %[[VAL_1:.*]] = constant 0.000000e+00 : f64
+// CHECK-DAG:       %[[VAL_2:.*]] = constant 0 : i64
+// CHECK-DAG:       %[[VAL_3:.*]] = constant 1 : i64
+// CHECK-DAG:       %[[VAL_4:.*]] = constant 1 : index
+// CHECK-DAG:       %[[VAL_5:.*]] = constant 0 : index
 // CHECK:           %[[VAL_6:.*]] = tensor.dim %[[VAL_0]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_7:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_8:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_9:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_10:.*]] = call @cast_csr_to_csx(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_11:.*]] = call @dup_matrix(%[[VAL_10]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_12:.*]] = call @cast_csx_to_csr(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_10:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_11:.*]] = call @dup_tensor(%[[VAL_10]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_12:.*]] = call @ptr8_to_matrix_csr_f64_p64i64(%[[VAL_11]]) : (!llvm.ptr<i8>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_13:.*]] = sparse_tensor.pointers %[[VAL_12]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_14:.*]] = sparse_tensor.indices %[[VAL_12]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_15:.*]] = sparse_tensor.values %[[VAL_12]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
@@ -57,10 +51,10 @@
 // CHECK:           %[[VAL_31:.*]] = tensor.dim %[[VAL_12]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_32:.*]] = memref.load %[[VAL_30]]{{\[}}%[[VAL_31]]] : memref<?xi64>
 // CHECK:           %[[VAL_33:.*]] = index_cast %[[VAL_32]] : i64 to index
-// CHECK:           %[[VAL_34:.*]] = call @cast_csr_to_csx(%[[VAL_12]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @matrix_resize_index(%[[VAL_34]], %[[VAL_4]], %[[VAL_33]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           %[[VAL_35:.*]] = call @cast_csr_to_csx(%[[VAL_12]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @matrix_resize_values(%[[VAL_35]], %[[VAL_33]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
+// CHECK:           %[[VAL_34:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_12]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_index(%[[VAL_34]], %[[VAL_4]], %[[VAL_33]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_35:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_12]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_values(%[[VAL_35]], %[[VAL_33]]) : (!llvm.ptr<i8>, index) -> ()
 // CHECK:           return %[[VAL_12]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
 

--- a/mlir_graphblas/src/test/GraphBLAS/lower_select_tril.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_select_tril.mlir
@@ -7,38 +7,32 @@
   indexBitWidth = 64
 }>
 
-// CHECK--DAG:    func private @matrix_resize_values(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index)
-// CHECK--DAG:    func private @matrix_resize_index(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK--DAG:    func private @cast_csx_to_csr(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK--DAG:    func private @dup_matrix(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK--DAG:    func private @cast_csr_to_csx(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-
 // CHECK-LABEL:   func @select_tril(
 // CHECK-SAME:                      %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK-DAG:       %[[VAL_1:.*]] = constant 0 : index
-// CHECK-DAG:       %[[VAL_2:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 0 : i64
-// CHECK-DAG:       %[[VAL_4:.*]] = constant 1 : i64
-// CHECK:           %[[VAL_5:.*]] = tensor.dim %[[VAL_0]], %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_6:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_7:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK-DAG:       %[[VAL_1:.*]] = constant 0 : i64
+// CHECK-DAG:       %[[VAL_2:.*]] = constant 1 : i64
+// CHECK-DAG:       %[[VAL_3:.*]] = constant 1 : index
+// CHECK-DAG:       %[[VAL_4:.*]] = constant 0 : index
+// CHECK:           %[[VAL_5:.*]] = tensor.dim %[[VAL_0]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_6:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_7:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_8:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_9:.*]] = call @cast_csr_to_csx(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_10:.*]] = call @dup_matrix(%[[VAL_9]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_11:.*]] = call @cast_csx_to_csr(%[[VAL_10]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_12:.*]] = sparse_tensor.pointers %[[VAL_11]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_13:.*]] = sparse_tensor.indices %[[VAL_11]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_9:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_10:.*]] = call @dup_tensor(%[[VAL_9]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_11:.*]] = call @ptr8_to_matrix_csr_f64_p64i64(%[[VAL_10]]) : (!llvm.ptr<i8>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_12:.*]] = sparse_tensor.pointers %[[VAL_11]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_13:.*]] = sparse_tensor.indices %[[VAL_11]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_14:.*]] = sparse_tensor.values %[[VAL_11]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           memref.store %[[VAL_3]], %[[VAL_12]]{{\[}}%[[VAL_1]]] : memref<?xi64>
-// CHECK:           scf.for %[[VAL_15:.*]] = %[[VAL_1]] to %[[VAL_5]] step %[[VAL_2]] {
-// CHECK:             %[[VAL_16:.*]] = addi %[[VAL_15]], %[[VAL_2]] : index
+// CHECK:           memref.store %[[VAL_1]], %[[VAL_12]]{{\[}}%[[VAL_4]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_15:.*]] = %[[VAL_4]] to %[[VAL_5]] step %[[VAL_3]] {
+// CHECK:             %[[VAL_16:.*]] = addi %[[VAL_15]], %[[VAL_3]] : index
 // CHECK:             %[[VAL_17:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_15]]] : memref<?xi64>
 // CHECK:             memref.store %[[VAL_17]], %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:             %[[VAL_18:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_15]]] : memref<?xi64>
 // CHECK:             %[[VAL_19:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:             %[[VAL_20:.*]] = index_cast %[[VAL_18]] : i64 to index
 // CHECK:             %[[VAL_21:.*]] = index_cast %[[VAL_19]] : i64 to index
-// CHECK:             scf.for %[[VAL_22:.*]] = %[[VAL_20]] to %[[VAL_21]] step %[[VAL_2]] {
+// CHECK:             scf.for %[[VAL_22:.*]] = %[[VAL_20]] to %[[VAL_21]] step %[[VAL_3]] {
 // CHECK:               %[[VAL_23:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_22]]] : memref<?xi64>
 // CHECK:               %[[VAL_24:.*]] = index_cast %[[VAL_23]] : i64 to index
 // CHECK:               %[[VAL_25:.*]] = memref.load %[[VAL_8]]{{\[}}%[[VAL_22]]] : memref<?xf64>
@@ -48,19 +42,19 @@
 // CHECK:                 %[[VAL_28:.*]] = index_cast %[[VAL_27]] : i64 to index
 // CHECK:                 memref.store %[[VAL_23]], %[[VAL_13]]{{\[}}%[[VAL_28]]] : memref<?xi64>
 // CHECK:                 memref.store %[[VAL_25]], %[[VAL_14]]{{\[}}%[[VAL_28]]] : memref<?xf64>
-// CHECK:                 %[[VAL_29:.*]] = addi %[[VAL_27]], %[[VAL_4]] : i64
+// CHECK:                 %[[VAL_29:.*]] = addi %[[VAL_27]], %[[VAL_2]] : i64
 // CHECK:                 memref.store %[[VAL_29]], %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:               }
 // CHECK:             }
 // CHECK:           }
-// CHECK:           %[[VAL_100:.*]] = sparse_tensor.pointers %[[VAL_11]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_101:.*]] = tensor.dim %[[VAL_11]], %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_30:.*]] = memref.load %[[VAL_100]]{{\[}}%[[VAL_101]]] : memref<?xi64>
-// CHECK:           %[[VAL_31:.*]] = index_cast %[[VAL_30]] : i64 to index
-// CHECK:           %[[VAL_32:.*]] = call @cast_csr_to_csx(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @matrix_resize_index(%[[VAL_32]], %[[VAL_2]], %[[VAL_31]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           %[[VAL_33:.*]] = call @cast_csr_to_csx(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @matrix_resize_values(%[[VAL_33]], %[[VAL_31]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
+// CHECK:           %[[VAL_30:.*]] = sparse_tensor.pointers %[[VAL_11]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_31:.*]] = tensor.dim %[[VAL_11]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_32:.*]] = memref.load %[[VAL_30]]{{\[}}%[[VAL_31]]] : memref<?xi64>
+// CHECK:           %[[VAL_33:.*]] = index_cast %[[VAL_32]] : i64 to index
+// CHECK:           %[[VAL_34:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_index(%[[VAL_34]], %[[VAL_3]], %[[VAL_33]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_35:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_values(%[[VAL_35]], %[[VAL_33]]) : (!llvm.ptr<i8>, index) -> ()
 // CHECK:           return %[[VAL_11]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
 

--- a/mlir_graphblas/src/test/GraphBLAS/lower_select_triu.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_select_triu.mlir
@@ -7,38 +7,32 @@
   indexBitWidth = 64
 }>
 
-// CHECK-DAG:     func private @matrix_resize_values(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index)
-// CHECK-DAG:     func private @matrix_resize_index(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK-DAG:     func private @cast_csx_to_csr(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK-DAG:     func private @dup_matrix(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK-DAG:     func private @cast_csr_to_csx(tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-
 // CHECK-LABEL:   func @select_triu(
 // CHECK-SAME:                      %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK-DAG:       %[[VAL_1:.*]] = constant 0 : index
-// CHECK-DAG:       %[[VAL_2:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 0 : i64
-// CHECK-DAG:       %[[VAL_4:.*]] = constant 1 : i64
-// CHECK:           %[[VAL_5:.*]] = tensor.dim %[[VAL_0]], %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_6:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_7:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK-DAG:       %[[VAL_1:.*]] = constant 0 : i64
+// CHECK-DAG:       %[[VAL_2:.*]] = constant 1 : i64
+// CHECK-DAG:       %[[VAL_3:.*]] = constant 1 : index
+// CHECK-DAG:       %[[VAL_4:.*]] = constant 0 : index
+// CHECK:           %[[VAL_5:.*]] = tensor.dim %[[VAL_0]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_6:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_7:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_8:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_9:.*]] = call @cast_csr_to_csx(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_10:.*]] = call @dup_matrix(%[[VAL_9]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_11:.*]] = call @cast_csx_to_csr(%[[VAL_10]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_12:.*]] = sparse_tensor.pointers %[[VAL_11]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_13:.*]] = sparse_tensor.indices %[[VAL_11]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_9:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_10:.*]] = call @dup_tensor(%[[VAL_9]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_11:.*]] = call @ptr8_to_matrix_csr_f64_p64i64(%[[VAL_10]]) : (!llvm.ptr<i8>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_12:.*]] = sparse_tensor.pointers %[[VAL_11]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_13:.*]] = sparse_tensor.indices %[[VAL_11]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_14:.*]] = sparse_tensor.values %[[VAL_11]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           memref.store %[[VAL_3]], %[[VAL_12]]{{\[}}%[[VAL_1]]] : memref<?xi64>
-// CHECK:           scf.for %[[VAL_15:.*]] = %[[VAL_1]] to %[[VAL_5]] step %[[VAL_2]] {
-// CHECK:             %[[VAL_16:.*]] = addi %[[VAL_15]], %[[VAL_2]] : index
+// CHECK:           memref.store %[[VAL_1]], %[[VAL_12]]{{\[}}%[[VAL_4]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_15:.*]] = %[[VAL_4]] to %[[VAL_5]] step %[[VAL_3]] {
+// CHECK:             %[[VAL_16:.*]] = addi %[[VAL_15]], %[[VAL_3]] : index
 // CHECK:             %[[VAL_17:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_15]]] : memref<?xi64>
 // CHECK:             memref.store %[[VAL_17]], %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:             %[[VAL_18:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_15]]] : memref<?xi64>
 // CHECK:             %[[VAL_19:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:             %[[VAL_20:.*]] = index_cast %[[VAL_18]] : i64 to index
 // CHECK:             %[[VAL_21:.*]] = index_cast %[[VAL_19]] : i64 to index
-// CHECK:             scf.for %[[VAL_22:.*]] = %[[VAL_20]] to %[[VAL_21]] step %[[VAL_2]] {
+// CHECK:             scf.for %[[VAL_22:.*]] = %[[VAL_20]] to %[[VAL_21]] step %[[VAL_3]] {
 // CHECK:               %[[VAL_23:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_22]]] : memref<?xi64>
 // CHECK:               %[[VAL_24:.*]] = index_cast %[[VAL_23]] : i64 to index
 // CHECK:               %[[VAL_25:.*]] = memref.load %[[VAL_8]]{{\[}}%[[VAL_22]]] : memref<?xf64>
@@ -48,19 +42,19 @@
 // CHECK:                 %[[VAL_28:.*]] = index_cast %[[VAL_27]] : i64 to index
 // CHECK:                 memref.store %[[VAL_23]], %[[VAL_13]]{{\[}}%[[VAL_28]]] : memref<?xi64>
 // CHECK:                 memref.store %[[VAL_25]], %[[VAL_14]]{{\[}}%[[VAL_28]]] : memref<?xf64>
-// CHECK:                 %[[VAL_29:.*]] = addi %[[VAL_27]], %[[VAL_4]] : i64
+// CHECK:                 %[[VAL_29:.*]] = addi %[[VAL_27]], %[[VAL_2]] : i64
 // CHECK:                 memref.store %[[VAL_29]], %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:               }
 // CHECK:             }
 // CHECK:           }
-// CHECK:           %[[VAL_100:.*]] = sparse_tensor.pointers %[[VAL_11]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_101:.*]] = tensor.dim %[[VAL_11]], %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_30:.*]] = memref.load %[[VAL_100]]{{\[}}%[[VAL_101]]] : memref<?xi64>
-// CHECK:           %[[VAL_31:.*]] = index_cast %[[VAL_30]] : i64 to index
-// CHECK:           %[[VAL_32:.*]] = call @cast_csr_to_csx(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @matrix_resize_index(%[[VAL_32]], %[[VAL_2]], %[[VAL_31]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           %[[VAL_33:.*]] = call @cast_csr_to_csx(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @matrix_resize_values(%[[VAL_33]], %[[VAL_31]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
+// CHECK:           %[[VAL_30:.*]] = sparse_tensor.pointers %[[VAL_11]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_31:.*]] = tensor.dim %[[VAL_11]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_32:.*]] = memref.load %[[VAL_30]]{{\[}}%[[VAL_31]]] : memref<?xi64>
+// CHECK:           %[[VAL_33:.*]] = index_cast %[[VAL_32]] : i64 to index
+// CHECK:           %[[VAL_34:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_index(%[[VAL_34]], %[[VAL_3]], %[[VAL_33]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_35:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_values(%[[VAL_35]], %[[VAL_33]]) : (!llvm.ptr<i8>, index) -> ()
 // CHECK:           return %[[VAL_11]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
 

--- a/mlir_graphblas/src/test/GraphBLAS/lower_transpose.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_transpose.mlir
@@ -17,21 +17,23 @@
 module {
 // CHECK-LABEL:   func @transpose_different_compression(
 // CHECK-SAME:                                          %[[VAL_0:.*]]: tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:           %[[VAL_1:.*]] = constant 0 : index
-// CHECK:           %[[VAL_2:.*]] = constant 1 : index
-// CHECK:           %[[VAL_3:.*]] = call @cast_csr_to_csx(%[[VAL_0]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_4:.*]] = call @dup_matrix(%[[VAL_3]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_5:.*]] = call @cast_csx_to_csc(%[[VAL_4]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_6:.*]] = tensor.dim %[[VAL_0]], %[[VAL_1]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_7:.*]] = tensor.dim %[[VAL_0]], %[[VAL_2]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_8:.*]] = cmpi ne, %[[VAL_6]], %[[VAL_7]] : index
-// CHECK:           scf.if %[[VAL_8]] {
-// CHECK:             %[[VAL_9:.*]] = call @cast_csc_to_csx(%[[VAL_5]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:             call @matrix_resize_dim(%[[VAL_9]], %[[VAL_1]], %[[VAL_7]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:             %[[VAL_10:.*]] = call @cast_csc_to_csx(%[[VAL_5]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:             call @matrix_resize_dim(%[[VAL_10]], %[[VAL_2]], %[[VAL_6]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK-DAG:       %[[VAL_1:.*]] = constant 0 : index
+// CHECK-DAG:       %[[VAL_2:.*]] = constant 1 : index
+// CHECK:           %[[VAL_3:.*]] = call @matrix_csr_i64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_4:.*]] = call @dup_tensor(%[[VAL_3]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_5:.*]] = call @ptr8_to_matrix_csr_i64_p64i64(%[[VAL_4]]) : (!llvm.ptr<i8>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_6:.*]] = call @matrix_csr_i64_p64i64_to_ptr8(%[[VAL_5]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_7:.*]] = call @ptr8_to_matrix_csc_i64_p64i64(%[[VAL_6]]) : (!llvm.ptr<i8>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_8:.*]] = tensor.dim %[[VAL_0]], %[[VAL_1]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_9:.*]] = tensor.dim %[[VAL_0]], %[[VAL_2]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_10:.*]] = cmpi ne, %[[VAL_8]], %[[VAL_9]] : index
+// CHECK:           scf.if %[[VAL_10]] {
+// CHECK:             %[[VAL_11:.*]] = call @matrix_csc_i64_p64i64_to_ptr8(%[[VAL_7]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:             call @resize_dim(%[[VAL_11]], %[[VAL_1]], %[[VAL_9]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:             %[[VAL_12:.*]] = call @matrix_csc_i64_p64i64_to_ptr8(%[[VAL_7]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:             call @resize_dim(%[[VAL_12]], %[[VAL_2]], %[[VAL_8]]) : (!llvm.ptr<i8>, index, index) -> ()
 // CHECK:           }
-// CHECK:           return %[[VAL_5]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           return %[[VAL_7]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
     func @transpose_different_compression(%sparse_tensor: tensor<?x?xi64, #CSR64>) -> tensor<?x?xi64, #CSC64> {
         %answer = graphblas.transpose %sparse_tensor : tensor<?x?xi64, #CSR64> to tensor<?x?xi64, #CSC64>
@@ -40,93 +42,102 @@ module {
  
 // CHECK-LABEL:   func @transpose_same_compression(
 // CHECK-SAME:                                     %[[VAL_0:.*]]: tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:           %[[VAL_1:.*]] = constant 0 : i64
-// CHECK:           %[[VAL_2:.*]] = constant 1 : i64
-// CHECK:           %[[VAL_3:.*]] = constant 0 : index
-// CHECK:           %[[VAL_4:.*]] = constant 1 : index
+// CHECK-DAG:       %[[VAL_1:.*]] = constant 0 : i64
+// CHECK-DAG:       %[[VAL_2:.*]] = constant 1 : i64
+// CHECK-DAG:       %[[VAL_3:.*]] = constant 0 : index
+// CHECK-DAG:       %[[VAL_4:.*]] = constant 1 : index
 // CHECK:           %[[VAL_5:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_4]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_6:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_4]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_7:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_8:.*]] = tensor.dim %[[VAL_0]], %[[VAL_3]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_9:.*]] = tensor.dim %[[VAL_0]], %[[VAL_4]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_11:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_4]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_12:.*]] = tensor.dim %[[VAL_0]], %[[VAL_3]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_13:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_12]]] : memref<?xi64>
-// CHECK:           %[[VAL_14:.*]] = index_cast %[[VAL_13]] : i64 to index
-// CHECK:           %[[VAL_15:.*]] = call @cast_csr_to_csx(%[[VAL_0]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_16:.*]] = call @matrix_empty_like(%[[VAL_15]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @matrix_resize_dim(%[[VAL_16]], %[[VAL_3]], %[[VAL_8]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @matrix_resize_dim(%[[VAL_16]], %[[VAL_4]], %[[VAL_9]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           %[[VAL_10:.*]] = addi %[[VAL_9]], %[[VAL_4]] : index
-// CHECK:           call @matrix_resize_pointers(%[[VAL_16]], %[[VAL_4]], %[[VAL_10]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @matrix_resize_index(%[[VAL_16]], %[[VAL_4]], %[[VAL_14]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @matrix_resize_values(%[[VAL_16]], %[[VAL_14]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
-// CHECK:           %[[VAL_17:.*]] = call @cast_csx_to_csc(%[[VAL_16]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_18:.*]] = sparse_tensor.pointers %[[VAL_17]], %[[VAL_4]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_19:.*]] = sparse_tensor.indices %[[VAL_17]], %[[VAL_4]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_20:.*]] = sparse_tensor.values %[[VAL_17]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           scf.for %[[VAL_21:.*]] = %[[VAL_3]] to %[[VAL_9]] step %[[VAL_4]] {
-// CHECK:             memref.store %[[VAL_1]], %[[VAL_18]]{{\[}}%[[VAL_21]]] : memref<?xi64>
+// CHECK:           %[[VAL_10:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_4]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_11:.*]] = tensor.dim %[[VAL_0]], %[[VAL_3]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_12:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_11]]] : memref<?xi64>
+// CHECK:           %[[VAL_13:.*]] = index_cast %[[VAL_12]] : i64 to index
+// CHECK:           %[[VAL_14:.*]] = call @matrix_csr_i64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_15:.*]] = call @empty_like(%[[VAL_14]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_16:.*]] = call @ptr8_to_matrix_csr_i64_p64i64(%[[VAL_15]]) : (!llvm.ptr<i8>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_17:.*]] = call @matrix_csr_i64_p64i64_to_ptr8(%[[VAL_16]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_dim(%[[VAL_17]], %[[VAL_3]], %[[VAL_8]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_18:.*]] = call @matrix_csr_i64_p64i64_to_ptr8(%[[VAL_16]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_dim(%[[VAL_18]], %[[VAL_4]], %[[VAL_9]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_19:.*]] = addi %[[VAL_9]], %[[VAL_4]] : index
+// CHECK:           %[[VAL_20:.*]] = call @matrix_csr_i64_p64i64_to_ptr8(%[[VAL_16]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_pointers(%[[VAL_20]], %[[VAL_4]], %[[VAL_19]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_21:.*]] = call @matrix_csr_i64_p64i64_to_ptr8(%[[VAL_16]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_index(%[[VAL_21]], %[[VAL_4]], %[[VAL_13]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_22:.*]] = call @matrix_csr_i64_p64i64_to_ptr8(%[[VAL_16]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_values(%[[VAL_22]], %[[VAL_13]]) : (!llvm.ptr<i8>, index) -> ()
+// CHECK:           %[[VAL_23:.*]] = call @matrix_csr_i64_p64i64_to_ptr8(%[[VAL_16]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_24:.*]] = call @ptr8_to_matrix_csc_i64_p64i64(%[[VAL_23]]) : (!llvm.ptr<i8>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_25:.*]] = sparse_tensor.pointers %[[VAL_24]], %[[VAL_4]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_26:.*]] = sparse_tensor.indices %[[VAL_24]], %[[VAL_4]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_27:.*]] = sparse_tensor.values %[[VAL_24]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           scf.for %[[VAL_28:.*]] = %[[VAL_3]] to %[[VAL_9]] step %[[VAL_4]] {
+// CHECK:             memref.store %[[VAL_1]], %[[VAL_25]]{{\[}}%[[VAL_28]]] : memref<?xi64>
 // CHECK:           }
-// CHECK:           scf.for %[[VAL_22:.*]] = %[[VAL_3]] to %[[VAL_14]] step %[[VAL_4]] {
-// CHECK:             %[[VAL_23:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_22]]] : memref<?xi64>
-// CHECK:             %[[VAL_24:.*]] = index_cast %[[VAL_23]] : i64 to index
-// CHECK:             %[[VAL_25:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_24]]] : memref<?xi64>
-// CHECK:             %[[VAL_26:.*]] = addi %[[VAL_25]], %[[VAL_2]] : i64
-// CHECK:             memref.store %[[VAL_26]], %[[VAL_18]]{{\[}}%[[VAL_24]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_29:.*]] = %[[VAL_3]] to %[[VAL_13]] step %[[VAL_4]] {
+// CHECK:             %[[VAL_30:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_29]]] : memref<?xi64>
+// CHECK:             %[[VAL_31:.*]] = index_cast %[[VAL_30]] : i64 to index
+// CHECK:             %[[VAL_32:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_31]]] : memref<?xi64>
+// CHECK:             %[[VAL_33:.*]] = addi %[[VAL_32]], %[[VAL_2]] : i64
+// CHECK:             memref.store %[[VAL_33]], %[[VAL_25]]{{\[}}%[[VAL_31]]] : memref<?xi64>
 // CHECK:           }
-// CHECK:           memref.store %[[VAL_1]], %[[VAL_18]]{{\[}}%[[VAL_9]]] : memref<?xi64>
-// CHECK:           scf.for %[[VAL_27:.*]] = %[[VAL_3]] to %[[VAL_9]] step %[[VAL_4]] {
-// CHECK:             %[[VAL_28:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_27]]] : memref<?xi64>
-// CHECK:             %[[VAL_29:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_9]]] : memref<?xi64>
-// CHECK:             memref.store %[[VAL_29]], %[[VAL_18]]{{\[}}%[[VAL_27]]] : memref<?xi64>
-// CHECK:             %[[VAL_30:.*]] = addi %[[VAL_29]], %[[VAL_28]] : i64
-// CHECK:             memref.store %[[VAL_30]], %[[VAL_18]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:           memref.store %[[VAL_1]], %[[VAL_25]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_34:.*]] = %[[VAL_3]] to %[[VAL_9]] step %[[VAL_4]] {
+// CHECK:             %[[VAL_35:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_34]]] : memref<?xi64>
+// CHECK:             %[[VAL_36:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_36]], %[[VAL_25]]{{\[}}%[[VAL_34]]] : memref<?xi64>
+// CHECK:             %[[VAL_37:.*]] = addi %[[VAL_36]], %[[VAL_35]] : i64
+// CHECK:             memref.store %[[VAL_37]], %[[VAL_25]]{{\[}}%[[VAL_9]]] : memref<?xi64>
 // CHECK:           }
-// CHECK:           scf.for %[[VAL_31:.*]] = %[[VAL_3]] to %[[VAL_8]] step %[[VAL_4]] {
-// CHECK:             %[[VAL_32:.*]] = index_cast %[[VAL_31]] : index to i64
-// CHECK:             %[[VAL_33:.*]] = memref.load %[[VAL_5]]{{\[}}%[[VAL_31]]] : memref<?xi64>
-// CHECK:             %[[VAL_34:.*]] = index_cast %[[VAL_33]] : i64 to index
-// CHECK:             %[[VAL_35:.*]] = addi %[[VAL_31]], %[[VAL_4]] : index
-// CHECK:             %[[VAL_36:.*]] = memref.load %[[VAL_5]]{{\[}}%[[VAL_35]]] : memref<?xi64>
-// CHECK:             %[[VAL_37:.*]] = index_cast %[[VAL_36]] : i64 to index
-// CHECK:             scf.for %[[VAL_38:.*]] = %[[VAL_34]] to %[[VAL_37]] step %[[VAL_4]] {
-// CHECK:               %[[VAL_39:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_38]]] : memref<?xi64>
-// CHECK:               %[[VAL_40:.*]] = index_cast %[[VAL_39]] : i64 to index
-// CHECK:               %[[VAL_41:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_40]]] : memref<?xi64>
-// CHECK:               %[[VAL_42:.*]] = index_cast %[[VAL_41]] : i64 to index
-// CHECK:               memref.store %[[VAL_32]], %[[VAL_19]]{{\[}}%[[VAL_42]]] : memref<?xi64>
-// CHECK:               %[[VAL_43:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_38]]] : memref<?xi64>
-// CHECK:               memref.store %[[VAL_43]], %[[VAL_20]]{{\[}}%[[VAL_42]]] : memref<?xi64>
-// CHECK:               %[[VAL_44:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_40]]] : memref<?xi64>
-// CHECK:               %[[VAL_45:.*]] = addi %[[VAL_44]], %[[VAL_2]] : i64
-// CHECK:               memref.store %[[VAL_45]], %[[VAL_18]]{{\[}}%[[VAL_40]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_38:.*]] = %[[VAL_3]] to %[[VAL_8]] step %[[VAL_4]] {
+// CHECK:             %[[VAL_39:.*]] = index_cast %[[VAL_38]] : index to i64
+// CHECK:             %[[VAL_40:.*]] = memref.load %[[VAL_5]]{{\[}}%[[VAL_38]]] : memref<?xi64>
+// CHECK:             %[[VAL_41:.*]] = index_cast %[[VAL_40]] : i64 to index
+// CHECK:             %[[VAL_42:.*]] = addi %[[VAL_38]], %[[VAL_4]] : index
+// CHECK:             %[[VAL_43:.*]] = memref.load %[[VAL_5]]{{\[}}%[[VAL_42]]] : memref<?xi64>
+// CHECK:             %[[VAL_44:.*]] = index_cast %[[VAL_43]] : i64 to index
+// CHECK:             scf.for %[[VAL_45:.*]] = %[[VAL_41]] to %[[VAL_44]] step %[[VAL_4]] {
+// CHECK:               %[[VAL_46:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_45]]] : memref<?xi64>
+// CHECK:               %[[VAL_47:.*]] = index_cast %[[VAL_46]] : i64 to index
+// CHECK:               %[[VAL_48:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_47]]] : memref<?xi64>
+// CHECK:               %[[VAL_49:.*]] = index_cast %[[VAL_48]] : i64 to index
+// CHECK:               memref.store %[[VAL_39]], %[[VAL_26]]{{\[}}%[[VAL_49]]] : memref<?xi64>
+// CHECK:               %[[VAL_50:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_45]]] : memref<?xi64>
+// CHECK:               memref.store %[[VAL_50]], %[[VAL_27]]{{\[}}%[[VAL_49]]] : memref<?xi64>
+// CHECK:               %[[VAL_51:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_47]]] : memref<?xi64>
+// CHECK:               %[[VAL_52:.*]] = addi %[[VAL_51]], %[[VAL_2]] : i64
+// CHECK:               memref.store %[[VAL_52]], %[[VAL_25]]{{\[}}%[[VAL_47]]] : memref<?xi64>
 // CHECK:             }
 // CHECK:           }
-// CHECK:           %[[VAL_46:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_9]]] : memref<?xi64>
-// CHECK:           memref.store %[[VAL_1]], %[[VAL_18]]{{\[}}%[[VAL_9]]] : memref<?xi64>
-// CHECK:           scf.for %[[VAL_47:.*]] = %[[VAL_3]] to %[[VAL_9]] step %[[VAL_4]] {
-// CHECK:             %[[VAL_48:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_47]]] : memref<?xi64>
-// CHECK:             %[[VAL_49:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_9]]] : memref<?xi64>
-// CHECK:             memref.store %[[VAL_49]], %[[VAL_18]]{{\[}}%[[VAL_47]]] : memref<?xi64>
-// CHECK:             memref.store %[[VAL_48]], %[[VAL_18]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:           %[[VAL_53:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:           memref.store %[[VAL_1]], %[[VAL_25]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_54:.*]] = %[[VAL_3]] to %[[VAL_9]] step %[[VAL_4]] {
+// CHECK:             %[[VAL_55:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_54]]] : memref<?xi64>
+// CHECK:             %[[VAL_56:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_56]], %[[VAL_25]]{{\[}}%[[VAL_54]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_55]], %[[VAL_25]]{{\[}}%[[VAL_9]]] : memref<?xi64>
 // CHECK:           }
-// CHECK:           memref.store %[[VAL_46]], %[[VAL_18]]{{\[}}%[[VAL_9]]] : memref<?xi64>
-// CHECK:           %[[VAL_50:.*]] = call @cast_csc_to_csx(%[[VAL_17]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_51:.*]] = call @dup_matrix(%[[VAL_50]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_52:.*]] = call @cast_csx_to_csr(%[[VAL_51]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_53:.*]] = tensor.dim %[[VAL_17]], %[[VAL_3]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_54:.*]] = tensor.dim %[[VAL_17]], %[[VAL_4]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_55:.*]] = cmpi ne, %[[VAL_53]], %[[VAL_54]] : index
-// CHECK:           scf.if %[[VAL_55]] {
-// CHECK:             %[[VAL_56:.*]] = call @cast_csr_to_csx(%[[VAL_52]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:             call @matrix_resize_dim(%[[VAL_56]], %[[VAL_3]], %[[VAL_54]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:             %[[VAL_57:.*]] = call @cast_csr_to_csx(%[[VAL_52]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:             call @matrix_resize_dim(%[[VAL_57]], %[[VAL_4]], %[[VAL_53]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
+// CHECK:           memref.store %[[VAL_53]], %[[VAL_25]]{{\[}}%[[VAL_9]]] : memref<?xi64>
+// CHECK:           %[[VAL_57:.*]] = call @matrix_csc_i64_p64i64_to_ptr8(%[[VAL_24]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_58:.*]] = call @dup_tensor(%[[VAL_57]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_59:.*]] = call @ptr8_to_matrix_csc_i64_p64i64(%[[VAL_58]]) : (!llvm.ptr<i8>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_60:.*]] = call @matrix_csc_i64_p64i64_to_ptr8(%[[VAL_59]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_61:.*]] = call @ptr8_to_matrix_csr_i64_p64i64(%[[VAL_60]]) : (!llvm.ptr<i8>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_62:.*]] = tensor.dim %[[VAL_24]], %[[VAL_3]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_63:.*]] = tensor.dim %[[VAL_24]], %[[VAL_4]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_64:.*]] = cmpi ne, %[[VAL_62]], %[[VAL_63]] : index
+// CHECK:           scf.if %[[VAL_64]] {
+// CHECK:             %[[VAL_65:.*]] = call @matrix_csr_i64_p64i64_to_ptr8(%[[VAL_61]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:             call @resize_dim(%[[VAL_65]], %[[VAL_3]], %[[VAL_63]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:             %[[VAL_66:.*]] = call @matrix_csr_i64_p64i64_to_ptr8(%[[VAL_61]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:             call @resize_dim(%[[VAL_66]], %[[VAL_4]], %[[VAL_62]]) : (!llvm.ptr<i8>, index, index) -> ()
 // CHECK:           }
-// CHECK:           %[[VAL_58:.*]] = call @cast_csc_to_csx(%[[VAL_17]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @delSparseMatrix(%[[VAL_58]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> ()
-// CHECK:           return %[[VAL_52]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_67:.*]] = call @matrix_csc_i64_p64i64_to_ptr8(%[[VAL_24]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @delSparseTensor(%[[VAL_67]]) : (!llvm.ptr<i8>) -> ()
+// CHECK:           return %[[VAL_61]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
     func @transpose_same_compression(%sparse_tensor: tensor<?x?xi64, #CSR64>) -> tensor<?x?xi64, #CSR64> {
         %answer = graphblas.transpose %sparse_tensor : tensor<?x?xi64, #CSR64> to tensor<?x?xi64, #CSR64>

--- a/mlir_graphblas/src/test/GraphBLAS/lower_union.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_union.mlir
@@ -23,152 +23,156 @@
 // CHECK-DAG:       %[[VAL_5:.*]] = constant false
 // CHECK-DAG:       %[[VAL_6:.*]] = constant true
 // CHECK-DAG:       %[[VAL_7:.*]] = constant 0.000000e+00 : f64
-// CHECK:           %[[VAL_8:.*]] = call @vector_empty_like(%[[VAL_0]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_9:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_10:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_3]]] : memref<?xi64>
-// CHECK:           %[[VAL_11:.*]] = index_cast %[[VAL_10]] : i64 to index
-// CHECK:           %[[VAL_12:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_13:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_3]]] : memref<?xi64>
-// CHECK:           %[[VAL_14:.*]] = index_cast %[[VAL_13]] : i64 to index
-// CHECK:           %[[VAL_15:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_16:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_17:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_18:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_19:.*]]:7 = scf.while (%[[VAL_20:.*]] = %[[VAL_2]], %[[VAL_21:.*]] = %[[VAL_2]], %[[VAL_22:.*]] = %[[VAL_2]], %[[VAL_23:.*]] = %[[VAL_2]], %[[VAL_24:.*]] = %[[VAL_6]], %[[VAL_25:.*]] = %[[VAL_6]], %[[VAL_26:.*]] = %[[VAL_2]]) : (index, index, index, index, i1, i1, index) -> (index, index, index, index, i1, i1, index) {
-// CHECK:             %[[VAL_27:.*]] = cmpi ult, %[[VAL_20]], %[[VAL_11]] : index
-// CHECK:             %[[VAL_28:.*]] = cmpi ult, %[[VAL_21]], %[[VAL_14]] : index
-// CHECK:             %[[VAL_29:.*]] = and %[[VAL_27]], %[[VAL_28]] : i1
-// CHECK:             scf.condition(%[[VAL_29]]) %[[VAL_20]], %[[VAL_21]], %[[VAL_22]], %[[VAL_23]], %[[VAL_24]], %[[VAL_25]], %[[VAL_26]] : index, index, index, index, i1, i1, index
+// CHECK:           %[[VAL_8:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_9:.*]] = call @empty_like(%[[VAL_8]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_10:.*]] = call @ptr8_to_vector_f64_p64i64(%[[VAL_9]]) : (!llvm.ptr<i8>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_11:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_12:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_3]]] : memref<?xi64>
+// CHECK:           %[[VAL_13:.*]] = index_cast %[[VAL_12]] : i64 to index
+// CHECK:           %[[VAL_14:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_15:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_3]]] : memref<?xi64>
+// CHECK:           %[[VAL_16:.*]] = index_cast %[[VAL_15]] : i64 to index
+// CHECK:           %[[VAL_17:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_18:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_19:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_20:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_21:.*]]:7 = scf.while (%[[VAL_22:.*]] = %[[VAL_2]], %[[VAL_23:.*]] = %[[VAL_2]], %[[VAL_24:.*]] = %[[VAL_2]], %[[VAL_25:.*]] = %[[VAL_2]], %[[VAL_26:.*]] = %[[VAL_6]], %[[VAL_27:.*]] = %[[VAL_6]], %[[VAL_28:.*]] = %[[VAL_2]]) : (index, index, index, index, i1, i1, index) -> (index, index, index, index, i1, i1, index) {
+// CHECK:             %[[VAL_29:.*]] = cmpi ult, %[[VAL_22]], %[[VAL_13]] : index
+// CHECK:             %[[VAL_30:.*]] = cmpi ult, %[[VAL_23]], %[[VAL_16]] : index
+// CHECK:             %[[VAL_31:.*]] = and %[[VAL_29]], %[[VAL_30]] : i1
+// CHECK:             scf.condition(%[[VAL_31]]) %[[VAL_22]], %[[VAL_23]], %[[VAL_24]], %[[VAL_25]], %[[VAL_26]], %[[VAL_27]], %[[VAL_28]] : index, index, index, index, i1, i1, index
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_30:.*]]: index, %[[VAL_31:.*]]: index, %[[VAL_32:.*]]: index, %[[VAL_33:.*]]: index, %[[VAL_34:.*]]: i1, %[[VAL_35:.*]]: i1, %[[VAL_36:.*]]: index):
-// CHECK:             %[[VAL_37:.*]] = scf.if %[[VAL_34]] -> (index) {
-// CHECK:               %[[VAL_38:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_30]]] : memref<?xi64>
-// CHECK:               %[[VAL_39:.*]] = index_cast %[[VAL_38]] : i64 to index
-// CHECK:               scf.yield %[[VAL_39]] : index
+// CHECK:           ^bb0(%[[VAL_32:.*]]: index, %[[VAL_33:.*]]: index, %[[VAL_34:.*]]: index, %[[VAL_35:.*]]: index, %[[VAL_36:.*]]: i1, %[[VAL_37:.*]]: i1, %[[VAL_38:.*]]: index):
+// CHECK:             %[[VAL_39:.*]] = scf.if %[[VAL_36]] -> (index) {
+// CHECK:               %[[VAL_40:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_32]]] : memref<?xi64>
+// CHECK:               %[[VAL_41:.*]] = index_cast %[[VAL_40]] : i64 to index
+// CHECK:               scf.yield %[[VAL_41]] : index
 // CHECK:             } else {
-// CHECK:               scf.yield %[[VAL_32]] : index
+// CHECK:               scf.yield %[[VAL_34]] : index
 // CHECK:             }
-// CHECK:             %[[VAL_40:.*]] = scf.if %[[VAL_35]] -> (index) {
-// CHECK:               %[[VAL_41:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_31]]] : memref<?xi64>
-// CHECK:               %[[VAL_42:.*]] = index_cast %[[VAL_41]] : i64 to index
-// CHECK:               scf.yield %[[VAL_42]] : index
+// CHECK:             %[[VAL_42:.*]] = scf.if %[[VAL_37]] -> (index) {
+// CHECK:               %[[VAL_43:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_33]]] : memref<?xi64>
+// CHECK:               %[[VAL_44:.*]] = index_cast %[[VAL_43]] : i64 to index
+// CHECK:               scf.yield %[[VAL_44]] : index
 // CHECK:             } else {
-// CHECK:               scf.yield %[[VAL_33]] : index
+// CHECK:               scf.yield %[[VAL_35]] : index
 // CHECK:             }
-// CHECK:             %[[VAL_43:.*]] = cmpi ult, %[[VAL_44:.*]], %[[VAL_45:.*]] : index
-// CHECK:             %[[VAL_46:.*]] = cmpi ugt, %[[VAL_44]], %[[VAL_45]] : index
-// CHECK:             %[[VAL_47:.*]] = addi %[[VAL_30]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_48:.*]] = addi %[[VAL_31]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_49:.*]] = addi %[[VAL_36]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_50:.*]]:5 = scf.if %[[VAL_43]] -> (index, index, i1, i1, index) {
-// CHECK:               scf.yield %[[VAL_47]], %[[VAL_31]], %[[VAL_6]], %[[VAL_5]], %[[VAL_49]] : index, index, i1, i1, index
+// CHECK:             %[[VAL_45:.*]] = cmpi ult, %[[VAL_46:.*]], %[[VAL_47:.*]] : index
+// CHECK:             %[[VAL_48:.*]] = cmpi ugt, %[[VAL_46]], %[[VAL_47]] : index
+// CHECK:             %[[VAL_49:.*]] = addi %[[VAL_32]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_50:.*]] = addi %[[VAL_33]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_51:.*]] = addi %[[VAL_38]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_52:.*]]:5 = scf.if %[[VAL_45]] -> (index, index, i1, i1, index) {
+// CHECK:               scf.yield %[[VAL_49]], %[[VAL_33]], %[[VAL_6]], %[[VAL_5]], %[[VAL_51]] : index, index, i1, i1, index
 // CHECK:             } else {
-// CHECK:               %[[VAL_51:.*]]:5 = scf.if %[[VAL_46]] -> (index, index, i1, i1, index) {
-// CHECK:                 scf.yield %[[VAL_30]], %[[VAL_48]], %[[VAL_5]], %[[VAL_6]], %[[VAL_49]] : index, index, i1, i1, index
+// CHECK:               %[[VAL_53:.*]]:5 = scf.if %[[VAL_48]] -> (index, index, i1, i1, index) {
+// CHECK:                 scf.yield %[[VAL_32]], %[[VAL_50]], %[[VAL_5]], %[[VAL_6]], %[[VAL_51]] : index, index, i1, i1, index
 // CHECK:               } else {
-// CHECK:                 scf.yield %[[VAL_47]], %[[VAL_48]], %[[VAL_6]], %[[VAL_6]], %[[VAL_49]] : index, index, i1, i1, index
+// CHECK:                 scf.yield %[[VAL_49]], %[[VAL_50]], %[[VAL_6]], %[[VAL_6]], %[[VAL_51]] : index, index, i1, i1, index
 // CHECK:               }
-// CHECK:               scf.yield %[[VAL_52:.*]]#0, %[[VAL_52]]#1, %[[VAL_52]]#2, %[[VAL_52]]#3, %[[VAL_52]]#4 : index, index, i1, i1, index
+// CHECK:               scf.yield %[[VAL_54:.*]]#0, %[[VAL_54]]#1, %[[VAL_54]]#2, %[[VAL_54]]#3, %[[VAL_54]]#4 : index, index, i1, i1, index
 // CHECK:             }
-// CHECK:             scf.yield %[[VAL_53:.*]]#0, %[[VAL_53]]#1, %[[VAL_44]], %[[VAL_45]], %[[VAL_53]]#2, %[[VAL_53]]#3, %[[VAL_53]]#4 : index, index, index, index, i1, i1, index
+// CHECK:             scf.yield %[[VAL_55:.*]]#0, %[[VAL_55]]#1, %[[VAL_46]], %[[VAL_47]], %[[VAL_55]]#2, %[[VAL_55]]#3, %[[VAL_55]]#4 : index, index, index, index, i1, i1, index
 // CHECK:           }
-// CHECK:           %[[VAL_54:.*]] = cmpi ult, %[[VAL_55:.*]]#0, %[[VAL_11]] : index
-// CHECK:           %[[VAL_56:.*]] = scf.if %[[VAL_54]] -> (index) {
-// CHECK:             %[[VAL_57:.*]] = subi %[[VAL_11]], %[[VAL_55]]#0 : index
-// CHECK:             %[[VAL_58:.*]] = addi %[[VAL_55]]#6, %[[VAL_57]] : index
-// CHECK:             scf.yield %[[VAL_58]] : index
+// CHECK:           %[[VAL_56:.*]] = cmpi ult, %[[VAL_57:.*]]#0, %[[VAL_13]] : index
+// CHECK:           %[[VAL_58:.*]] = scf.if %[[VAL_56]] -> (index) {
+// CHECK:             %[[VAL_59:.*]] = subi %[[VAL_13]], %[[VAL_57]]#0 : index
+// CHECK:             %[[VAL_60:.*]] = addi %[[VAL_57]]#6, %[[VAL_59]] : index
+// CHECK:             scf.yield %[[VAL_60]] : index
 // CHECK:           } else {
-// CHECK:             %[[VAL_59:.*]] = cmpi ult, %[[VAL_55]]#1, %[[VAL_14]] : index
-// CHECK:             %[[VAL_60:.*]] = scf.if %[[VAL_59]] -> (index) {
-// CHECK:               %[[VAL_61:.*]] = subi %[[VAL_14]], %[[VAL_55]]#1 : index
-// CHECK:               %[[VAL_62:.*]] = addi %[[VAL_55]]#6, %[[VAL_61]] : index
-// CHECK:               scf.yield %[[VAL_62]] : index
+// CHECK:             %[[VAL_61:.*]] = cmpi ult, %[[VAL_57]]#1, %[[VAL_16]] : index
+// CHECK:             %[[VAL_62:.*]] = scf.if %[[VAL_61]] -> (index) {
+// CHECK:               %[[VAL_63:.*]] = subi %[[VAL_16]], %[[VAL_57]]#1 : index
+// CHECK:               %[[VAL_64:.*]] = addi %[[VAL_57]]#6, %[[VAL_63]] : index
+// CHECK:               scf.yield %[[VAL_64]] : index
 // CHECK:             } else {
-// CHECK:               scf.yield %[[VAL_55]]#6 : index
+// CHECK:               scf.yield %[[VAL_57]]#6 : index
 // CHECK:             }
-// CHECK:             scf.yield %[[VAL_63:.*]] : index
+// CHECK:             scf.yield %[[VAL_65:.*]] : index
 // CHECK:           }
-// CHECK:           %[[VAL_64:.*]] = index_cast %[[VAL_65:.*]] : index to i64
-// CHECK:           call @vector_resize_index(%[[VAL_8]], %[[VAL_2]], %[[VAL_65]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @vector_resize_values(%[[VAL_8]], %[[VAL_65]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
-// CHECK:           %[[VAL_66:.*]] = sparse_tensor.pointers %[[VAL_8]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           memref.store %[[VAL_64]], %[[VAL_66]]{{\[}}%[[VAL_3]]] : memref<?xi64>
-// CHECK:           %[[VAL_67:.*]] = sparse_tensor.indices %[[VAL_8]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_68:.*]] = sparse_tensor.values %[[VAL_8]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_69:.*]]:9 = scf.while (%[[VAL_70:.*]] = %[[VAL_2]], %[[VAL_71:.*]] = %[[VAL_2]], %[[VAL_72:.*]] = %[[VAL_2]], %[[VAL_73:.*]] = %[[VAL_4]], %[[VAL_74:.*]] = %[[VAL_4]], %[[VAL_75:.*]] = %[[VAL_7]], %[[VAL_76:.*]] = %[[VAL_7]], %[[VAL_77:.*]] = %[[VAL_6]], %[[VAL_78:.*]] = %[[VAL_6]]) : (index, index, index, i64, i64, f64, f64, i1, i1) -> (index, index, index, i64, i64, f64, f64, i1, i1) {
-// CHECK:             %[[VAL_79:.*]] = cmpi ult, %[[VAL_70]], %[[VAL_11]] : index
-// CHECK:             %[[VAL_80:.*]] = cmpi ult, %[[VAL_71]], %[[VAL_14]] : index
-// CHECK:             %[[VAL_81:.*]] = and %[[VAL_79]], %[[VAL_80]] : i1
-// CHECK:             scf.condition(%[[VAL_81]]) %[[VAL_70]], %[[VAL_71]], %[[VAL_72]], %[[VAL_73]], %[[VAL_74]], %[[VAL_75]], %[[VAL_76]], %[[VAL_77]], %[[VAL_78]] : index, index, index, i64, i64, f64, f64, i1, i1
+// CHECK:           %[[VAL_66:.*]] = index_cast %[[VAL_67:.*]] : index to i64
+// CHECK:           %[[VAL_68:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_10]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_index(%[[VAL_68]], %[[VAL_2]], %[[VAL_67]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_69:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_10]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_values(%[[VAL_69]], %[[VAL_67]]) : (!llvm.ptr<i8>, index) -> ()
+// CHECK:           %[[VAL_70:.*]] = sparse_tensor.pointers %[[VAL_10]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           memref.store %[[VAL_66]], %[[VAL_70]]{{\[}}%[[VAL_3]]] : memref<?xi64>
+// CHECK:           %[[VAL_71:.*]] = sparse_tensor.indices %[[VAL_10]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_72:.*]] = sparse_tensor.values %[[VAL_10]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_73:.*]]:9 = scf.while (%[[VAL_74:.*]] = %[[VAL_2]], %[[VAL_75:.*]] = %[[VAL_2]], %[[VAL_76:.*]] = %[[VAL_2]], %[[VAL_77:.*]] = %[[VAL_4]], %[[VAL_78:.*]] = %[[VAL_4]], %[[VAL_79:.*]] = %[[VAL_7]], %[[VAL_80:.*]] = %[[VAL_7]], %[[VAL_81:.*]] = %[[VAL_6]], %[[VAL_82:.*]] = %[[VAL_6]]) : (index, index, index, i64, i64, f64, f64, i1, i1) -> (index, index, index, i64, i64, f64, f64, i1, i1) {
+// CHECK:             %[[VAL_83:.*]] = cmpi ult, %[[VAL_74]], %[[VAL_13]] : index
+// CHECK:             %[[VAL_84:.*]] = cmpi ult, %[[VAL_75]], %[[VAL_16]] : index
+// CHECK:             %[[VAL_85:.*]] = and %[[VAL_83]], %[[VAL_84]] : i1
+// CHECK:             scf.condition(%[[VAL_85]]) %[[VAL_74]], %[[VAL_75]], %[[VAL_76]], %[[VAL_77]], %[[VAL_78]], %[[VAL_79]], %[[VAL_80]], %[[VAL_81]], %[[VAL_82]] : index, index, index, i64, i64, f64, f64, i1, i1
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_82:.*]]: index, %[[VAL_83:.*]]: index, %[[VAL_84:.*]]: index, %[[VAL_85:.*]]: i64, %[[VAL_86:.*]]: i64, %[[VAL_87:.*]]: f64, %[[VAL_88:.*]]: f64, %[[VAL_89:.*]]: i1, %[[VAL_90:.*]]: i1):
-// CHECK:             %[[VAL_91:.*]]:2 = scf.if %[[VAL_89]] -> (i64, f64) {
-// CHECK:               %[[VAL_92:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_82]]] : memref<?xi64>
-// CHECK:               %[[VAL_93:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_82]]] : memref<?xf64>
-// CHECK:               scf.yield %[[VAL_92]], %[[VAL_93]] : i64, f64
+// CHECK:           ^bb0(%[[VAL_86:.*]]: index, %[[VAL_87:.*]]: index, %[[VAL_88:.*]]: index, %[[VAL_89:.*]]: i64, %[[VAL_90:.*]]: i64, %[[VAL_91:.*]]: f64, %[[VAL_92:.*]]: f64, %[[VAL_93:.*]]: i1, %[[VAL_94:.*]]: i1):
+// CHECK:             %[[VAL_95:.*]]:2 = scf.if %[[VAL_93]] -> (i64, f64) {
+// CHECK:               %[[VAL_96:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_86]]] : memref<?xi64>
+// CHECK:               %[[VAL_97:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_86]]] : memref<?xf64>
+// CHECK:               scf.yield %[[VAL_96]], %[[VAL_97]] : i64, f64
 // CHECK:             } else {
-// CHECK:               scf.yield %[[VAL_85]], %[[VAL_87]] : i64, f64
+// CHECK:               scf.yield %[[VAL_89]], %[[VAL_91]] : i64, f64
 // CHECK:             }
-// CHECK:             %[[VAL_94:.*]]:2 = scf.if %[[VAL_90]] -> (i64, f64) {
-// CHECK:               %[[VAL_95:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_83]]] : memref<?xi64>
-// CHECK:               %[[VAL_96:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_83]]] : memref<?xf64>
-// CHECK:               scf.yield %[[VAL_95]], %[[VAL_96]] : i64, f64
+// CHECK:             %[[VAL_98:.*]]:2 = scf.if %[[VAL_94]] -> (i64, f64) {
+// CHECK:               %[[VAL_99:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_87]]] : memref<?xi64>
+// CHECK:               %[[VAL_100:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_87]]] : memref<?xf64>
+// CHECK:               scf.yield %[[VAL_99]], %[[VAL_100]] : i64, f64
 // CHECK:             } else {
-// CHECK:               scf.yield %[[VAL_86]], %[[VAL_88]] : i64, f64
+// CHECK:               scf.yield %[[VAL_90]], %[[VAL_92]] : i64, f64
 // CHECK:             }
-// CHECK:             %[[VAL_97:.*]] = cmpi ult, %[[VAL_98:.*]]#0, %[[VAL_99:.*]]#0 : i64
-// CHECK:             %[[VAL_100:.*]] = cmpi ugt, %[[VAL_98]]#0, %[[VAL_99]]#0 : i64
-// CHECK:             %[[VAL_101:.*]] = addi %[[VAL_82]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_102:.*]] = addi %[[VAL_83]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_103:.*]] = addi %[[VAL_84]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_104:.*]]:5 = scf.if %[[VAL_97]] -> (index, index, index, i1, i1) {
-// CHECK:               memref.store %[[VAL_98]]#0, %[[VAL_67]]{{\[}}%[[VAL_84]]] : memref<?xi64>
-// CHECK:               memref.store %[[VAL_98]]#1, %[[VAL_68]]{{\[}}%[[VAL_84]]] : memref<?xf64>
-// CHECK:               scf.yield %[[VAL_101]], %[[VAL_83]], %[[VAL_103]], %[[VAL_6]], %[[VAL_5]] : index, index, index, i1, i1
+// CHECK:             %[[VAL_101:.*]] = cmpi ult, %[[VAL_102:.*]]#0, %[[VAL_103:.*]]#0 : i64
+// CHECK:             %[[VAL_104:.*]] = cmpi ugt, %[[VAL_102]]#0, %[[VAL_103]]#0 : i64
+// CHECK:             %[[VAL_105:.*]] = addi %[[VAL_86]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_106:.*]] = addi %[[VAL_87]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_107:.*]] = addi %[[VAL_88]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_108:.*]]:5 = scf.if %[[VAL_101]] -> (index, index, index, i1, i1) {
+// CHECK:               memref.store %[[VAL_102]]#0, %[[VAL_71]]{{\[}}%[[VAL_88]]] : memref<?xi64>
+// CHECK:               memref.store %[[VAL_102]]#1, %[[VAL_72]]{{\[}}%[[VAL_88]]] : memref<?xf64>
+// CHECK:               scf.yield %[[VAL_105]], %[[VAL_87]], %[[VAL_107]], %[[VAL_6]], %[[VAL_5]] : index, index, index, i1, i1
 // CHECK:             } else {
-// CHECK:               %[[VAL_105:.*]]:5 = scf.if %[[VAL_100]] -> (index, index, index, i1, i1) {
-// CHECK:                 memref.store %[[VAL_99]]#0, %[[VAL_67]]{{\[}}%[[VAL_84]]] : memref<?xi64>
-// CHECK:                 memref.store %[[VAL_99]]#1, %[[VAL_68]]{{\[}}%[[VAL_84]]] : memref<?xf64>
-// CHECK:                 scf.yield %[[VAL_82]], %[[VAL_102]], %[[VAL_103]], %[[VAL_5]], %[[VAL_6]] : index, index, index, i1, i1
+// CHECK:               %[[VAL_109:.*]]:5 = scf.if %[[VAL_104]] -> (index, index, index, i1, i1) {
+// CHECK:                 memref.store %[[VAL_103]]#0, %[[VAL_71]]{{\[}}%[[VAL_88]]] : memref<?xi64>
+// CHECK:                 memref.store %[[VAL_103]]#1, %[[VAL_72]]{{\[}}%[[VAL_88]]] : memref<?xf64>
+// CHECK:                 scf.yield %[[VAL_86]], %[[VAL_106]], %[[VAL_107]], %[[VAL_5]], %[[VAL_6]] : index, index, index, i1, i1
 // CHECK:               } else {
-// CHECK:                 memref.store %[[VAL_98]]#0, %[[VAL_67]]{{\[}}%[[VAL_84]]] : memref<?xi64>
-// CHECK:                 %[[VAL_106:.*]] = addf %[[VAL_98]]#1, %[[VAL_99]]#1 : f64
-// CHECK:                 memref.store %[[VAL_106]], %[[VAL_68]]{{\[}}%[[VAL_84]]] : memref<?xf64>
-// CHECK:                 scf.yield %[[VAL_101]], %[[VAL_102]], %[[VAL_103]], %[[VAL_6]], %[[VAL_6]] : index, index, index, i1, i1
+// CHECK:                 memref.store %[[VAL_102]]#0, %[[VAL_71]]{{\[}}%[[VAL_88]]] : memref<?xi64>
+// CHECK:                 %[[VAL_110:.*]] = addf %[[VAL_102]]#1, %[[VAL_103]]#1 : f64
+// CHECK:                 memref.store %[[VAL_110]], %[[VAL_72]]{{\[}}%[[VAL_88]]] : memref<?xf64>
+// CHECK:                 scf.yield %[[VAL_105]], %[[VAL_106]], %[[VAL_107]], %[[VAL_6]], %[[VAL_6]] : index, index, index, i1, i1
 // CHECK:               }
-// CHECK:               scf.yield %[[VAL_107:.*]]#0, %[[VAL_107]]#1, %[[VAL_107]]#2, %[[VAL_107]]#3, %[[VAL_107]]#4 : index, index, index, i1, i1
+// CHECK:               scf.yield %[[VAL_111:.*]]#0, %[[VAL_111]]#1, %[[VAL_111]]#2, %[[VAL_111]]#3, %[[VAL_111]]#4 : index, index, index, i1, i1
 // CHECK:             }
-// CHECK:             scf.yield %[[VAL_108:.*]]#0, %[[VAL_108]]#1, %[[VAL_108]]#2, %[[VAL_98]]#0, %[[VAL_99]]#0, %[[VAL_98]]#1, %[[VAL_99]]#1, %[[VAL_108]]#3, %[[VAL_108]]#4 : index, index, index, i64, i64, f64, f64, i1, i1
+// CHECK:             scf.yield %[[VAL_112:.*]]#0, %[[VAL_112]]#1, %[[VAL_112]]#2, %[[VAL_102]]#0, %[[VAL_103]]#0, %[[VAL_102]]#1, %[[VAL_103]]#1, %[[VAL_112]]#3, %[[VAL_112]]#4 : index, index, index, i64, i64, f64, f64, i1, i1
 // CHECK:           }
-// CHECK:           %[[VAL_109:.*]] = cmpi ult, %[[VAL_110:.*]]#0, %[[VAL_11]] : index
-// CHECK:           %[[VAL_111:.*]] = scf.if %[[VAL_109]] -> (index) {
-// CHECK:             %[[VAL_112:.*]] = scf.for %[[VAL_113:.*]] = %[[VAL_110]]#0 to %[[VAL_11]] step %[[VAL_3]] iter_args(%[[VAL_114:.*]] = %[[VAL_110]]#2) -> (index) {
-// CHECK:               %[[VAL_115:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_113]]] : memref<?xi64>
-// CHECK:               %[[VAL_116:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_113]]] : memref<?xf64>
-// CHECK:               memref.store %[[VAL_115]], %[[VAL_67]]{{\[}}%[[VAL_114]]] : memref<?xi64>
-// CHECK:               memref.store %[[VAL_116]], %[[VAL_68]]{{\[}}%[[VAL_114]]] : memref<?xf64>
-// CHECK:               %[[VAL_117:.*]] = addi %[[VAL_114]], %[[VAL_3]] : index
-// CHECK:               scf.yield %[[VAL_117]] : index
+// CHECK:           %[[VAL_113:.*]] = cmpi ult, %[[VAL_114:.*]]#0, %[[VAL_13]] : index
+// CHECK:           %[[VAL_115:.*]] = scf.if %[[VAL_113]] -> (index) {
+// CHECK:             %[[VAL_116:.*]] = scf.for %[[VAL_117:.*]] = %[[VAL_114]]#0 to %[[VAL_13]] step %[[VAL_3]] iter_args(%[[VAL_118:.*]] = %[[VAL_114]]#2) -> (index) {
+// CHECK:               %[[VAL_119:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_117]]] : memref<?xi64>
+// CHECK:               %[[VAL_120:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_117]]] : memref<?xf64>
+// CHECK:               memref.store %[[VAL_119]], %[[VAL_71]]{{\[}}%[[VAL_118]]] : memref<?xi64>
+// CHECK:               memref.store %[[VAL_120]], %[[VAL_72]]{{\[}}%[[VAL_118]]] : memref<?xf64>
+// CHECK:               %[[VAL_121:.*]] = addi %[[VAL_118]], %[[VAL_3]] : index
+// CHECK:               scf.yield %[[VAL_121]] : index
 // CHECK:             }
-// CHECK:             scf.yield %[[VAL_118:.*]] : index
+// CHECK:             scf.yield %[[VAL_122:.*]] : index
 // CHECK:           } else {
-// CHECK:             %[[VAL_119:.*]] = cmpi ult, %[[VAL_110]]#1, %[[VAL_14]] : index
-// CHECK:             %[[VAL_120:.*]] = scf.if %[[VAL_119]] -> (index) {
-// CHECK:               %[[VAL_121:.*]] = scf.for %[[VAL_122:.*]] = %[[VAL_110]]#1 to %[[VAL_14]] step %[[VAL_3]] iter_args(%[[VAL_123:.*]] = %[[VAL_110]]#2) -> (index) {
-// CHECK:                 %[[VAL_124:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_122]]] : memref<?xi64>
-// CHECK:                 %[[VAL_125:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_122]]] : memref<?xf64>
-// CHECK:                 memref.store %[[VAL_124]], %[[VAL_67]]{{\[}}%[[VAL_123]]] : memref<?xi64>
-// CHECK:                 memref.store %[[VAL_125]], %[[VAL_68]]{{\[}}%[[VAL_123]]] : memref<?xf64>
-// CHECK:                 %[[VAL_126:.*]] = addi %[[VAL_123]], %[[VAL_3]] : index
-// CHECK:                 scf.yield %[[VAL_126]] : index
+// CHECK:             %[[VAL_123:.*]] = cmpi ult, %[[VAL_114]]#1, %[[VAL_16]] : index
+// CHECK:             %[[VAL_124:.*]] = scf.if %[[VAL_123]] -> (index) {
+// CHECK:               %[[VAL_125:.*]] = scf.for %[[VAL_126:.*]] = %[[VAL_114]]#1 to %[[VAL_16]] step %[[VAL_3]] iter_args(%[[VAL_127:.*]] = %[[VAL_114]]#2) -> (index) {
+// CHECK:                 %[[VAL_128:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_126]]] : memref<?xi64>
+// CHECK:                 %[[VAL_129:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_126]]] : memref<?xf64>
+// CHECK:                 memref.store %[[VAL_128]], %[[VAL_71]]{{\[}}%[[VAL_127]]] : memref<?xi64>
+// CHECK:                 memref.store %[[VAL_129]], %[[VAL_72]]{{\[}}%[[VAL_127]]] : memref<?xf64>
+// CHECK:                 %[[VAL_130:.*]] = addi %[[VAL_127]], %[[VAL_3]] : index
+// CHECK:                 scf.yield %[[VAL_130]] : index
 // CHECK:               }
-// CHECK:               scf.yield %[[VAL_127:.*]] : index
+// CHECK:               scf.yield %[[VAL_131:.*]] : index
 // CHECK:             } else {
-// CHECK:               scf.yield %[[VAL_110]]#2 : index
+// CHECK:               scf.yield %[[VAL_114]]#2 : index
 // CHECK:             }
-// CHECK:             scf.yield %[[VAL_128:.*]] : index
+// CHECK:             scf.yield %[[VAL_132:.*]] : index
 // CHECK:           }
-// CHECK:           return %[[VAL_8]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           return %[[VAL_10]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
 
 func @vector_union(%a: tensor<?xf64, #CV64>, %b: tensor<?xf64, #CV64>) -> tensor<?xf64, #CV64> {
@@ -186,202 +190,204 @@ func @vector_union(%a: tensor<?xf64, #CV64>, %b: tensor<?xf64, #CV64>) -> tensor
 // CHECK-DAG:       %[[VAL_5:.*]] = constant false
 // CHECK-DAG:       %[[VAL_6:.*]] = constant true
 // CHECK-DAG:       %[[VAL_7:.*]] = constant 0.000000e+00 : f64
-// CHECK:           %[[VAL_8:.*]] = call @cast_csr_to_csx(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_9:.*]] = call @matrix_empty_like(%[[VAL_8]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_10:.*]] = tensor.dim %[[VAL_9]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_11:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_12:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_13:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_14:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_15:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_16:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_17:.*]] = sparse_tensor.pointers %[[VAL_9]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           scf.parallel (%[[VAL_18:.*]]) = (%[[VAL_2]]) to (%[[VAL_10]]) step (%[[VAL_3]]) {
-// CHECK:             %[[VAL_19:.*]] = addi %[[VAL_18]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_20:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_18]]] : memref<?xi64>
-// CHECK:             %[[VAL_21:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_19]]] : memref<?xi64>
-// CHECK:             %[[VAL_22:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_18]]] : memref<?xi64>
-// CHECK:             %[[VAL_23:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_19]]] : memref<?xi64>
-// CHECK:             %[[VAL_24:.*]] = cmpi eq, %[[VAL_20]], %[[VAL_21]] : i64
-// CHECK:             %[[VAL_25:.*]] = cmpi eq, %[[VAL_22]], %[[VAL_23]] : i64
-// CHECK:             %[[VAL_26:.*]] = and %[[VAL_24]], %[[VAL_25]] : i1
-// CHECK:             %[[VAL_27:.*]] = scf.if %[[VAL_26]] -> (i64) {
+// CHECK:           %[[VAL_8:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_9:.*]] = call @empty_like(%[[VAL_8]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_10:.*]] = call @ptr8_to_matrix_csr_f64_p64i64(%[[VAL_9]]) : (!llvm.ptr<i8>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_11:.*]] = tensor.dim %[[VAL_10]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_12:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_13:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_14:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_15:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_16:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_17:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_18:.*]] = sparse_tensor.pointers %[[VAL_10]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           scf.parallel (%[[VAL_19:.*]]) = (%[[VAL_2]]) to (%[[VAL_11]]) step (%[[VAL_3]]) {
+// CHECK:             %[[VAL_20:.*]] = addi %[[VAL_19]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_21:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_19]]] : memref<?xi64>
+// CHECK:             %[[VAL_22:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_20]]] : memref<?xi64>
+// CHECK:             %[[VAL_23:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_19]]] : memref<?xi64>
+// CHECK:             %[[VAL_24:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_20]]] : memref<?xi64>
+// CHECK:             %[[VAL_25:.*]] = cmpi eq, %[[VAL_21]], %[[VAL_22]] : i64
+// CHECK:             %[[VAL_26:.*]] = cmpi eq, %[[VAL_23]], %[[VAL_24]] : i64
+// CHECK:             %[[VAL_27:.*]] = and %[[VAL_25]], %[[VAL_26]] : i1
+// CHECK:             %[[VAL_28:.*]] = scf.if %[[VAL_27]] -> (i64) {
 // CHECK:               scf.yield %[[VAL_4]] : i64
 // CHECK:             } else {
-// CHECK:               %[[VAL_28:.*]] = index_cast %[[VAL_20]] : i64 to index
 // CHECK:               %[[VAL_29:.*]] = index_cast %[[VAL_21]] : i64 to index
 // CHECK:               %[[VAL_30:.*]] = index_cast %[[VAL_22]] : i64 to index
 // CHECK:               %[[VAL_31:.*]] = index_cast %[[VAL_23]] : i64 to index
-// CHECK:               %[[VAL_32:.*]]:7 = scf.while (%[[VAL_33:.*]] = %[[VAL_28]], %[[VAL_34:.*]] = %[[VAL_30]], %[[VAL_35:.*]] = %[[VAL_2]], %[[VAL_36:.*]] = %[[VAL_2]], %[[VAL_37:.*]] = %[[VAL_6]], %[[VAL_38:.*]] = %[[VAL_6]], %[[VAL_39:.*]] = %[[VAL_2]]) : (index, index, index, index, i1, i1, index) -> (index, index, index, index, i1, i1, index) {
-// CHECK:                 %[[VAL_40:.*]] = cmpi ult, %[[VAL_33]], %[[VAL_29]] : index
-// CHECK:                 %[[VAL_41:.*]] = cmpi ult, %[[VAL_34]], %[[VAL_31]] : index
-// CHECK:                 %[[VAL_42:.*]] = and %[[VAL_40]], %[[VAL_41]] : i1
-// CHECK:                 scf.condition(%[[VAL_42]]) %[[VAL_33]], %[[VAL_34]], %[[VAL_35]], %[[VAL_36]], %[[VAL_37]], %[[VAL_38]], %[[VAL_39]] : index, index, index, index, i1, i1, index
+// CHECK:               %[[VAL_32:.*]] = index_cast %[[VAL_24]] : i64 to index
+// CHECK:               %[[VAL_33:.*]]:7 = scf.while (%[[VAL_34:.*]] = %[[VAL_29]], %[[VAL_35:.*]] = %[[VAL_31]], %[[VAL_36:.*]] = %[[VAL_2]], %[[VAL_37:.*]] = %[[VAL_2]], %[[VAL_38:.*]] = %[[VAL_6]], %[[VAL_39:.*]] = %[[VAL_6]], %[[VAL_40:.*]] = %[[VAL_2]]) : (index, index, index, index, i1, i1, index) -> (index, index, index, index, i1, i1, index) {
+// CHECK:                 %[[VAL_41:.*]] = cmpi ult, %[[VAL_34]], %[[VAL_30]] : index
+// CHECK:                 %[[VAL_42:.*]] = cmpi ult, %[[VAL_35]], %[[VAL_32]] : index
+// CHECK:                 %[[VAL_43:.*]] = and %[[VAL_41]], %[[VAL_42]] : i1
+// CHECK:                 scf.condition(%[[VAL_43]]) %[[VAL_34]], %[[VAL_35]], %[[VAL_36]], %[[VAL_37]], %[[VAL_38]], %[[VAL_39]], %[[VAL_40]] : index, index, index, index, i1, i1, index
 // CHECK:               } do {
-// CHECK:               ^bb0(%[[VAL_43:.*]]: index, %[[VAL_44:.*]]: index, %[[VAL_45:.*]]: index, %[[VAL_46:.*]]: index, %[[VAL_47:.*]]: i1, %[[VAL_48:.*]]: i1, %[[VAL_49:.*]]: index):
-// CHECK:                 %[[VAL_50:.*]] = scf.if %[[VAL_47]] -> (index) {
-// CHECK:                   %[[VAL_51:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_43]]] : memref<?xi64>
-// CHECK:                   %[[VAL_52:.*]] = index_cast %[[VAL_51]] : i64 to index
-// CHECK:                   scf.yield %[[VAL_52]] : index
-// CHECK:                 } else {
-// CHECK:                   scf.yield %[[VAL_45]] : index
-// CHECK:                 }
-// CHECK:                 %[[VAL_53:.*]] = scf.if %[[VAL_48]] -> (index) {
-// CHECK:                   %[[VAL_54:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_44]]] : memref<?xi64>
-// CHECK:                   %[[VAL_55:.*]] = index_cast %[[VAL_54]] : i64 to index
-// CHECK:                   scf.yield %[[VAL_55]] : index
+// CHECK:               ^bb0(%[[VAL_44:.*]]: index, %[[VAL_45:.*]]: index, %[[VAL_46:.*]]: index, %[[VAL_47:.*]]: index, %[[VAL_48:.*]]: i1, %[[VAL_49:.*]]: i1, %[[VAL_50:.*]]: index):
+// CHECK:                 %[[VAL_51:.*]] = scf.if %[[VAL_48]] -> (index) {
+// CHECK:                   %[[VAL_52:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_44]]] : memref<?xi64>
+// CHECK:                   %[[VAL_53:.*]] = index_cast %[[VAL_52]] : i64 to index
+// CHECK:                   scf.yield %[[VAL_53]] : index
 // CHECK:                 } else {
 // CHECK:                   scf.yield %[[VAL_46]] : index
 // CHECK:                 }
-// CHECK:                 %[[VAL_56:.*]] = cmpi ult, %[[VAL_57:.*]], %[[VAL_58:.*]] : index
-// CHECK:                 %[[VAL_59:.*]] = cmpi ugt, %[[VAL_57]], %[[VAL_58]] : index
-// CHECK:                 %[[VAL_60:.*]] = addi %[[VAL_43]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_54:.*]] = scf.if %[[VAL_49]] -> (index) {
+// CHECK:                   %[[VAL_55:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_45]]] : memref<?xi64>
+// CHECK:                   %[[VAL_56:.*]] = index_cast %[[VAL_55]] : i64 to index
+// CHECK:                   scf.yield %[[VAL_56]] : index
+// CHECK:                 } else {
+// CHECK:                   scf.yield %[[VAL_47]] : index
+// CHECK:                 }
+// CHECK:                 %[[VAL_57:.*]] = cmpi ult, %[[VAL_58:.*]], %[[VAL_59:.*]] : index
+// CHECK:                 %[[VAL_60:.*]] = cmpi ugt, %[[VAL_58]], %[[VAL_59]] : index
 // CHECK:                 %[[VAL_61:.*]] = addi %[[VAL_44]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_62:.*]] = addi %[[VAL_49]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_63:.*]]:5 = scf.if %[[VAL_56]] -> (index, index, i1, i1, index) {
-// CHECK:                   scf.yield %[[VAL_60]], %[[VAL_44]], %[[VAL_6]], %[[VAL_5]], %[[VAL_62]] : index, index, i1, i1, index
+// CHECK:                 %[[VAL_62:.*]] = addi %[[VAL_45]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_63:.*]] = addi %[[VAL_50]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_64:.*]]:5 = scf.if %[[VAL_57]] -> (index, index, i1, i1, index) {
+// CHECK:                   scf.yield %[[VAL_61]], %[[VAL_45]], %[[VAL_6]], %[[VAL_5]], %[[VAL_63]] : index, index, i1, i1, index
 // CHECK:                 } else {
-// CHECK:                   %[[VAL_64:.*]]:5 = scf.if %[[VAL_59]] -> (index, index, i1, i1, index) {
-// CHECK:                     scf.yield %[[VAL_43]], %[[VAL_61]], %[[VAL_5]], %[[VAL_6]], %[[VAL_62]] : index, index, i1, i1, index
+// CHECK:                   %[[VAL_65:.*]]:5 = scf.if %[[VAL_60]] -> (index, index, i1, i1, index) {
+// CHECK:                     scf.yield %[[VAL_44]], %[[VAL_62]], %[[VAL_5]], %[[VAL_6]], %[[VAL_63]] : index, index, i1, i1, index
 // CHECK:                   } else {
-// CHECK:                     scf.yield %[[VAL_60]], %[[VAL_61]], %[[VAL_6]], %[[VAL_6]], %[[VAL_62]] : index, index, i1, i1, index
+// CHECK:                     scf.yield %[[VAL_61]], %[[VAL_62]], %[[VAL_6]], %[[VAL_6]], %[[VAL_63]] : index, index, i1, i1, index
 // CHECK:                   }
-// CHECK:                   scf.yield %[[VAL_65:.*]]#0, %[[VAL_65]]#1, %[[VAL_65]]#2, %[[VAL_65]]#3, %[[VAL_65]]#4 : index, index, i1, i1, index
+// CHECK:                   scf.yield %[[VAL_66:.*]]#0, %[[VAL_66]]#1, %[[VAL_66]]#2, %[[VAL_66]]#3, %[[VAL_66]]#4 : index, index, i1, i1, index
 // CHECK:                 }
-// CHECK:                 scf.yield %[[VAL_66:.*]]#0, %[[VAL_66]]#1, %[[VAL_57]], %[[VAL_58]], %[[VAL_66]]#2, %[[VAL_66]]#3, %[[VAL_66]]#4 : index, index, index, index, i1, i1, index
+// CHECK:                 scf.yield %[[VAL_67:.*]]#0, %[[VAL_67]]#1, %[[VAL_58]], %[[VAL_59]], %[[VAL_67]]#2, %[[VAL_67]]#3, %[[VAL_67]]#4 : index, index, index, index, i1, i1, index
 // CHECK:               }
-// CHECK:               %[[VAL_67:.*]] = cmpi ult, %[[VAL_68:.*]]#0, %[[VAL_29]] : index
-// CHECK:               %[[VAL_69:.*]] = scf.if %[[VAL_67]] -> (index) {
-// CHECK:                 %[[VAL_70:.*]] = subi %[[VAL_29]], %[[VAL_68]]#0 : index
-// CHECK:                 %[[VAL_71:.*]] = addi %[[VAL_68]]#6, %[[VAL_70]] : index
-// CHECK:                 scf.yield %[[VAL_71]] : index
+// CHECK:               %[[VAL_68:.*]] = cmpi ult, %[[VAL_69:.*]]#0, %[[VAL_30]] : index
+// CHECK:               %[[VAL_70:.*]] = scf.if %[[VAL_68]] -> (index) {
+// CHECK:                 %[[VAL_71:.*]] = subi %[[VAL_30]], %[[VAL_69]]#0 : index
+// CHECK:                 %[[VAL_72:.*]] = addi %[[VAL_69]]#6, %[[VAL_71]] : index
+// CHECK:                 scf.yield %[[VAL_72]] : index
 // CHECK:               } else {
-// CHECK:                 %[[VAL_72:.*]] = cmpi ult, %[[VAL_68]]#1, %[[VAL_31]] : index
-// CHECK:                 %[[VAL_73:.*]] = scf.if %[[VAL_72]] -> (index) {
-// CHECK:                   %[[VAL_74:.*]] = subi %[[VAL_31]], %[[VAL_68]]#1 : index
-// CHECK:                   %[[VAL_75:.*]] = addi %[[VAL_68]]#6, %[[VAL_74]] : index
-// CHECK:                   scf.yield %[[VAL_75]] : index
+// CHECK:                 %[[VAL_73:.*]] = cmpi ult, %[[VAL_69]]#1, %[[VAL_32]] : index
+// CHECK:                 %[[VAL_74:.*]] = scf.if %[[VAL_73]] -> (index) {
+// CHECK:                   %[[VAL_75:.*]] = subi %[[VAL_32]], %[[VAL_69]]#1 : index
+// CHECK:                   %[[VAL_76:.*]] = addi %[[VAL_69]]#6, %[[VAL_75]] : index
+// CHECK:                   scf.yield %[[VAL_76]] : index
 // CHECK:                 } else {
-// CHECK:                   scf.yield %[[VAL_68]]#6 : index
+// CHECK:                   scf.yield %[[VAL_69]]#6 : index
 // CHECK:                 }
-// CHECK:                 scf.yield %[[VAL_76:.*]] : index
+// CHECK:                 scf.yield %[[VAL_77:.*]] : index
 // CHECK:               }
-// CHECK:               %[[VAL_77:.*]] = index_cast %[[VAL_78:.*]] : index to i64
-// CHECK:               scf.yield %[[VAL_77]] : i64
+// CHECK:               %[[VAL_78:.*]] = index_cast %[[VAL_79:.*]] : index to i64
+// CHECK:               scf.yield %[[VAL_78]] : i64
 // CHECK:             }
-// CHECK:             memref.store %[[VAL_79:.*]], %[[VAL_17]]{{\[}}%[[VAL_18]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_80:.*]], %[[VAL_18]]{{\[}}%[[VAL_19]]] : memref<?xi64>
 // CHECK:             scf.yield
 // CHECK:           }
-// CHECK:           memref.store %[[VAL_4]], %[[VAL_17]]{{\[}}%[[VAL_10]]] : memref<?xi64>
-// CHECK:           scf.for %[[VAL_80:.*]] = %[[VAL_2]] to %[[VAL_10]] step %[[VAL_3]] {
-// CHECK:             %[[VAL_81:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_80]]] : memref<?xi64>
-// CHECK:             %[[VAL_82:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_10]]] : memref<?xi64>
-// CHECK:             memref.store %[[VAL_82]], %[[VAL_17]]{{\[}}%[[VAL_80]]] : memref<?xi64>
-// CHECK:             %[[VAL_83:.*]] = addi %[[VAL_82]], %[[VAL_81]] : i64
-// CHECK:             memref.store %[[VAL_83]], %[[VAL_17]]{{\[}}%[[VAL_10]]] : memref<?xi64>
+// CHECK:           memref.store %[[VAL_4]], %[[VAL_18]]{{\[}}%[[VAL_11]]] : memref<?xi64>
+// CHECK:           scf.for %[[VAL_81:.*]] = %[[VAL_2]] to %[[VAL_11]] step %[[VAL_3]] {
+// CHECK:             %[[VAL_82:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_81]]] : memref<?xi64>
+// CHECK:             %[[VAL_83:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_11]]] : memref<?xi64>
+// CHECK:             memref.store %[[VAL_83]], %[[VAL_18]]{{\[}}%[[VAL_81]]] : memref<?xi64>
+// CHECK:             %[[VAL_84:.*]] = addi %[[VAL_83]], %[[VAL_82]] : i64
+// CHECK:             memref.store %[[VAL_84]], %[[VAL_18]]{{\[}}%[[VAL_11]]] : memref<?xi64>
 // CHECK:           }
-// CHECK:           %[[VAL_84:.*]] = sparse_tensor.pointers %[[VAL_9]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_85:.*]] = tensor.dim %[[VAL_9]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_86:.*]] = memref.load %[[VAL_84]]{{\[}}%[[VAL_85]]] : memref<?xi64>
-// CHECK:           %[[VAL_87:.*]] = index_cast %[[VAL_86]] : i64 to index
-// CHECK:           call @matrix_resize_index(%[[VAL_9]], %[[VAL_3]], %[[VAL_87]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @matrix_resize_values(%[[VAL_9]], %[[VAL_87]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
-// CHECK:           %[[VAL_88:.*]] = sparse_tensor.indices %[[VAL_9]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_89:.*]] = sparse_tensor.values %[[VAL_9]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           scf.parallel (%[[VAL_90:.*]]) = (%[[VAL_2]]) to (%[[VAL_10]]) step (%[[VAL_3]]) {
-// CHECK:             %[[VAL_91:.*]] = addi %[[VAL_90]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_92:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_90]]] : memref<?xi64>
-// CHECK:             %[[VAL_93:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_91]]] : memref<?xi64>
-// CHECK:             %[[VAL_94:.*]] = cmpi ne, %[[VAL_92]], %[[VAL_93]] : i64
-// CHECK:             scf.if %[[VAL_94]] {
-// CHECK:               %[[VAL_95:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_90]]] : memref<?xi64>
-// CHECK:               %[[VAL_96:.*]] = index_cast %[[VAL_95]] : i64 to index
-// CHECK:               %[[VAL_97:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_90]]] : memref<?xi64>
-// CHECK:               %[[VAL_98:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_91]]] : memref<?xi64>
-// CHECK:               %[[VAL_99:.*]] = index_cast %[[VAL_97]] : i64 to index
-// CHECK:               %[[VAL_100:.*]] = index_cast %[[VAL_98]] : i64 to index
-// CHECK:               %[[VAL_101:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_90]]] : memref<?xi64>
-// CHECK:               %[[VAL_102:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_91]]] : memref<?xi64>
+// CHECK:           %[[VAL_85:.*]] = sparse_tensor.pointers %[[VAL_10]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_86:.*]] = tensor.dim %[[VAL_10]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_87:.*]] = memref.load %[[VAL_85]]{{\[}}%[[VAL_86]]] : memref<?xi64>
+// CHECK:           %[[VAL_88:.*]] = index_cast %[[VAL_87]] : i64 to index
+// CHECK:           %[[VAL_89:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_10]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_index(%[[VAL_89]], %[[VAL_3]], %[[VAL_88]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_90:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_10]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_values(%[[VAL_90]], %[[VAL_88]]) : (!llvm.ptr<i8>, index) -> ()
+// CHECK:           %[[VAL_91:.*]] = sparse_tensor.indices %[[VAL_10]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_92:.*]] = sparse_tensor.values %[[VAL_10]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           scf.parallel (%[[VAL_93:.*]]) = (%[[VAL_2]]) to (%[[VAL_11]]) step (%[[VAL_3]]) {
+// CHECK:             %[[VAL_94:.*]] = addi %[[VAL_93]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_95:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_93]]] : memref<?xi64>
+// CHECK:             %[[VAL_96:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_94]]] : memref<?xi64>
+// CHECK:             %[[VAL_97:.*]] = cmpi ne, %[[VAL_95]], %[[VAL_96]] : i64
+// CHECK:             scf.if %[[VAL_97]] {
+// CHECK:               %[[VAL_98:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_93]]] : memref<?xi64>
+// CHECK:               %[[VAL_99:.*]] = index_cast %[[VAL_98]] : i64 to index
+// CHECK:               %[[VAL_100:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_93]]] : memref<?xi64>
+// CHECK:               %[[VAL_101:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_94]]] : memref<?xi64>
+// CHECK:               %[[VAL_102:.*]] = index_cast %[[VAL_100]] : i64 to index
 // CHECK:               %[[VAL_103:.*]] = index_cast %[[VAL_101]] : i64 to index
-// CHECK:               %[[VAL_104:.*]] = index_cast %[[VAL_102]] : i64 to index
-// CHECK:               %[[VAL_105:.*]]:9 = scf.while (%[[VAL_106:.*]] = %[[VAL_99]], %[[VAL_107:.*]] = %[[VAL_103]], %[[VAL_108:.*]] = %[[VAL_96]], %[[VAL_109:.*]] = %[[VAL_4]], %[[VAL_110:.*]] = %[[VAL_4]], %[[VAL_111:.*]] = %[[VAL_7]], %[[VAL_112:.*]] = %[[VAL_7]], %[[VAL_113:.*]] = %[[VAL_6]], %[[VAL_114:.*]] = %[[VAL_6]]) : (index, index, index, i64, i64, f64, f64, i1, i1) -> (index, index, index, i64, i64, f64, f64, i1, i1) {
-// CHECK:                 %[[VAL_115:.*]] = cmpi ult, %[[VAL_106]], %[[VAL_100]] : index
-// CHECK:                 %[[VAL_116:.*]] = cmpi ult, %[[VAL_107]], %[[VAL_104]] : index
-// CHECK:                 %[[VAL_117:.*]] = and %[[VAL_115]], %[[VAL_116]] : i1
-// CHECK:                 scf.condition(%[[VAL_117]]) %[[VAL_106]], %[[VAL_107]], %[[VAL_108]], %[[VAL_109]], %[[VAL_110]], %[[VAL_111]], %[[VAL_112]], %[[VAL_113]], %[[VAL_114]] : index, index, index, i64, i64, f64, f64, i1, i1
+// CHECK:               %[[VAL_104:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_93]]] : memref<?xi64>
+// CHECK:               %[[VAL_105:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_94]]] : memref<?xi64>
+// CHECK:               %[[VAL_106:.*]] = index_cast %[[VAL_104]] : i64 to index
+// CHECK:               %[[VAL_107:.*]] = index_cast %[[VAL_105]] : i64 to index
+// CHECK:               %[[VAL_108:.*]]:9 = scf.while (%[[VAL_109:.*]] = %[[VAL_102]], %[[VAL_110:.*]] = %[[VAL_106]], %[[VAL_111:.*]] = %[[VAL_99]], %[[VAL_112:.*]] = %[[VAL_4]], %[[VAL_113:.*]] = %[[VAL_4]], %[[VAL_114:.*]] = %[[VAL_7]], %[[VAL_115:.*]] = %[[VAL_7]], %[[VAL_116:.*]] = %[[VAL_6]], %[[VAL_117:.*]] = %[[VAL_6]]) : (index, index, index, i64, i64, f64, f64, i1, i1) -> (index, index, index, i64, i64, f64, f64, i1, i1) {
+// CHECK:                 %[[VAL_118:.*]] = cmpi ult, %[[VAL_109]], %[[VAL_103]] : index
+// CHECK:                 %[[VAL_119:.*]] = cmpi ult, %[[VAL_110]], %[[VAL_107]] : index
+// CHECK:                 %[[VAL_120:.*]] = and %[[VAL_118]], %[[VAL_119]] : i1
+// CHECK:                 scf.condition(%[[VAL_120]]) %[[VAL_109]], %[[VAL_110]], %[[VAL_111]], %[[VAL_112]], %[[VAL_113]], %[[VAL_114]], %[[VAL_115]], %[[VAL_116]], %[[VAL_117]] : index, index, index, i64, i64, f64, f64, i1, i1
 // CHECK:               } do {
-// CHECK:               ^bb0(%[[VAL_118:.*]]: index, %[[VAL_119:.*]]: index, %[[VAL_120:.*]]: index, %[[VAL_121:.*]]: i64, %[[VAL_122:.*]]: i64, %[[VAL_123:.*]]: f64, %[[VAL_124:.*]]: f64, %[[VAL_125:.*]]: i1, %[[VAL_126:.*]]: i1):
-// CHECK:                 %[[VAL_127:.*]]:2 = scf.if %[[VAL_125]] -> (i64, f64) {
-// CHECK:                   %[[VAL_128:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_118]]] : memref<?xi64>
-// CHECK:                   %[[VAL_129:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_118]]] : memref<?xf64>
-// CHECK:                   scf.yield %[[VAL_128]], %[[VAL_129]] : i64, f64
-// CHECK:                 } else {
-// CHECK:                   scf.yield %[[VAL_121]], %[[VAL_123]] : i64, f64
-// CHECK:                 }
-// CHECK:                 %[[VAL_130:.*]]:2 = scf.if %[[VAL_126]] -> (i64, f64) {
-// CHECK:                   %[[VAL_131:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_119]]] : memref<?xi64>
-// CHECK:                   %[[VAL_132:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_119]]] : memref<?xf64>
+// CHECK:               ^bb0(%[[VAL_121:.*]]: index, %[[VAL_122:.*]]: index, %[[VAL_123:.*]]: index, %[[VAL_124:.*]]: i64, %[[VAL_125:.*]]: i64, %[[VAL_126:.*]]: f64, %[[VAL_127:.*]]: f64, %[[VAL_128:.*]]: i1, %[[VAL_129:.*]]: i1):
+// CHECK:                 %[[VAL_130:.*]]:2 = scf.if %[[VAL_128]] -> (i64, f64) {
+// CHECK:                   %[[VAL_131:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_121]]] : memref<?xi64>
+// CHECK:                   %[[VAL_132:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_121]]] : memref<?xf64>
 // CHECK:                   scf.yield %[[VAL_131]], %[[VAL_132]] : i64, f64
 // CHECK:                 } else {
-// CHECK:                   scf.yield %[[VAL_122]], %[[VAL_124]] : i64, f64
+// CHECK:                   scf.yield %[[VAL_124]], %[[VAL_126]] : i64, f64
 // CHECK:                 }
-// CHECK:                 %[[VAL_133:.*]] = cmpi ult, %[[VAL_134:.*]]#0, %[[VAL_135:.*]]#0 : i64
-// CHECK:                 %[[VAL_136:.*]] = cmpi ugt, %[[VAL_134]]#0, %[[VAL_135]]#0 : i64
-// CHECK:                 %[[VAL_137:.*]] = addi %[[VAL_118]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_138:.*]] = addi %[[VAL_119]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_139:.*]] = addi %[[VAL_120]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_140:.*]]:5 = scf.if %[[VAL_133]] -> (index, index, index, i1, i1) {
-// CHECK:                   memref.store %[[VAL_134]]#0, %[[VAL_88]]{{\[}}%[[VAL_120]]] : memref<?xi64>
-// CHECK:                   memref.store %[[VAL_134]]#1, %[[VAL_89]]{{\[}}%[[VAL_120]]] : memref<?xf64>
-// CHECK:                   scf.yield %[[VAL_137]], %[[VAL_119]], %[[VAL_139]], %[[VAL_6]], %[[VAL_5]] : index, index, index, i1, i1
+// CHECK:                 %[[VAL_133:.*]]:2 = scf.if %[[VAL_129]] -> (i64, f64) {
+// CHECK:                   %[[VAL_134:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_122]]] : memref<?xi64>
+// CHECK:                   %[[VAL_135:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_122]]] : memref<?xf64>
+// CHECK:                   scf.yield %[[VAL_134]], %[[VAL_135]] : i64, f64
 // CHECK:                 } else {
-// CHECK:                   %[[VAL_141:.*]]:5 = scf.if %[[VAL_136]] -> (index, index, index, i1, i1) {
-// CHECK:                     memref.store %[[VAL_135]]#0, %[[VAL_88]]{{\[}}%[[VAL_120]]] : memref<?xi64>
-// CHECK:                     memref.store %[[VAL_135]]#1, %[[VAL_89]]{{\[}}%[[VAL_120]]] : memref<?xf64>
-// CHECK:                     scf.yield %[[VAL_118]], %[[VAL_138]], %[[VAL_139]], %[[VAL_5]], %[[VAL_6]] : index, index, index, i1, i1
+// CHECK:                   scf.yield %[[VAL_125]], %[[VAL_127]] : i64, f64
+// CHECK:                 }
+// CHECK:                 %[[VAL_136:.*]] = cmpi ult, %[[VAL_137:.*]]#0, %[[VAL_138:.*]]#0 : i64
+// CHECK:                 %[[VAL_139:.*]] = cmpi ugt, %[[VAL_137]]#0, %[[VAL_138]]#0 : i64
+// CHECK:                 %[[VAL_140:.*]] = addi %[[VAL_121]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_141:.*]] = addi %[[VAL_122]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_142:.*]] = addi %[[VAL_123]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_143:.*]]:5 = scf.if %[[VAL_136]] -> (index, index, index, i1, i1) {
+// CHECK:                   memref.store %[[VAL_137]]#0, %[[VAL_91]]{{\[}}%[[VAL_123]]] : memref<?xi64>
+// CHECK:                   memref.store %[[VAL_137]]#1, %[[VAL_92]]{{\[}}%[[VAL_123]]] : memref<?xf64>
+// CHECK:                   scf.yield %[[VAL_140]], %[[VAL_122]], %[[VAL_142]], %[[VAL_6]], %[[VAL_5]] : index, index, index, i1, i1
+// CHECK:                 } else {
+// CHECK:                   %[[VAL_144:.*]]:5 = scf.if %[[VAL_139]] -> (index, index, index, i1, i1) {
+// CHECK:                     memref.store %[[VAL_138]]#0, %[[VAL_91]]{{\[}}%[[VAL_123]]] : memref<?xi64>
+// CHECK:                     memref.store %[[VAL_138]]#1, %[[VAL_92]]{{\[}}%[[VAL_123]]] : memref<?xf64>
+// CHECK:                     scf.yield %[[VAL_121]], %[[VAL_141]], %[[VAL_142]], %[[VAL_5]], %[[VAL_6]] : index, index, index, i1, i1
 // CHECK:                   } else {
-// CHECK:                     memref.store %[[VAL_134]]#0, %[[VAL_88]]{{\[}}%[[VAL_120]]] : memref<?xi64>
-// CHECK:                     %[[VAL_142:.*]] = addf %[[VAL_134]]#1, %[[VAL_135]]#1 : f64
-// CHECK:                     memref.store %[[VAL_142]], %[[VAL_89]]{{\[}}%[[VAL_120]]] : memref<?xf64>
-// CHECK:                     scf.yield %[[VAL_137]], %[[VAL_138]], %[[VAL_139]], %[[VAL_6]], %[[VAL_6]] : index, index, index, i1, i1
+// CHECK:                     memref.store %[[VAL_137]]#0, %[[VAL_91]]{{\[}}%[[VAL_123]]] : memref<?xi64>
+// CHECK:                     %[[VAL_145:.*]] = addf %[[VAL_137]]#1, %[[VAL_138]]#1 : f64
+// CHECK:                     memref.store %[[VAL_145]], %[[VAL_92]]{{\[}}%[[VAL_123]]] : memref<?xf64>
+// CHECK:                     scf.yield %[[VAL_140]], %[[VAL_141]], %[[VAL_142]], %[[VAL_6]], %[[VAL_6]] : index, index, index, i1, i1
 // CHECK:                   }
-// CHECK:                   scf.yield %[[VAL_143:.*]]#0, %[[VAL_143]]#1, %[[VAL_143]]#2, %[[VAL_143]]#3, %[[VAL_143]]#4 : index, index, index, i1, i1
+// CHECK:                   scf.yield %[[VAL_146:.*]]#0, %[[VAL_146]]#1, %[[VAL_146]]#2, %[[VAL_146]]#3, %[[VAL_146]]#4 : index, index, index, i1, i1
 // CHECK:                 }
-// CHECK:                 scf.yield %[[VAL_144:.*]]#0, %[[VAL_144]]#1, %[[VAL_144]]#2, %[[VAL_134]]#0, %[[VAL_135]]#0, %[[VAL_134]]#1, %[[VAL_135]]#1, %[[VAL_144]]#3, %[[VAL_144]]#4 : index, index, index, i64, i64, f64, f64, i1, i1
+// CHECK:                 scf.yield %[[VAL_147:.*]]#0, %[[VAL_147]]#1, %[[VAL_147]]#2, %[[VAL_137]]#0, %[[VAL_138]]#0, %[[VAL_137]]#1, %[[VAL_138]]#1, %[[VAL_147]]#3, %[[VAL_147]]#4 : index, index, index, i64, i64, f64, f64, i1, i1
 // CHECK:               }
-// CHECK:               %[[VAL_145:.*]] = cmpi ult, %[[VAL_146:.*]]#0, %[[VAL_100]] : index
-// CHECK:               %[[VAL_147:.*]] = scf.if %[[VAL_145]] -> (index) {
-// CHECK:                 %[[VAL_148:.*]] = scf.for %[[VAL_149:.*]] = %[[VAL_146]]#0 to %[[VAL_100]] step %[[VAL_3]] iter_args(%[[VAL_150:.*]] = %[[VAL_146]]#2) -> (index) {
-// CHECK:                   %[[VAL_151:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_149]]] : memref<?xi64>
-// CHECK:                   %[[VAL_152:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_149]]] : memref<?xf64>
-// CHECK:                   memref.store %[[VAL_151]], %[[VAL_88]]{{\[}}%[[VAL_150]]] : memref<?xi64>
-// CHECK:                   memref.store %[[VAL_152]], %[[VAL_89]]{{\[}}%[[VAL_150]]] : memref<?xf64>
-// CHECK:                   %[[VAL_153:.*]] = addi %[[VAL_150]], %[[VAL_3]] : index
-// CHECK:                   scf.yield %[[VAL_153]] : index
+// CHECK:               %[[VAL_148:.*]] = cmpi ult, %[[VAL_149:.*]]#0, %[[VAL_103]] : index
+// CHECK:               %[[VAL_150:.*]] = scf.if %[[VAL_148]] -> (index) {
+// CHECK:                 %[[VAL_151:.*]] = scf.for %[[VAL_152:.*]] = %[[VAL_149]]#0 to %[[VAL_103]] step %[[VAL_3]] iter_args(%[[VAL_153:.*]] = %[[VAL_149]]#2) -> (index) {
+// CHECK:                   %[[VAL_154:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_152]]] : memref<?xi64>
+// CHECK:                   %[[VAL_155:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_152]]] : memref<?xf64>
+// CHECK:                   memref.store %[[VAL_154]], %[[VAL_91]]{{\[}}%[[VAL_153]]] : memref<?xi64>
+// CHECK:                   memref.store %[[VAL_155]], %[[VAL_92]]{{\[}}%[[VAL_153]]] : memref<?xf64>
+// CHECK:                   %[[VAL_156:.*]] = addi %[[VAL_153]], %[[VAL_3]] : index
+// CHECK:                   scf.yield %[[VAL_156]] : index
 // CHECK:                 }
-// CHECK:                 scf.yield %[[VAL_154:.*]] : index
+// CHECK:                 scf.yield %[[VAL_157:.*]] : index
 // CHECK:               } else {
-// CHECK:                 %[[VAL_155:.*]] = cmpi ult, %[[VAL_146]]#1, %[[VAL_104]] : index
-// CHECK:                 %[[VAL_156:.*]] = scf.if %[[VAL_155]] -> (index) {
-// CHECK:                   %[[VAL_157:.*]] = scf.for %[[VAL_158:.*]] = %[[VAL_146]]#1 to %[[VAL_104]] step %[[VAL_3]] iter_args(%[[VAL_159:.*]] = %[[VAL_146]]#2) -> (index) {
-// CHECK:                     %[[VAL_160:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_158]]] : memref<?xi64>
-// CHECK:                     %[[VAL_161:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_158]]] : memref<?xf64>
-// CHECK:                     memref.store %[[VAL_160]], %[[VAL_88]]{{\[}}%[[VAL_159]]] : memref<?xi64>
-// CHECK:                     memref.store %[[VAL_161]], %[[VAL_89]]{{\[}}%[[VAL_159]]] : memref<?xf64>
-// CHECK:                     %[[VAL_162:.*]] = addi %[[VAL_159]], %[[VAL_3]] : index
-// CHECK:                     scf.yield %[[VAL_162]] : index
+// CHECK:                 %[[VAL_158:.*]] = cmpi ult, %[[VAL_149]]#1, %[[VAL_107]] : index
+// CHECK:                 %[[VAL_159:.*]] = scf.if %[[VAL_158]] -> (index) {
+// CHECK:                   %[[VAL_160:.*]] = scf.for %[[VAL_161:.*]] = %[[VAL_149]]#1 to %[[VAL_107]] step %[[VAL_3]] iter_args(%[[VAL_162:.*]] = %[[VAL_149]]#2) -> (index) {
+// CHECK:                     %[[VAL_163:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_161]]] : memref<?xi64>
+// CHECK:                     %[[VAL_164:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_161]]] : memref<?xf64>
+// CHECK:                     memref.store %[[VAL_163]], %[[VAL_91]]{{\[}}%[[VAL_162]]] : memref<?xi64>
+// CHECK:                     memref.store %[[VAL_164]], %[[VAL_92]]{{\[}}%[[VAL_162]]] : memref<?xf64>
+// CHECK:                     %[[VAL_165:.*]] = addi %[[VAL_162]], %[[VAL_3]] : index
+// CHECK:                     scf.yield %[[VAL_165]] : index
 // CHECK:                   }
-// CHECK:                   scf.yield %[[VAL_163:.*]] : index
+// CHECK:                   scf.yield %[[VAL_166:.*]] : index
 // CHECK:                 } else {
-// CHECK:                   scf.yield %[[VAL_146]]#2 : index
+// CHECK:                   scf.yield %[[VAL_149]]#2 : index
 // CHECK:                 }
-// CHECK:                 scf.yield %[[VAL_164:.*]] : index
+// CHECK:                 scf.yield %[[VAL_167:.*]] : index
 // CHECK:               }
 // CHECK:             }
 // CHECK:             scf.yield
 // CHECK:           }
-// CHECK:           %[[VAL_165:.*]] = call @cast_csx_to_csr(%[[VAL_9]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           return %[[VAL_165]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           return %[[VAL_10]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
 
 func @matrix_union(%a: tensor<?x?xf64, #CSR64>, %b: tensor<?x?xf64, #CSR64>) -> tensor<?x?xf64, #CSR64> {

--- a/mlir_graphblas/src/test/GraphBLAS/lower_vector_matrix_multiply_full.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_vector_matrix_multiply_full.mlir
@@ -13,12 +13,6 @@
   indexBitWidth = 64
 }>
 
-// CHECK-DAG:     func private @vector_resize_values(tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index)
-// CHECK-DAG:     func private @vector_resize_index(tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK-DAG:     func private @vector_resize_pointers(tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK-DAG:     func private @vector_resize_dim(tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK-DAG:     func private @vector_empty_like(tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-
 // CHECK-LABEL:   func @vector_matrix_multiply_plus_times(
 // CHECK-SAME:                                            %[[VAL_0:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                                            %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
@@ -32,124 +26,130 @@
 // CHECK-DAG:       %[[VAL_9:.*]] = constant 0.000000e+00 : f64
 // CHECK:           %[[VAL_10:.*]] = tensor.dim %[[VAL_1]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_11:.*]] = tensor.dim %[[VAL_0]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_12:.*]] = call @vector_empty_like(%[[VAL_0]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @vector_resize_dim(%[[VAL_12]], %[[VAL_5]], %[[VAL_10]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @vector_resize_pointers(%[[VAL_12]], %[[VAL_5]], %[[VAL_2]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           %[[VAL_13:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_14:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_15:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_16:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_17:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_18:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_19:.*]] = sparse_tensor.pointers %[[VAL_12]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_20:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_6]]] : memref<?xi64>
-// CHECK:           %[[VAL_21:.*]] = index_cast %[[VAL_20]] : i64 to index
-// CHECK:           %[[VAL_22:.*]] = cmpi eq, %[[VAL_5]], %[[VAL_21]] : index
-// CHECK:           %[[VAL_23:.*]] = scf.if %[[VAL_22]] -> (i64) {
+// CHECK:           %[[VAL_12:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_13:.*]] = call @empty_like(%[[VAL_12]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_14:.*]] = call @ptr8_to_vector_f64_p64i64(%[[VAL_13]]) : (!llvm.ptr<i8>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_15:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_14]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_dim(%[[VAL_15]], %[[VAL_5]], %[[VAL_10]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_16:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_14]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_pointers(%[[VAL_16]], %[[VAL_5]], %[[VAL_2]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_17:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_18:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_19:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_20:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_21:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_22:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_23:.*]] = sparse_tensor.pointers %[[VAL_14]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_24:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_6]]] : memref<?xi64>
+// CHECK:           %[[VAL_25:.*]] = index_cast %[[VAL_24]] : i64 to index
+// CHECK:           %[[VAL_26:.*]] = cmpi eq, %[[VAL_5]], %[[VAL_25]] : index
+// CHECK:           %[[VAL_27:.*]] = scf.if %[[VAL_26]] -> (i64) {
 // CHECK:             scf.yield %[[VAL_3]] : i64
 // CHECK:           } else {
-// CHECK:             %[[VAL_24:.*]] = memref.alloc(%[[VAL_11]]) : memref<?xi1>
-// CHECK:             linalg.fill(%[[VAL_8]], %[[VAL_24]]) : i1, memref<?xi1>
-// CHECK:             scf.parallel (%[[VAL_25:.*]]) = (%[[VAL_5]]) to (%[[VAL_21]]) step (%[[VAL_6]]) {
-// CHECK:               %[[VAL_26:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_25]]] : memref<?xi64>
-// CHECK:               %[[VAL_27:.*]] = index_cast %[[VAL_26]] : i64 to index
-// CHECK:               memref.store %[[VAL_7]], %[[VAL_24]]{{\[}}%[[VAL_27]]] : memref<?xi1>
+// CHECK:             %[[VAL_28:.*]] = memref.alloc(%[[VAL_11]]) : memref<?xi1>
+// CHECK:             linalg.fill(%[[VAL_8]], %[[VAL_28]]) : i1, memref<?xi1>
+// CHECK:             scf.parallel (%[[VAL_29:.*]]) = (%[[VAL_5]]) to (%[[VAL_25]]) step (%[[VAL_6]]) {
+// CHECK:               %[[VAL_30:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_29]]] : memref<?xi64>
+// CHECK:               %[[VAL_31:.*]] = index_cast %[[VAL_30]] : i64 to index
+// CHECK:               memref.store %[[VAL_7]], %[[VAL_28]]{{\[}}%[[VAL_31]]] : memref<?xi1>
 // CHECK:               scf.yield
 // CHECK:             }
-// CHECK:             %[[VAL_28:.*]] = scf.parallel (%[[VAL_29:.*]]) = (%[[VAL_5]]) to (%[[VAL_10]]) step (%[[VAL_6]]) init (%[[VAL_3]]) -> i64 {
-// CHECK:               %[[VAL_30:.*]] = addi %[[VAL_29]], %[[VAL_6]] : index
-// CHECK:               %[[VAL_31:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_29]]] : memref<?xi64>
-// CHECK:               %[[VAL_32:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_30]]] : memref<?xi64>
-// CHECK:               %[[VAL_33:.*]] = cmpi eq, %[[VAL_31]], %[[VAL_32]] : i64
-// CHECK:               %[[VAL_34:.*]] = scf.if %[[VAL_33]] -> (i64) {
+// CHECK:             %[[VAL_32:.*]] = scf.parallel (%[[VAL_33:.*]]) = (%[[VAL_5]]) to (%[[VAL_10]]) step (%[[VAL_6]]) init (%[[VAL_3]]) -> i64 {
+// CHECK:               %[[VAL_34:.*]] = addi %[[VAL_33]], %[[VAL_6]] : index
+// CHECK:               %[[VAL_35:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_33]]] : memref<?xi64>
+// CHECK:               %[[VAL_36:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_34]]] : memref<?xi64>
+// CHECK:               %[[VAL_37:.*]] = cmpi eq, %[[VAL_35]], %[[VAL_36]] : i64
+// CHECK:               %[[VAL_38:.*]] = scf.if %[[VAL_37]] -> (i64) {
 // CHECK:                 scf.yield %[[VAL_3]] : i64
 // CHECK:               } else {
-// CHECK:                 %[[VAL_35:.*]] = scf.while (%[[VAL_36:.*]] = %[[VAL_31]]) : (i64) -> i64 {
-// CHECK:                   %[[VAL_37:.*]] = cmpi uge, %[[VAL_36]], %[[VAL_32]] : i64
-// CHECK:                   %[[VAL_38:.*]]:2 = scf.if %[[VAL_37]] -> (i1, i64) {
+// CHECK:                 %[[VAL_39:.*]] = scf.while (%[[VAL_40:.*]] = %[[VAL_35]]) : (i64) -> i64 {
+// CHECK:                   %[[VAL_41:.*]] = cmpi uge, %[[VAL_40]], %[[VAL_36]] : i64
+// CHECK:                   %[[VAL_42:.*]]:2 = scf.if %[[VAL_41]] -> (i1, i64) {
 // CHECK:                     scf.yield %[[VAL_8]], %[[VAL_3]] : i1, i64
 // CHECK:                   } else {
-// CHECK:                     %[[VAL_39:.*]] = index_cast %[[VAL_36]] : i64 to index
-// CHECK:                     %[[VAL_40:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_39]]] : memref<?xi64>
-// CHECK:                     %[[VAL_41:.*]] = index_cast %[[VAL_40]] : i64 to index
-// CHECK:                     %[[VAL_42:.*]] = memref.load %[[VAL_24]]{{\[}}%[[VAL_41]]] : memref<?xi1>
-// CHECK:                     %[[VAL_43:.*]] = select %[[VAL_42]], %[[VAL_8]], %[[VAL_7]] : i1
-// CHECK:                     %[[VAL_44:.*]] = select %[[VAL_42]], %[[VAL_4]], %[[VAL_36]] : i64
-// CHECK:                     scf.yield %[[VAL_43]], %[[VAL_44]] : i1, i64
+// CHECK:                     %[[VAL_43:.*]] = index_cast %[[VAL_40]] : i64 to index
+// CHECK:                     %[[VAL_44:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_43]]] : memref<?xi64>
+// CHECK:                     %[[VAL_45:.*]] = index_cast %[[VAL_44]] : i64 to index
+// CHECK:                     %[[VAL_46:.*]] = memref.load %[[VAL_28]]{{\[}}%[[VAL_45]]] : memref<?xi1>
+// CHECK:                     %[[VAL_47:.*]] = select %[[VAL_46]], %[[VAL_8]], %[[VAL_7]] : i1
+// CHECK:                     %[[VAL_48:.*]] = select %[[VAL_46]], %[[VAL_4]], %[[VAL_40]] : i64
+// CHECK:                     scf.yield %[[VAL_47]], %[[VAL_48]] : i1, i64
 // CHECK:                   }
-// CHECK:                   scf.condition(%[[VAL_45:.*]]#0) %[[VAL_45]]#1 : i64
+// CHECK:                   scf.condition(%[[VAL_49:.*]]#0) %[[VAL_49]]#1 : i64
 // CHECK:                 } do {
-// CHECK:                 ^bb0(%[[VAL_46:.*]]: i64):
-// CHECK:                   %[[VAL_47:.*]] = addi %[[VAL_46]], %[[VAL_4]] : i64
-// CHECK:                   scf.yield %[[VAL_47]] : i64
+// CHECK:                 ^bb0(%[[VAL_50:.*]]: i64):
+// CHECK:                   %[[VAL_51:.*]] = addi %[[VAL_50]], %[[VAL_4]] : i64
+// CHECK:                   scf.yield %[[VAL_51]] : i64
 // CHECK:                 }
-// CHECK:                 scf.yield %[[VAL_48:.*]] : i64
+// CHECK:                 scf.yield %[[VAL_52:.*]] : i64
 // CHECK:               }
-// CHECK:               scf.reduce(%[[VAL_49:.*]])  : i64 {
-// CHECK:               ^bb0(%[[VAL_50:.*]]: i64, %[[VAL_51:.*]]: i64):
-// CHECK:                 %[[VAL_52:.*]] = addi %[[VAL_50]], %[[VAL_51]] : i64
-// CHECK:                 scf.reduce.return %[[VAL_52]] : i64
+// CHECK:               scf.reduce(%[[VAL_53:.*]])  : i64 {
+// CHECK:               ^bb0(%[[VAL_54:.*]]: i64, %[[VAL_55:.*]]: i64):
+// CHECK:                 %[[VAL_56:.*]] = addi %[[VAL_54]], %[[VAL_55]] : i64
+// CHECK:                 scf.reduce.return %[[VAL_56]] : i64
 // CHECK:               }
 // CHECK:               scf.yield
 // CHECK:             }
-// CHECK:             memref.dealloc %[[VAL_24]] : memref<?xi1>
-// CHECK:             scf.yield %[[VAL_28]] : i64
+// CHECK:             memref.dealloc %[[VAL_28]] : memref<?xi1>
+// CHECK:             scf.yield %[[VAL_57:.*]] : i64
 // CHECK:           }
-// CHECK:           %[[VAL_54:.*]] = index_cast %[[VAL_23]] : i64 to index
-// CHECK:           memref.store %[[VAL_23]], %[[VAL_19]]{{\[}}%[[VAL_6]]] : memref<?xi64>
-// CHECK:           call @vector_resize_index(%[[VAL_12]], %[[VAL_5]], %[[VAL_54]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @vector_resize_values(%[[VAL_12]], %[[VAL_54]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
-// CHECK:           %[[VAL_56:.*]] = sparse_tensor.indices %[[VAL_12]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_57:.*]] = sparse_tensor.values %[[VAL_12]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_58:.*]] = cmpi ne, %[[VAL_5]], %[[VAL_54]] : index
-// CHECK:           scf.if %[[VAL_58]] {
-// CHECK:             %[[VAL_59:.*]] = memref.alloc(%[[VAL_11]]) : memref<?xf64>
-// CHECK:             %[[VAL_60:.*]] = memref.alloc(%[[VAL_11]]) : memref<?xi1>
-// CHECK:             linalg.fill(%[[VAL_8]], %[[VAL_60]]) : i1, memref<?xi1>
-// CHECK:             scf.parallel (%[[VAL_61:.*]]) = (%[[VAL_5]]) to (%[[VAL_21]]) step (%[[VAL_6]]) {
-// CHECK:               %[[VAL_62:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_61]]] : memref<?xi64>
-// CHECK:               %[[VAL_63:.*]] = index_cast %[[VAL_62]] : i64 to index
-// CHECK:               memref.store %[[VAL_7]], %[[VAL_60]]{{\[}}%[[VAL_63]]] : memref<?xi1>
-// CHECK:               %[[VAL_64:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_61]]] : memref<?xf64>
-// CHECK:               memref.store %[[VAL_64]], %[[VAL_59]]{{\[}}%[[VAL_63]]] : memref<?xf64>
+// CHECK:           %[[VAL_58:.*]] = index_cast %[[VAL_59:.*]] : i64 to index
+// CHECK:           memref.store %[[VAL_59]], %[[VAL_23]]{{\[}}%[[VAL_6]]] : memref<?xi64>
+// CHECK:           %[[VAL_60:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_14]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_index(%[[VAL_60]], %[[VAL_5]], %[[VAL_58]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_61:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_14]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_values(%[[VAL_61]], %[[VAL_58]]) : (!llvm.ptr<i8>, index) -> ()
+// CHECK:           %[[VAL_62:.*]] = sparse_tensor.indices %[[VAL_14]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_63:.*]] = sparse_tensor.values %[[VAL_14]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_64:.*]] = cmpi ne, %[[VAL_5]], %[[VAL_58]] : index
+// CHECK:           scf.if %[[VAL_64]] {
+// CHECK:             %[[VAL_65:.*]] = memref.alloc(%[[VAL_11]]) : memref<?xf64>
+// CHECK:             %[[VAL_66:.*]] = memref.alloc(%[[VAL_11]]) : memref<?xi1>
+// CHECK:             linalg.fill(%[[VAL_8]], %[[VAL_66]]) : i1, memref<?xi1>
+// CHECK:             scf.parallel (%[[VAL_67:.*]]) = (%[[VAL_5]]) to (%[[VAL_25]]) step (%[[VAL_6]]) {
+// CHECK:               %[[VAL_68:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_67]]] : memref<?xi64>
+// CHECK:               %[[VAL_69:.*]] = index_cast %[[VAL_68]] : i64 to index
+// CHECK:               memref.store %[[VAL_7]], %[[VAL_66]]{{\[}}%[[VAL_69]]] : memref<?xi1>
+// CHECK:               %[[VAL_70:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_67]]] : memref<?xf64>
+// CHECK:               memref.store %[[VAL_70]], %[[VAL_65]]{{\[}}%[[VAL_69]]] : memref<?xf64>
 // CHECK:               scf.yield
 // CHECK:             }
-// CHECK:             %[[VAL_65:.*]] = scf.for %[[VAL_66:.*]] = %[[VAL_5]] to %[[VAL_10]] step %[[VAL_6]] iter_args(%[[VAL_67:.*]] = %[[VAL_5]]) -> (index) {
-// CHECK:               %[[VAL_68:.*]] = index_cast %[[VAL_66]] : index to i64
-// CHECK:               %[[VAL_69:.*]] = addi %[[VAL_66]], %[[VAL_6]] : index
-// CHECK:               %[[VAL_70:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_66]]] : memref<?xi64>
-// CHECK:               %[[VAL_71:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_69]]] : memref<?xi64>
-// CHECK:               %[[VAL_72:.*]] = index_cast %[[VAL_70]] : i64 to index
-// CHECK:               %[[VAL_73:.*]] = index_cast %[[VAL_71]] : i64 to index
-// CHECK:               %[[VAL_74:.*]]:2 = scf.for %[[VAL_75:.*]] = %[[VAL_72]] to %[[VAL_73]] step %[[VAL_6]] iter_args(%[[VAL_76:.*]] = %[[VAL_9]], %[[VAL_77:.*]] = %[[VAL_8]]) -> (f64, i1) {
-// CHECK:                 %[[VAL_78:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_75]]] : memref<?xi64>
-// CHECK:                 %[[VAL_79:.*]] = index_cast %[[VAL_78]] : i64 to index
-// CHECK:                 %[[VAL_80:.*]] = memref.load %[[VAL_60]]{{\[}}%[[VAL_79]]] : memref<?xi1>
-// CHECK:                 %[[VAL_81:.*]]:2 = scf.if %[[VAL_80]] -> (f64, i1) {
-// CHECK:                   %[[VAL_82:.*]] = memref.load %[[VAL_59]]{{\[}}%[[VAL_79]]] : memref<?xf64>
-// CHECK:                   %[[VAL_83:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_75]]] : memref<?xf64>
-// CHECK:                   %[[VAL_84:.*]] = mulf %[[VAL_82]], %[[VAL_83]] : f64
-// CHECK:                   %[[VAL_85:.*]] = addf %[[VAL_76]], %[[VAL_84]] : f64
-// CHECK:                   scf.yield %[[VAL_85]], %[[VAL_7]] : f64, i1
+// CHECK:             %[[VAL_71:.*]] = scf.for %[[VAL_72:.*]] = %[[VAL_5]] to %[[VAL_10]] step %[[VAL_6]] iter_args(%[[VAL_73:.*]] = %[[VAL_5]]) -> (index) {
+// CHECK:               %[[VAL_74:.*]] = index_cast %[[VAL_72]] : index to i64
+// CHECK:               %[[VAL_75:.*]] = addi %[[VAL_72]], %[[VAL_6]] : index
+// CHECK:               %[[VAL_76:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_72]]] : memref<?xi64>
+// CHECK:               %[[VAL_77:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_75]]] : memref<?xi64>
+// CHECK:               %[[VAL_78:.*]] = index_cast %[[VAL_76]] : i64 to index
+// CHECK:               %[[VAL_79:.*]] = index_cast %[[VAL_77]] : i64 to index
+// CHECK:               %[[VAL_80:.*]]:2 = scf.for %[[VAL_81:.*]] = %[[VAL_78]] to %[[VAL_79]] step %[[VAL_6]] iter_args(%[[VAL_82:.*]] = %[[VAL_9]], %[[VAL_83:.*]] = %[[VAL_8]]) -> (f64, i1) {
+// CHECK:                 %[[VAL_84:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_81]]] : memref<?xi64>
+// CHECK:                 %[[VAL_85:.*]] = index_cast %[[VAL_84]] : i64 to index
+// CHECK:                 %[[VAL_86:.*]] = memref.load %[[VAL_66]]{{\[}}%[[VAL_85]]] : memref<?xi1>
+// CHECK:                 %[[VAL_87:.*]]:2 = scf.if %[[VAL_86]] -> (f64, i1) {
+// CHECK:                   %[[VAL_88:.*]] = memref.load %[[VAL_65]]{{\[}}%[[VAL_85]]] : memref<?xf64>
+// CHECK:                   %[[VAL_89:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_81]]] : memref<?xf64>
+// CHECK:                   %[[VAL_90:.*]] = mulf %[[VAL_88]], %[[VAL_89]] : f64
+// CHECK:                   %[[VAL_91:.*]] = addf %[[VAL_82]], %[[VAL_90]] : f64
+// CHECK:                   scf.yield %[[VAL_91]], %[[VAL_7]] : f64, i1
 // CHECK:                 } else {
-// CHECK:                   scf.yield %[[VAL_76]], %[[VAL_77]] : f64, i1
+// CHECK:                   scf.yield %[[VAL_82]], %[[VAL_83]] : f64, i1
 // CHECK:                 }
-// CHECK:                 scf.yield %[[VAL_86:.*]]#0, %[[VAL_86]]#1 : f64, i1
+// CHECK:                 scf.yield %[[VAL_92:.*]]#0, %[[VAL_92]]#1 : f64, i1
 // CHECK:               }
-// CHECK:               %[[VAL_87:.*]] = scf.if %[[VAL_88:.*]]#1 -> (index) {
-// CHECK:                 memref.store %[[VAL_68]], %[[VAL_56]]{{\[}}%[[VAL_67]]] : memref<?xi64>
-// CHECK:                 memref.store %[[VAL_88]]#0, %[[VAL_57]]{{\[}}%[[VAL_67]]] : memref<?xf64>
-// CHECK:                 %[[VAL_89:.*]] = addi %[[VAL_67]], %[[VAL_6]] : index
-// CHECK:                 scf.yield %[[VAL_89]] : index
+// CHECK:               %[[VAL_93:.*]] = scf.if %[[VAL_94:.*]]#1 -> (index) {
+// CHECK:                 memref.store %[[VAL_74]], %[[VAL_62]]{{\[}}%[[VAL_73]]] : memref<?xi64>
+// CHECK:                 memref.store %[[VAL_94]]#0, %[[VAL_63]]{{\[}}%[[VAL_73]]] : memref<?xf64>
+// CHECK:                 %[[VAL_95:.*]] = addi %[[VAL_73]], %[[VAL_6]] : index
+// CHECK:                 scf.yield %[[VAL_95]] : index
 // CHECK:               } else {
-// CHECK:                 scf.yield %[[VAL_67]] : index
+// CHECK:                 scf.yield %[[VAL_73]] : index
 // CHECK:               }
-// CHECK:               scf.yield %[[VAL_90:.*]] : index
+// CHECK:               scf.yield %[[VAL_96:.*]] : index
 // CHECK:             }
-// CHECK:             memref.dealloc %[[VAL_59]] : memref<?xf64>
-// CHECK:             memref.dealloc %[[VAL_60]] : memref<?xi1>
+// CHECK:             memref.dealloc %[[VAL_65]] : memref<?xf64>
+// CHECK:             memref.dealloc %[[VAL_66]] : memref<?xi1>
 // CHECK:           }
-// CHECK:           return %[[VAL_12]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           return %[[VAL_14]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
 
 

--- a/mlir_graphblas/src/test/GraphBLAS/lower_vector_update_accumulate.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_vector_update_accumulate.mlir
@@ -6,11 +6,6 @@
   indexBitWidth = 64
 }>
 
-// CHECK-DAG:     func private @delSparseVector(tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>)
-// CHECK-DAG:     func private @vector_resize_values(tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index)
-// CHECK-DAG:     func private @vector_resize_index(tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK-DAG:     func private @dup_vector(tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-
 // CHECK-LABEL:   func @vector_update_accumulate(
 // CHECK-SAME:                                   %[[VAL_0:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                                   %[[VAL_1:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> index {
@@ -20,153 +15,158 @@
 // CHECK-DAG:       %[[VAL_5:.*]] = constant false
 // CHECK-DAG:       %[[VAL_6:.*]] = constant true
 // CHECK-DAG:       %[[VAL_7:.*]] = constant 0.000000e+00 : f64
-// CHECK:           %[[VAL_8:.*]] = call @dup_vector(%[[VAL_1]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_9:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_10:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_3]]] : memref<?xi64>
-// CHECK:           %[[VAL_11:.*]] = index_cast %[[VAL_10]] : i64 to index
-// CHECK:           %[[VAL_12:.*]] = sparse_tensor.pointers %[[VAL_8]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_13:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_3]]] : memref<?xi64>
-// CHECK:           %[[VAL_14:.*]] = index_cast %[[VAL_13]] : i64 to index
-// CHECK:           %[[VAL_15:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_16:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_17:.*]] = sparse_tensor.indices %[[VAL_8]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_18:.*]] = sparse_tensor.values %[[VAL_8]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_19:.*]]:7 = scf.while (%[[VAL_20:.*]] = %[[VAL_2]], %[[VAL_21:.*]] = %[[VAL_2]], %[[VAL_22:.*]] = %[[VAL_2]], %[[VAL_23:.*]] = %[[VAL_2]], %[[VAL_24:.*]] = %[[VAL_6]], %[[VAL_25:.*]] = %[[VAL_6]], %[[VAL_26:.*]] = %[[VAL_2]]) : (index, index, index, index, i1, i1, index) -> (index, index, index, index, i1, i1, index) {
-// CHECK:             %[[VAL_27:.*]] = cmpi ult, %[[VAL_20]], %[[VAL_11]] : index
-// CHECK:             %[[VAL_28:.*]] = cmpi ult, %[[VAL_21]], %[[VAL_14]] : index
-// CHECK:             %[[VAL_29:.*]] = and %[[VAL_27]], %[[VAL_28]] : i1
-// CHECK:             scf.condition(%[[VAL_29]]) %[[VAL_20]], %[[VAL_21]], %[[VAL_22]], %[[VAL_23]], %[[VAL_24]], %[[VAL_25]], %[[VAL_26]] : index, index, index, index, i1, i1, index
+// CHECK:           %[[VAL_8:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_1]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_9:.*]] = call @dup_tensor(%[[VAL_8]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_10:.*]] = call @ptr8_to_vector_f64_p64i64(%[[VAL_9]]) : (!llvm.ptr<i8>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_11:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_12:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_3]]] : memref<?xi64>
+// CHECK:           %[[VAL_13:.*]] = index_cast %[[VAL_12]] : i64 to index
+// CHECK:           %[[VAL_14:.*]] = sparse_tensor.pointers %[[VAL_10]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_15:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_3]]] : memref<?xi64>
+// CHECK:           %[[VAL_16:.*]] = index_cast %[[VAL_15]] : i64 to index
+// CHECK:           %[[VAL_17:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_18:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_19:.*]] = sparse_tensor.indices %[[VAL_10]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_20:.*]] = sparse_tensor.values %[[VAL_10]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_21:.*]]:7 = scf.while (%[[VAL_22:.*]] = %[[VAL_2]], %[[VAL_23:.*]] = %[[VAL_2]], %[[VAL_24:.*]] = %[[VAL_2]], %[[VAL_25:.*]] = %[[VAL_2]], %[[VAL_26:.*]] = %[[VAL_6]], %[[VAL_27:.*]] = %[[VAL_6]], %[[VAL_28:.*]] = %[[VAL_2]]) : (index, index, index, index, i1, i1, index) -> (index, index, index, index, i1, i1, index) {
+// CHECK:             %[[VAL_29:.*]] = cmpi ult, %[[VAL_22]], %[[VAL_13]] : index
+// CHECK:             %[[VAL_30:.*]] = cmpi ult, %[[VAL_23]], %[[VAL_16]] : index
+// CHECK:             %[[VAL_31:.*]] = and %[[VAL_29]], %[[VAL_30]] : i1
+// CHECK:             scf.condition(%[[VAL_31]]) %[[VAL_22]], %[[VAL_23]], %[[VAL_24]], %[[VAL_25]], %[[VAL_26]], %[[VAL_27]], %[[VAL_28]] : index, index, index, index, i1, i1, index
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_30:.*]]: index, %[[VAL_31:.*]]: index, %[[VAL_32:.*]]: index, %[[VAL_33:.*]]: index, %[[VAL_34:.*]]: i1, %[[VAL_35:.*]]: i1, %[[VAL_36:.*]]: index):
-// CHECK:             %[[VAL_37:.*]] = scf.if %[[VAL_34]] -> (index) {
-// CHECK:               %[[VAL_38:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_30]]] : memref<?xi64>
-// CHECK:               %[[VAL_39:.*]] = index_cast %[[VAL_38]] : i64 to index
-// CHECK:               scf.yield %[[VAL_39]] : index
+// CHECK:           ^bb0(%[[VAL_32:.*]]: index, %[[VAL_33:.*]]: index, %[[VAL_34:.*]]: index, %[[VAL_35:.*]]: index, %[[VAL_36:.*]]: i1, %[[VAL_37:.*]]: i1, %[[VAL_38:.*]]: index):
+// CHECK:             %[[VAL_39:.*]] = scf.if %[[VAL_36]] -> (index) {
+// CHECK:               %[[VAL_40:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_32]]] : memref<?xi64>
+// CHECK:               %[[VAL_41:.*]] = index_cast %[[VAL_40]] : i64 to index
+// CHECK:               scf.yield %[[VAL_41]] : index
 // CHECK:             } else {
-// CHECK:               scf.yield %[[VAL_32]] : index
+// CHECK:               scf.yield %[[VAL_34]] : index
 // CHECK:             }
-// CHECK:             %[[VAL_40:.*]] = scf.if %[[VAL_35]] -> (index) {
-// CHECK:               %[[VAL_41:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_31]]] : memref<?xi64>
-// CHECK:               %[[VAL_42:.*]] = index_cast %[[VAL_41]] : i64 to index
-// CHECK:               scf.yield %[[VAL_42]] : index
+// CHECK:             %[[VAL_42:.*]] = scf.if %[[VAL_37]] -> (index) {
+// CHECK:               %[[VAL_43:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_33]]] : memref<?xi64>
+// CHECK:               %[[VAL_44:.*]] = index_cast %[[VAL_43]] : i64 to index
+// CHECK:               scf.yield %[[VAL_44]] : index
 // CHECK:             } else {
-// CHECK:               scf.yield %[[VAL_33]] : index
+// CHECK:               scf.yield %[[VAL_35]] : index
 // CHECK:             }
-// CHECK:             %[[VAL_43:.*]] = cmpi ult, %[[VAL_44:.*]], %[[VAL_45:.*]] : index
-// CHECK:             %[[VAL_46:.*]] = cmpi ugt, %[[VAL_44]], %[[VAL_45]] : index
-// CHECK:             %[[VAL_47:.*]] = addi %[[VAL_30]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_48:.*]] = addi %[[VAL_31]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_49:.*]] = addi %[[VAL_36]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_50:.*]]:5 = scf.if %[[VAL_43]] -> (index, index, i1, i1, index) {
-// CHECK:               scf.yield %[[VAL_47]], %[[VAL_31]], %[[VAL_6]], %[[VAL_5]], %[[VAL_49]] : index, index, i1, i1, index
+// CHECK:             %[[VAL_45:.*]] = cmpi ult, %[[VAL_46:.*]], %[[VAL_47:.*]] : index
+// CHECK:             %[[VAL_48:.*]] = cmpi ugt, %[[VAL_46]], %[[VAL_47]] : index
+// CHECK:             %[[VAL_49:.*]] = addi %[[VAL_32]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_50:.*]] = addi %[[VAL_33]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_51:.*]] = addi %[[VAL_38]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_52:.*]]:5 = scf.if %[[VAL_45]] -> (index, index, i1, i1, index) {
+// CHECK:               scf.yield %[[VAL_49]], %[[VAL_33]], %[[VAL_6]], %[[VAL_5]], %[[VAL_51]] : index, index, i1, i1, index
 // CHECK:             } else {
-// CHECK:               %[[VAL_51:.*]]:5 = scf.if %[[VAL_46]] -> (index, index, i1, i1, index) {
-// CHECK:                 scf.yield %[[VAL_30]], %[[VAL_48]], %[[VAL_5]], %[[VAL_6]], %[[VAL_49]] : index, index, i1, i1, index
+// CHECK:               %[[VAL_53:.*]]:5 = scf.if %[[VAL_48]] -> (index, index, i1, i1, index) {
+// CHECK:                 scf.yield %[[VAL_32]], %[[VAL_50]], %[[VAL_5]], %[[VAL_6]], %[[VAL_51]] : index, index, i1, i1, index
 // CHECK:               } else {
-// CHECK:                 scf.yield %[[VAL_47]], %[[VAL_48]], %[[VAL_6]], %[[VAL_6]], %[[VAL_49]] : index, index, i1, i1, index
+// CHECK:                 scf.yield %[[VAL_49]], %[[VAL_50]], %[[VAL_6]], %[[VAL_6]], %[[VAL_51]] : index, index, i1, i1, index
 // CHECK:               }
-// CHECK:               scf.yield %[[VAL_52:.*]]#0, %[[VAL_52]]#1, %[[VAL_52]]#2, %[[VAL_52]]#3, %[[VAL_52]]#4 : index, index, i1, i1, index
+// CHECK:               scf.yield %[[VAL_54:.*]]#0, %[[VAL_54]]#1, %[[VAL_54]]#2, %[[VAL_54]]#3, %[[VAL_54]]#4 : index, index, i1, i1, index
 // CHECK:             }
-// CHECK:             scf.yield %[[VAL_53:.*]]#0, %[[VAL_53]]#1, %[[VAL_44]], %[[VAL_45]], %[[VAL_53]]#2, %[[VAL_53]]#3, %[[VAL_53]]#4 : index, index, index, index, i1, i1, index
+// CHECK:             scf.yield %[[VAL_55:.*]]#0, %[[VAL_55]]#1, %[[VAL_46]], %[[VAL_47]], %[[VAL_55]]#2, %[[VAL_55]]#3, %[[VAL_55]]#4 : index, index, index, index, i1, i1, index
 // CHECK:           }
-// CHECK:           %[[VAL_54:.*]] = cmpi ult, %[[VAL_55:.*]]#0, %[[VAL_11]] : index
-// CHECK:           %[[VAL_56:.*]] = scf.if %[[VAL_54]] -> (index) {
-// CHECK:             %[[VAL_57:.*]] = subi %[[VAL_11]], %[[VAL_55]]#0 : index
-// CHECK:             %[[VAL_58:.*]] = addi %[[VAL_55]]#6, %[[VAL_57]] : index
-// CHECK:             scf.yield %[[VAL_58]] : index
+// CHECK:           %[[VAL_56:.*]] = cmpi ult, %[[VAL_57:.*]]#0, %[[VAL_13]] : index
+// CHECK:           %[[VAL_58:.*]] = scf.if %[[VAL_56]] -> (index) {
+// CHECK:             %[[VAL_59:.*]] = subi %[[VAL_13]], %[[VAL_57]]#0 : index
+// CHECK:             %[[VAL_60:.*]] = addi %[[VAL_57]]#6, %[[VAL_59]] : index
+// CHECK:             scf.yield %[[VAL_60]] : index
 // CHECK:           } else {
-// CHECK:             %[[VAL_59:.*]] = cmpi ult, %[[VAL_55]]#1, %[[VAL_14]] : index
-// CHECK:             %[[VAL_60:.*]] = scf.if %[[VAL_59]] -> (index) {
-// CHECK:               %[[VAL_61:.*]] = subi %[[VAL_14]], %[[VAL_55]]#1 : index
-// CHECK:               %[[VAL_62:.*]] = addi %[[VAL_55]]#6, %[[VAL_61]] : index
-// CHECK:               scf.yield %[[VAL_62]] : index
+// CHECK:             %[[VAL_61:.*]] = cmpi ult, %[[VAL_57]]#1, %[[VAL_16]] : index
+// CHECK:             %[[VAL_62:.*]] = scf.if %[[VAL_61]] -> (index) {
+// CHECK:               %[[VAL_63:.*]] = subi %[[VAL_16]], %[[VAL_57]]#1 : index
+// CHECK:               %[[VAL_64:.*]] = addi %[[VAL_57]]#6, %[[VAL_63]] : index
+// CHECK:               scf.yield %[[VAL_64]] : index
 // CHECK:             } else {
-// CHECK:               scf.yield %[[VAL_55]]#6 : index
+// CHECK:               scf.yield %[[VAL_57]]#6 : index
 // CHECK:             }
-// CHECK:             scf.yield %[[VAL_63:.*]] : index
+// CHECK:             scf.yield %[[VAL_65:.*]] : index
 // CHECK:           }
-// CHECK:           %[[VAL_64:.*]] = index_cast %[[VAL_65:.*]] : index to i64
-// CHECK:           call @vector_resize_index(%[[VAL_1]], %[[VAL_2]], %[[VAL_65]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @vector_resize_values(%[[VAL_1]], %[[VAL_65]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
-// CHECK:           %[[VAL_66:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           memref.store %[[VAL_64]], %[[VAL_66]]{{\[}}%[[VAL_3]]] : memref<?xi64>
-// CHECK:           %[[VAL_67:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_68:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_69:.*]]:9 = scf.while (%[[VAL_70:.*]] = %[[VAL_2]], %[[VAL_71:.*]] = %[[VAL_2]], %[[VAL_72:.*]] = %[[VAL_2]], %[[VAL_73:.*]] = %[[VAL_4]], %[[VAL_74:.*]] = %[[VAL_4]], %[[VAL_75:.*]] = %[[VAL_7]], %[[VAL_76:.*]] = %[[VAL_7]], %[[VAL_77:.*]] = %[[VAL_6]], %[[VAL_78:.*]] = %[[VAL_6]]) : (index, index, index, i64, i64, f64, f64, i1, i1) -> (index, index, index, i64, i64, f64, f64, i1, i1) {
-// CHECK:             %[[VAL_79:.*]] = cmpi ult, %[[VAL_70]], %[[VAL_11]] : index
-// CHECK:             %[[VAL_80:.*]] = cmpi ult, %[[VAL_71]], %[[VAL_14]] : index
-// CHECK:             %[[VAL_81:.*]] = and %[[VAL_79]], %[[VAL_80]] : i1
-// CHECK:             scf.condition(%[[VAL_81]]) %[[VAL_70]], %[[VAL_71]], %[[VAL_72]], %[[VAL_73]], %[[VAL_74]], %[[VAL_75]], %[[VAL_76]], %[[VAL_77]], %[[VAL_78]] : index, index, index, i64, i64, f64, f64, i1, i1
+// CHECK:           %[[VAL_66:.*]] = index_cast %[[VAL_67:.*]] : index to i64
+// CHECK:           %[[VAL_68:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_1]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_index(%[[VAL_68]], %[[VAL_2]], %[[VAL_67]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_69:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_1]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_values(%[[VAL_69]], %[[VAL_67]]) : (!llvm.ptr<i8>, index) -> ()
+// CHECK:           %[[VAL_70:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           memref.store %[[VAL_66]], %[[VAL_70]]{{\[}}%[[VAL_3]]] : memref<?xi64>
+// CHECK:           %[[VAL_71:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_72:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_73:.*]]:9 = scf.while (%[[VAL_74:.*]] = %[[VAL_2]], %[[VAL_75:.*]] = %[[VAL_2]], %[[VAL_76:.*]] = %[[VAL_2]], %[[VAL_77:.*]] = %[[VAL_4]], %[[VAL_78:.*]] = %[[VAL_4]], %[[VAL_79:.*]] = %[[VAL_7]], %[[VAL_80:.*]] = %[[VAL_7]], %[[VAL_81:.*]] = %[[VAL_6]], %[[VAL_82:.*]] = %[[VAL_6]]) : (index, index, index, i64, i64, f64, f64, i1, i1) -> (index, index, index, i64, i64, f64, f64, i1, i1) {
+// CHECK:             %[[VAL_83:.*]] = cmpi ult, %[[VAL_74]], %[[VAL_13]] : index
+// CHECK:             %[[VAL_84:.*]] = cmpi ult, %[[VAL_75]], %[[VAL_16]] : index
+// CHECK:             %[[VAL_85:.*]] = and %[[VAL_83]], %[[VAL_84]] : i1
+// CHECK:             scf.condition(%[[VAL_85]]) %[[VAL_74]], %[[VAL_75]], %[[VAL_76]], %[[VAL_77]], %[[VAL_78]], %[[VAL_79]], %[[VAL_80]], %[[VAL_81]], %[[VAL_82]] : index, index, index, i64, i64, f64, f64, i1, i1
 // CHECK:           } do {
-// CHECK:           ^bb0(%[[VAL_82:.*]]: index, %[[VAL_83:.*]]: index, %[[VAL_84:.*]]: index, %[[VAL_85:.*]]: i64, %[[VAL_86:.*]]: i64, %[[VAL_87:.*]]: f64, %[[VAL_88:.*]]: f64, %[[VAL_89:.*]]: i1, %[[VAL_90:.*]]: i1):
-// CHECK:             %[[VAL_91:.*]]:2 = scf.if %[[VAL_89]] -> (i64, f64) {
-// CHECK:               %[[VAL_92:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_82]]] : memref<?xi64>
-// CHECK:               %[[VAL_93:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_82]]] : memref<?xf64>
-// CHECK:               scf.yield %[[VAL_92]], %[[VAL_93]] : i64, f64
+// CHECK:           ^bb0(%[[VAL_86:.*]]: index, %[[VAL_87:.*]]: index, %[[VAL_88:.*]]: index, %[[VAL_89:.*]]: i64, %[[VAL_90:.*]]: i64, %[[VAL_91:.*]]: f64, %[[VAL_92:.*]]: f64, %[[VAL_93:.*]]: i1, %[[VAL_94:.*]]: i1):
+// CHECK:             %[[VAL_95:.*]]:2 = scf.if %[[VAL_93]] -> (i64, f64) {
+// CHECK:               %[[VAL_96:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_86]]] : memref<?xi64>
+// CHECK:               %[[VAL_97:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_86]]] : memref<?xf64>
+// CHECK:               scf.yield %[[VAL_96]], %[[VAL_97]] : i64, f64
 // CHECK:             } else {
-// CHECK:               scf.yield %[[VAL_85]], %[[VAL_87]] : i64, f64
+// CHECK:               scf.yield %[[VAL_89]], %[[VAL_91]] : i64, f64
 // CHECK:             }
-// CHECK:             %[[VAL_94:.*]]:2 = scf.if %[[VAL_90]] -> (i64, f64) {
-// CHECK:               %[[VAL_95:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_83]]] : memref<?xi64>
-// CHECK:               %[[VAL_96:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_83]]] : memref<?xf64>
-// CHECK:               scf.yield %[[VAL_95]], %[[VAL_96]] : i64, f64
+// CHECK:             %[[VAL_98:.*]]:2 = scf.if %[[VAL_94]] -> (i64, f64) {
+// CHECK:               %[[VAL_99:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_87]]] : memref<?xi64>
+// CHECK:               %[[VAL_100:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_87]]] : memref<?xf64>
+// CHECK:               scf.yield %[[VAL_99]], %[[VAL_100]] : i64, f64
 // CHECK:             } else {
-// CHECK:               scf.yield %[[VAL_86]], %[[VAL_88]] : i64, f64
+// CHECK:               scf.yield %[[VAL_90]], %[[VAL_92]] : i64, f64
 // CHECK:             }
-// CHECK:             %[[VAL_97:.*]] = cmpi ult, %[[VAL_98:.*]]#0, %[[VAL_99:.*]]#0 : i64
-// CHECK:             %[[VAL_100:.*]] = cmpi ugt, %[[VAL_98]]#0, %[[VAL_99]]#0 : i64
-// CHECK:             %[[VAL_101:.*]] = addi %[[VAL_82]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_102:.*]] = addi %[[VAL_83]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_103:.*]] = addi %[[VAL_84]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_104:.*]]:5 = scf.if %[[VAL_97]] -> (index, index, index, i1, i1) {
-// CHECK:               memref.store %[[VAL_98]]#0, %[[VAL_67]]{{\[}}%[[VAL_84]]] : memref<?xi64>
-// CHECK:               memref.store %[[VAL_98]]#1, %[[VAL_68]]{{\[}}%[[VAL_84]]] : memref<?xf64>
-// CHECK:               scf.yield %[[VAL_101]], %[[VAL_83]], %[[VAL_103]], %[[VAL_6]], %[[VAL_5]] : index, index, index, i1, i1
+// CHECK:             %[[VAL_101:.*]] = cmpi ult, %[[VAL_102:.*]]#0, %[[VAL_103:.*]]#0 : i64
+// CHECK:             %[[VAL_104:.*]] = cmpi ugt, %[[VAL_102]]#0, %[[VAL_103]]#0 : i64
+// CHECK:             %[[VAL_105:.*]] = addi %[[VAL_86]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_106:.*]] = addi %[[VAL_87]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_107:.*]] = addi %[[VAL_88]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_108:.*]]:5 = scf.if %[[VAL_101]] -> (index, index, index, i1, i1) {
+// CHECK:               memref.store %[[VAL_102]]#0, %[[VAL_71]]{{\[}}%[[VAL_88]]] : memref<?xi64>
+// CHECK:               memref.store %[[VAL_102]]#1, %[[VAL_72]]{{\[}}%[[VAL_88]]] : memref<?xf64>
+// CHECK:               scf.yield %[[VAL_105]], %[[VAL_87]], %[[VAL_107]], %[[VAL_6]], %[[VAL_5]] : index, index, index, i1, i1
 // CHECK:             } else {
-// CHECK:               %[[VAL_105:.*]]:5 = scf.if %[[VAL_100]] -> (index, index, index, i1, i1) {
-// CHECK:                 memref.store %[[VAL_99]]#0, %[[VAL_67]]{{\[}}%[[VAL_84]]] : memref<?xi64>
-// CHECK:                 memref.store %[[VAL_99]]#1, %[[VAL_68]]{{\[}}%[[VAL_84]]] : memref<?xf64>
-// CHECK:                 scf.yield %[[VAL_82]], %[[VAL_102]], %[[VAL_103]], %[[VAL_5]], %[[VAL_6]] : index, index, index, i1, i1
+// CHECK:               %[[VAL_109:.*]]:5 = scf.if %[[VAL_104]] -> (index, index, index, i1, i1) {
+// CHECK:                 memref.store %[[VAL_103]]#0, %[[VAL_71]]{{\[}}%[[VAL_88]]] : memref<?xi64>
+// CHECK:                 memref.store %[[VAL_103]]#1, %[[VAL_72]]{{\[}}%[[VAL_88]]] : memref<?xf64>
+// CHECK:                 scf.yield %[[VAL_86]], %[[VAL_106]], %[[VAL_107]], %[[VAL_5]], %[[VAL_6]] : index, index, index, i1, i1
 // CHECK:               } else {
-// CHECK:                 memref.store %[[VAL_98]]#0, %[[VAL_67]]{{\[}}%[[VAL_84]]] : memref<?xi64>
-// CHECK:                 %[[VAL_106:.*]] = addf %[[VAL_98]]#1, %[[VAL_99]]#1 : f64
-// CHECK:                 memref.store %[[VAL_106]], %[[VAL_68]]{{\[}}%[[VAL_84]]] : memref<?xf64>
-// CHECK:                 scf.yield %[[VAL_101]], %[[VAL_102]], %[[VAL_103]], %[[VAL_6]], %[[VAL_6]] : index, index, index, i1, i1
+// CHECK:                 memref.store %[[VAL_102]]#0, %[[VAL_71]]{{\[}}%[[VAL_88]]] : memref<?xi64>
+// CHECK:                 %[[VAL_110:.*]] = addf %[[VAL_102]]#1, %[[VAL_103]]#1 : f64
+// CHECK:                 memref.store %[[VAL_110]], %[[VAL_72]]{{\[}}%[[VAL_88]]] : memref<?xf64>
+// CHECK:                 scf.yield %[[VAL_105]], %[[VAL_106]], %[[VAL_107]], %[[VAL_6]], %[[VAL_6]] : index, index, index, i1, i1
 // CHECK:               }
-// CHECK:               scf.yield %[[VAL_107:.*]]#0, %[[VAL_107]]#1, %[[VAL_107]]#2, %[[VAL_107]]#3, %[[VAL_107]]#4 : index, index, index, i1, i1
+// CHECK:               scf.yield %[[VAL_111:.*]]#0, %[[VAL_111]]#1, %[[VAL_111]]#2, %[[VAL_111]]#3, %[[VAL_111]]#4 : index, index, index, i1, i1
 // CHECK:             }
-// CHECK:             scf.yield %[[VAL_108:.*]]#0, %[[VAL_108]]#1, %[[VAL_108]]#2, %[[VAL_98]]#0, %[[VAL_99]]#0, %[[VAL_98]]#1, %[[VAL_99]]#1, %[[VAL_108]]#3, %[[VAL_108]]#4 : index, index, index, i64, i64, f64, f64, i1, i1
+// CHECK:             scf.yield %[[VAL_112:.*]]#0, %[[VAL_112]]#1, %[[VAL_112]]#2, %[[VAL_102]]#0, %[[VAL_103]]#0, %[[VAL_102]]#1, %[[VAL_103]]#1, %[[VAL_112]]#3, %[[VAL_112]]#4 : index, index, index, i64, i64, f64, f64, i1, i1
 // CHECK:           }
-// CHECK:           %[[VAL_109:.*]] = cmpi ult, %[[VAL_110:.*]]#0, %[[VAL_11]] : index
-// CHECK:           %[[VAL_111:.*]] = scf.if %[[VAL_109]] -> (index) {
-// CHECK:             %[[VAL_112:.*]] = scf.for %[[VAL_113:.*]] = %[[VAL_110]]#0 to %[[VAL_11]] step %[[VAL_3]] iter_args(%[[VAL_114:.*]] = %[[VAL_110]]#2) -> (index) {
-// CHECK:               %[[VAL_115:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_113]]] : memref<?xi64>
-// CHECK:               %[[VAL_116:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_113]]] : memref<?xf64>
-// CHECK:               memref.store %[[VAL_115]], %[[VAL_67]]{{\[}}%[[VAL_114]]] : memref<?xi64>
-// CHECK:               memref.store %[[VAL_116]], %[[VAL_68]]{{\[}}%[[VAL_114]]] : memref<?xf64>
-// CHECK:               %[[VAL_117:.*]] = addi %[[VAL_114]], %[[VAL_3]] : index
-// CHECK:               scf.yield %[[VAL_117]] : index
+// CHECK:           %[[VAL_113:.*]] = cmpi ult, %[[VAL_114:.*]]#0, %[[VAL_13]] : index
+// CHECK:           %[[VAL_115:.*]] = scf.if %[[VAL_113]] -> (index) {
+// CHECK:             %[[VAL_116:.*]] = scf.for %[[VAL_117:.*]] = %[[VAL_114]]#0 to %[[VAL_13]] step %[[VAL_3]] iter_args(%[[VAL_118:.*]] = %[[VAL_114]]#2) -> (index) {
+// CHECK:               %[[VAL_119:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_117]]] : memref<?xi64>
+// CHECK:               %[[VAL_120:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_117]]] : memref<?xf64>
+// CHECK:               memref.store %[[VAL_119]], %[[VAL_71]]{{\[}}%[[VAL_118]]] : memref<?xi64>
+// CHECK:               memref.store %[[VAL_120]], %[[VAL_72]]{{\[}}%[[VAL_118]]] : memref<?xf64>
+// CHECK:               %[[VAL_121:.*]] = addi %[[VAL_118]], %[[VAL_3]] : index
+// CHECK:               scf.yield %[[VAL_121]] : index
 // CHECK:             }
-// CHECK:             scf.yield %[[VAL_118:.*]] : index
+// CHECK:             scf.yield %[[VAL_122:.*]] : index
 // CHECK:           } else {
-// CHECK:             %[[VAL_119:.*]] = cmpi ult, %[[VAL_110]]#1, %[[VAL_14]] : index
-// CHECK:             %[[VAL_120:.*]] = scf.if %[[VAL_119]] -> (index) {
-// CHECK:               %[[VAL_121:.*]] = scf.for %[[VAL_122:.*]] = %[[VAL_110]]#1 to %[[VAL_14]] step %[[VAL_3]] iter_args(%[[VAL_123:.*]] = %[[VAL_110]]#2) -> (index) {
-// CHECK:                 %[[VAL_124:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_122]]] : memref<?xi64>
-// CHECK:                 %[[VAL_125:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_122]]] : memref<?xf64>
-// CHECK:                 memref.store %[[VAL_124]], %[[VAL_67]]{{\[}}%[[VAL_123]]] : memref<?xi64>
-// CHECK:                 memref.store %[[VAL_125]], %[[VAL_68]]{{\[}}%[[VAL_123]]] : memref<?xf64>
-// CHECK:                 %[[VAL_126:.*]] = addi %[[VAL_123]], %[[VAL_3]] : index
-// CHECK:                 scf.yield %[[VAL_126]] : index
+// CHECK:             %[[VAL_123:.*]] = cmpi ult, %[[VAL_114]]#1, %[[VAL_16]] : index
+// CHECK:             %[[VAL_124:.*]] = scf.if %[[VAL_123]] -> (index) {
+// CHECK:               %[[VAL_125:.*]] = scf.for %[[VAL_126:.*]] = %[[VAL_114]]#1 to %[[VAL_16]] step %[[VAL_3]] iter_args(%[[VAL_127:.*]] = %[[VAL_114]]#2) -> (index) {
+// CHECK:                 %[[VAL_128:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_126]]] : memref<?xi64>
+// CHECK:                 %[[VAL_129:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_126]]] : memref<?xf64>
+// CHECK:                 memref.store %[[VAL_128]], %[[VAL_71]]{{\[}}%[[VAL_127]]] : memref<?xi64>
+// CHECK:                 memref.store %[[VAL_129]], %[[VAL_72]]{{\[}}%[[VAL_127]]] : memref<?xf64>
+// CHECK:                 %[[VAL_130:.*]] = addi %[[VAL_127]], %[[VAL_3]] : index
+// CHECK:                 scf.yield %[[VAL_130]] : index
 // CHECK:               }
-// CHECK:               scf.yield %[[VAL_127:.*]] : index
+// CHECK:               scf.yield %[[VAL_131:.*]] : index
 // CHECK:             } else {
-// CHECK:               scf.yield %[[VAL_110]]#2 : index
+// CHECK:               scf.yield %[[VAL_114]]#2 : index
 // CHECK:             }
-// CHECK:             scf.yield %[[VAL_128:.*]] : index
+// CHECK:             scf.yield %[[VAL_132:.*]] : index
 // CHECK:           }
-// CHECK:           call @delSparseVector(%[[VAL_8]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> ()
-// CHECK:           return %[[VAL_129:.*]] : index
+// CHECK:           %[[VAL_133:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_10]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @delSparseTensor(%[[VAL_133]]) : (!llvm.ptr<i8>) -> ()
+// CHECK:           return %[[VAL_2]] : index
 // CHECK:         }
 
 func @vector_update_accumulate(%input: tensor<?xf64, #CV64>, %output: tensor<?xf64, #CV64>) -> index {

--- a/mlir_graphblas/src/test/GraphBLAS/lower_vector_vector_multiply_full.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_vector_vector_multiply_full.mlir
@@ -6,13 +6,6 @@
   indexBitWidth = 64
 }>
 
-// CHECK-DAG:     func private @delSparseVector(tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>)
-// CHECK-DAG:     func private @vector_resize_values(tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index)
-// CHECK-DAG:     func private @vector_resize_index(tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK-DAG:     func private @vector_resize_pointers(tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK-DAG:     func private @vector_resize_dim(tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index)
-// CHECK-DAG:     func private @vector_empty_like(tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-
 // CHECK-LABEL:   func @vector_vector_multiply_plus_times(
 // CHECK-SAME:                                            %[[VAL_0:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                                            %[[VAL_1:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> f64 {
@@ -23,69 +16,76 @@
 // CHECK-DAG:       %[[VAL_6:.*]] = constant false
 // CHECK-DAG:       %[[VAL_7:.*]] = constant 0.000000e+00 : f64
 // CHECK:           %[[VAL_8:.*]] = tensor.dim %[[VAL_0]], %[[VAL_3]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_9:.*]] = call @vector_empty_like(%[[VAL_0]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           call @vector_resize_dim(%[[VAL_9]], %[[VAL_3]], %[[VAL_4]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @vector_resize_pointers(%[[VAL_9]], %[[VAL_3]], %[[VAL_2]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @vector_resize_index(%[[VAL_9]], %[[VAL_3]], %[[VAL_4]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index, index) -> ()
-// CHECK:           call @vector_resize_values(%[[VAL_9]], %[[VAL_4]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, index) -> ()
-// CHECK:           %[[VAL_10:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_11:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_3]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_12:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_13:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_3]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_14:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_3]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_15:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_16:.*]] = sparse_tensor.indices %[[VAL_9]], %[[VAL_3]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:           %[[VAL_17:.*]] = sparse_tensor.values %[[VAL_9]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_18:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_4]]] : memref<?xi64>
-// CHECK:           %[[VAL_19:.*]] = index_cast %[[VAL_18]] : i64 to index
-// CHECK:           %[[VAL_20:.*]] = memref.alloc(%[[VAL_8]]) : memref<?xf64>
-// CHECK:           %[[VAL_21:.*]] = memref.alloc(%[[VAL_8]]) : memref<?xi1>
-// CHECK:           linalg.fill(%[[VAL_6]], %[[VAL_21]]) : i1, memref<?xi1>
-// CHECK:           scf.parallel (%[[VAL_22:.*]]) = (%[[VAL_3]]) to (%[[VAL_19]]) step (%[[VAL_4]]) {
-// CHECK:             %[[VAL_23:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_22]]] : memref<?xi64>
-// CHECK:             %[[VAL_24:.*]] = index_cast %[[VAL_23]] : i64 to index
-// CHECK:             memref.store %[[VAL_5]], %[[VAL_21]]{{\[}}%[[VAL_24]]] : memref<?xi1>
-// CHECK:             %[[VAL_25:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_22]]] : memref<?xf64>
-// CHECK:             memref.store %[[VAL_25]], %[[VAL_20]]{{\[}}%[[VAL_24]]] : memref<?xf64>
+// CHECK:           %[[VAL_9:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_10:.*]] = call @empty_like(%[[VAL_9]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_11:.*]] = call @ptr8_to_vector_f64_p64i64(%[[VAL_10]]) : (!llvm.ptr<i8>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_12:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_11]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_dim(%[[VAL_12]], %[[VAL_3]], %[[VAL_4]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_13:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_11]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_pointers(%[[VAL_13]], %[[VAL_3]], %[[VAL_2]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_14:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_11]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_index(%[[VAL_14]], %[[VAL_3]], %[[VAL_4]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:           %[[VAL_15:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_11]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @resize_values(%[[VAL_15]], %[[VAL_4]]) : (!llvm.ptr<i8>, index) -> ()
+// CHECK:           %[[VAL_16:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_17:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_3]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_18:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_19:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_3]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_20:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_3]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_21:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_22:.*]] = sparse_tensor.indices %[[VAL_11]], %[[VAL_3]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:           %[[VAL_23:.*]] = sparse_tensor.values %[[VAL_11]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:           %[[VAL_24:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_4]]] : memref<?xi64>
+// CHECK:           %[[VAL_25:.*]] = index_cast %[[VAL_24]] : i64 to index
+// CHECK:           %[[VAL_26:.*]] = memref.alloc(%[[VAL_8]]) : memref<?xf64>
+// CHECK:           %[[VAL_27:.*]] = memref.alloc(%[[VAL_8]]) : memref<?xi1>
+// CHECK:           linalg.fill(%[[VAL_6]], %[[VAL_27]]) : i1, memref<?xi1>
+// CHECK:           scf.parallel (%[[VAL_28:.*]]) = (%[[VAL_3]]) to (%[[VAL_25]]) step (%[[VAL_4]]) {
+// CHECK:             %[[VAL_29:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_28]]] : memref<?xi64>
+// CHECK:             %[[VAL_30:.*]] = index_cast %[[VAL_29]] : i64 to index
+// CHECK:             memref.store %[[VAL_5]], %[[VAL_27]]{{\[}}%[[VAL_30]]] : memref<?xi1>
+// CHECK:             %[[VAL_31:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_28]]] : memref<?xf64>
+// CHECK:             memref.store %[[VAL_31]], %[[VAL_26]]{{\[}}%[[VAL_30]]] : memref<?xf64>
 // CHECK:             scf.yield
 // CHECK:           }
-// CHECK:           %[[VAL_26:.*]] = scf.for %[[VAL_27:.*]] = %[[VAL_3]] to %[[VAL_4]] step %[[VAL_4]] iter_args(%[[VAL_28:.*]] = %[[VAL_3]]) -> (index) {
-// CHECK:             %[[VAL_29:.*]] = index_cast %[[VAL_27]] : index to i64
-// CHECK:             %[[VAL_30:.*]] = addi %[[VAL_27]], %[[VAL_4]] : index
-// CHECK:             %[[VAL_31:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_27]]] : memref<?xi64>
-// CHECK:             %[[VAL_32:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_30]]] : memref<?xi64>
-// CHECK:             %[[VAL_33:.*]] = index_cast %[[VAL_31]] : i64 to index
-// CHECK:             %[[VAL_34:.*]] = index_cast %[[VAL_32]] : i64 to index
-// CHECK:             %[[VAL_35:.*]]:2 = scf.for %[[VAL_36:.*]] = %[[VAL_33]] to %[[VAL_34]] step %[[VAL_4]] iter_args(%[[VAL_37:.*]] = %[[VAL_7]], %[[VAL_38:.*]] = %[[VAL_6]]) -> (f64, i1) {
-// CHECK:               %[[VAL_39:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_36]]] : memref<?xi64>
-// CHECK:               %[[VAL_40:.*]] = index_cast %[[VAL_39]] : i64 to index
-// CHECK:               %[[VAL_41:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_40]]] : memref<?xi1>
-// CHECK:               %[[VAL_42:.*]]:2 = scf.if %[[VAL_41]] -> (f64, i1) {
-// CHECK:                 %[[VAL_43:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_40]]] : memref<?xf64>
-// CHECK:                 %[[VAL_44:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_36]]] : memref<?xf64>
-// CHECK:                 %[[VAL_45:.*]] = mulf %[[VAL_43]], %[[VAL_44]] : f64
-// CHECK:                 %[[VAL_46:.*]] = addf %[[VAL_37]], %[[VAL_45]] : f64
-// CHECK:                 scf.yield %[[VAL_46]], %[[VAL_5]] : f64, i1
+// CHECK:           %[[VAL_32:.*]] = scf.for %[[VAL_33:.*]] = %[[VAL_3]] to %[[VAL_4]] step %[[VAL_4]] iter_args(%[[VAL_34:.*]] = %[[VAL_3]]) -> (index) {
+// CHECK:             %[[VAL_35:.*]] = index_cast %[[VAL_33]] : index to i64
+// CHECK:             %[[VAL_36:.*]] = addi %[[VAL_33]], %[[VAL_4]] : index
+// CHECK:             %[[VAL_37:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_33]]] : memref<?xi64>
+// CHECK:             %[[VAL_38:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_36]]] : memref<?xi64>
+// CHECK:             %[[VAL_39:.*]] = index_cast %[[VAL_37]] : i64 to index
+// CHECK:             %[[VAL_40:.*]] = index_cast %[[VAL_38]] : i64 to index
+// CHECK:             %[[VAL_41:.*]]:2 = scf.for %[[VAL_42:.*]] = %[[VAL_39]] to %[[VAL_40]] step %[[VAL_4]] iter_args(%[[VAL_43:.*]] = %[[VAL_7]], %[[VAL_44:.*]] = %[[VAL_6]]) -> (f64, i1) {
+// CHECK:               %[[VAL_45:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_42]]] : memref<?xi64>
+// CHECK:               %[[VAL_46:.*]] = index_cast %[[VAL_45]] : i64 to index
+// CHECK:               %[[VAL_47:.*]] = memref.load %[[VAL_27]]{{\[}}%[[VAL_46]]] : memref<?xi1>
+// CHECK:               %[[VAL_48:.*]]:2 = scf.if %[[VAL_47]] -> (f64, i1) {
+// CHECK:                 %[[VAL_49:.*]] = memref.load %[[VAL_26]]{{\[}}%[[VAL_46]]] : memref<?xf64>
+// CHECK:                 %[[VAL_50:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_42]]] : memref<?xf64>
+// CHECK:                 %[[VAL_51:.*]] = mulf %[[VAL_49]], %[[VAL_50]] : f64
+// CHECK:                 %[[VAL_52:.*]] = addf %[[VAL_43]], %[[VAL_51]] : f64
+// CHECK:                 scf.yield %[[VAL_52]], %[[VAL_5]] : f64, i1
 // CHECK:               } else {
-// CHECK:                 scf.yield %[[VAL_37]], %[[VAL_38]] : f64, i1
+// CHECK:                 scf.yield %[[VAL_43]], %[[VAL_44]] : f64, i1
 // CHECK:               }
-// CHECK:               scf.yield %[[VAL_47:.*]]#0, %[[VAL_47]]#1 : f64, i1
+// CHECK:               scf.yield %[[VAL_53:.*]]#0, %[[VAL_53]]#1 : f64, i1
 // CHECK:             }
-// CHECK:             %[[VAL_48:.*]] = scf.if %[[VAL_35]]#1 -> (index) {
-// CHECK:               memref.store %[[VAL_29]], %[[VAL_16]]{{\[}}%[[VAL_28]]] : memref<?xi64>
-// CHECK:               memref.store %[[VAL_35]]#0, %[[VAL_17]]{{\[}}%[[VAL_28]]] : memref<?xf64>
-// CHECK:               %[[VAL_50:.*]] = addi %[[VAL_28]], %[[VAL_4]] : index
-// CHECK:               scf.yield %[[VAL_50]] : index
+// CHECK:             %[[VAL_54:.*]] = scf.if %[[VAL_55:.*]]#1 -> (index) {
+// CHECK:               memref.store %[[VAL_35]], %[[VAL_22]]{{\[}}%[[VAL_34]]] : memref<?xi64>
+// CHECK:               memref.store %[[VAL_55]]#0, %[[VAL_23]]{{\[}}%[[VAL_34]]] : memref<?xf64>
+// CHECK:               %[[VAL_56:.*]] = addi %[[VAL_34]], %[[VAL_4]] : index
+// CHECK:               scf.yield %[[VAL_56]] : index
 // CHECK:             } else {
-// CHECK:               scf.yield %[[VAL_28]] : index
+// CHECK:               scf.yield %[[VAL_34]] : index
 // CHECK:             }
-// CHECK:             scf.yield %[[VAL_48]] : index
+// CHECK:             scf.yield %[[VAL_57:.*]] : index
 // CHECK:           }
-// CHECK:           memref.dealloc %[[VAL_20]] : memref<?xf64>
-// CHECK:           memref.dealloc %[[VAL_21]] : memref<?xi1>
-// CHECK:           %[[VAL_52:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_3]]] : memref<?xf64>
-// CHECK:           call @delSparseVector(%[[VAL_9]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> ()
-// CHECK:           return %[[VAL_52]] : f64
+// CHECK:           memref.dealloc %[[VAL_26]] : memref<?xf64>
+// CHECK:           memref.dealloc %[[VAL_27]] : memref<?xi1>
+// CHECK:           %[[VAL_58:.*]] = memref.load %[[VAL_23]]{{\[}}%[[VAL_3]]] : memref<?xf64>
+// CHECK:           %[[VAL_59:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_11]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:           call @delSparseTensor(%[[VAL_59]]) : (!llvm.ptr<i8>) -> ()
+// CHECK:           return %[[VAL_58]] : f64
 // CHECK:         }
 
 func @vector_vector_multiply_plus_times(%a: tensor<?xf64, #CV64>, %b: tensor<?xf64, #CV64>) -> f64 {

--- a/mlir_graphblas/tests/test_jit_engine.py
+++ b/mlir_graphblas/tests/test_jit_engine.py
@@ -521,7 +521,7 @@ def test_jit_engine_sequence_of_sparse_tensors_input(engine):
   indexBitWidth = 64
 }>
 
-func private @ptr8_to_matrix(!llvm.ptr<i8>) -> tensor<2x3xf64, #sparseTensor>
+func private @ptr8_to_matrix_csr_f64_p64i64(!llvm.ptr<i8>) -> tensor<2x3xf64, #sparseTensor>
 
 func @sparse_tensors_summation(%sequence: !llvm.ptr<!llvm.ptr<i8>>, %sequence_length: index) -> f64 {
   // Take an array of sparse 2x3 matrices
@@ -546,7 +546,7 @@ func @sparse_tensors_summation(%sequence: !llvm.ptr<!llvm.ptr<i8>>, %sequence_le
     // dereference %sparse_tensor_ptr_ptr to get an !llvm.ptr<i8>
     %sparse_tensor_ptr = llvm.load %sparse_tensor_ptr_ptr : !llvm.ptr<!llvm.ptr<i8>>
 
-    %sparse_tensor = call @ptr8_to_matrix(%sparse_tensor_ptr) : (!llvm.ptr<i8>) -> tensor<2x3xf64, #sparseTensor>
+    %sparse_tensor = call @ptr8_to_matrix_csr_f64_p64i64(%sparse_tensor_ptr) : (!llvm.ptr<i8>) -> tensor<2x3xf64, #sparseTensor>
 
     %reduction = linalg.generic #trait_sum_reduction
         ins(%sparse_tensor: tensor<2x3xf64, #sparseTensor>)

--- a/mlir_graphblas/types.py
+++ b/mlir_graphblas/types.py
@@ -125,6 +125,19 @@ class TensorType(Type):
         shape_string = "x".join("?" if dim == -1 else str(dim) for dim in self.shape)
         return f"tensor<{shape_string}x{self.value_type}, {self.encoding}>"
 
+    def to_short_string(self):
+        ret = []
+        if self.encoding.rank == 2:
+            ret.append("matrix")
+            ret.append("csc" if self.encoding.ordering == [1, 0] else "csr")
+        elif self.encoding.rank == 1:
+            ret.append("vector")
+        else:
+            raise ValueError(f"Invalid rank: {self.encoding.rank}")
+        ret.append(str(self.value_type))
+        ret.append(f"p{self.encoding.pointer_bit_width}i{self.encoding.index_bit_width}")
+        return "_".join(ret)
+
     @classmethod
     def parse(cls, text: str, aliases: AliasMap = None):
         if m := cls._patt.match(text):

--- a/mlir_graphblas/types.py
+++ b/mlir_graphblas/types.py
@@ -135,7 +135,9 @@ class TensorType(Type):
         else:
             raise ValueError(f"Invalid rank: {self.encoding.rank}")
         ret.append(str(self.value_type))
-        ret.append(f"p{self.encoding.pointer_bit_width}i{self.encoding.index_bit_width}")
+        ret.append(
+            f"p{self.encoding.pointer_bit_width}i{self.encoding.index_bit_width}"
+        )
         return "_".join(ret)
 
     @classmethod


### PR DESCRIPTION
Previous state:

- Conversions between CSR/CSC and CSX to avoid duplicating top-level SparseUtils functions twice.
- CSX wasn't able to absorb vectors, so separate functions were written for, e.g. `matrix_resize_pointers` and `vector_resize_pointers`
- Hope that you never have to switch dtypes, because the top-level function is defined for `tensor<?x?xf64, #CSX>`, so i64 or i1 is impossible

New state:

- Conversions between everything and `!llvm.ptr<i8>`
- All top-level are written using `!llvm.ptr<i8>`, allowing any rank and any dtype
- Converting to ptr8, calling C-function, and converting back is all done in GraphBLASUtils.cpp

Ultimately, this greatly simplifies the calls to SparseUtils. Even though there are lots of conversion functions (`matrix_csc_f32_p64i64_to_ptr8`, etc), in general the user never has to call the specific version. Utilities exist which inspect the `RankedTensorType` and call the appropriate version for the user.