### PR TITLE
Revise and consolidate the tensor encoding checks

### DIFF
--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
@@ -563,7 +563,7 @@ def GraphBLAS_UpdateOp : GraphBLAS_Op<"update", []> {
     let arguments = (ins
      GraphBlasMatrixOrVectorOperand:$input,
      GraphBlasMatrixOrVectorOperand:$output,
-     Optional<AnyTensor>:$mask, OptionalAttr<StrAttr>:$accumulate_operator,
+     Optional<GraphBlasMatrixOrVectorOperand>:$mask, OptionalAttr<StrAttr>:$accumulate_operator,
      DefaultValuedAttr<BoolAttr, "false">:$replace, DefaultValuedAttr<BoolAttr, "false">:$mask_complement);
     let results = (outs Index:$fake_output);
     

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
@@ -37,6 +37,8 @@ static const llvm::StringSet<> supportedBinaryApplyOperators{"min", "div",
                                                              "fill"};
 static const llvm::StringSet<> supportedUnaryApplyOperators{"abs", "minv"};
 
+bool hasRowOrdering(mlir::Type inputType);
+bool hasColumnOrdering(mlir::Type inputType);
 bool typeIsCSR(mlir::Type inputType);
 bool typeIsCSC(mlir::Type inputType);
 mlir::RankedTensorType getCompressedVectorType(mlir::MLIRContext *context,

--- a/mlir_graphblas/src/test/GraphBLAS/invalid.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid.mlir
@@ -28,21 +28,8 @@ func @num_cols_wrapper(%argA: tensor<1xi64>) -> index {
 
 // -----
 
-func @dup_warpper(%argA: tensor<1x1xi64>) -> tensor<1x1xi64> {
-  %answer = graphblas.dup %argA : tensor<1x1xi64> // expected-error {{operand #0 must have sparse tensor attribute}}
+func @dup_wrapper(%argA: tensor<1x1xi64>) -> tensor<1x1xi64> {
+  %answer = graphblas.dup %argA : tensor<1x1xi64> // expected-error {{operand must be a sparse tensor}}
   return %answer : tensor<1x1xi64>
 }
 
-// -----
-
-#E = #sparse_tensor.encoding<{
-  dimLevelType = [ "compressed", "compressed" ],
-  dimOrdering = affine_map<(i,j) -> (i,j)>,
-  pointerBitWidth = 64,
-  indexBitWidth = 64
-}>
-
-func @dup_warpper(%argA: tensor<1x1xi64, #E>) -> tensor<1x1xi64, #E> {
-  %answer = graphblas.dup %argA : tensor<1x1xi64, #E> // expected-error {{operand #0 must be in CSR or in CSC compression}}
-  return %answer : tensor<1x1xi64, #E>
-}

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_apply.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_apply.mlir
@@ -9,7 +9,7 @@
 
 module {
     func @apply_wrapper(%sparse_tensor: tensor<2x3xbf16>, %thunk: bf16) -> tensor<2x3xbf16, #CSR64> {
-        %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "min" } : (tensor<2x3xbf16>, bf16) to tensor<2x3xbf16, #CSR64> // expected-error {{operand #0 must have sparse tensor attribute}}
+        %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "min" } : (tensor<2x3xbf16>, bf16) to tensor<2x3xbf16, #CSR64> // expected-error {{operand must be a sparse tensor.}}
         return %answer : tensor<2x3xbf16, #CSR64>
     }
 }
@@ -24,7 +24,7 @@ module {
 
 module {
     func @apply_wrapper(%sparse_tensor: tensor<3xbf16>, %thunk: bf16) -> tensor<3xbf16, #SparseVec64> {
-        %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "min" } : (tensor<3xbf16>, bf16) to tensor<3xbf16, #SparseVec64> // expected-error {{operand #0 must have sparse tensor attribute}}
+        %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "min" } : (tensor<3xbf16>, bf16) to tensor<3xbf16, #SparseVec64> // expected-error {{operand must be a sparse tensor.}}
         return %answer : tensor<3xbf16, #SparseVec64>
     }
 }
@@ -40,7 +40,7 @@ module {
 
 module {
     func @apply_wrapper(%sparse_tensor: tensor<2x3xbf16, #CSR64>, %thunk: bf16) -> tensor<2x3xbf16> {
-        %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "min" } : (tensor<2x3xbf16, #CSR64>, bf16) to tensor<2x3xbf16> // expected-error {{result #0 must have sparse tensor attribute}}
+        %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "min" } : (tensor<2x3xbf16, #CSR64>, bf16) to tensor<2x3xbf16> // expected-error {{result must be a sparse tensor.}}
         return %answer : tensor<2x3xbf16>
     }
 }
@@ -55,7 +55,7 @@ module {
 
 module {
     func @apply_wrapper(%sparse_tensor: tensor<3xbf16, #SparseVec64>, %thunk: bf16) -> tensor<3xbf16> {
-        %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "min" } : (tensor<3xbf16, #SparseVec64>, bf16) to tensor<3xbf16> // expected-error {{result #0 must have sparse tensor attribute}}
+        %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "min" } : (tensor<3xbf16, #SparseVec64>, bf16) to tensor<3xbf16> // expected-error {{result must be a sparse tensor.}}
         return %answer : tensor<3xbf16>
     }
 }
@@ -133,7 +133,7 @@ module {
 
 module {
     func @apply_wrapper(%sparse_tensor: tensor<2x3xi8, #CSR64>, %thunk: i8) -> tensor<99x99xi8, #CSR64> {
-        %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "min" } : (tensor<2x3xi8, #CSR64>, i8) to tensor<99x99xi8, #CSR64> // expected-error {{Input shape does not match output shape.}}
+        %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "min" } : (tensor<2x3xi8, #CSR64>, i8) to tensor<99x99xi8, #CSR64> // expected-error {{operand and result shapes must match}}
         return %answer : tensor<99x99xi8, #CSR64>
     }
 }
@@ -148,7 +148,7 @@ module {
 
 module {
     func @apply_wrapper(%sparse_tensor: tensor<6xi8, #SparseVec64>, %thunk: i8) -> tensor<9999xi8, #SparseVec64> {
-        %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "min" } : (tensor<6xi8, #SparseVec64>, i8) to tensor<9999xi8, #SparseVec64> // expected-error {{Input shape does not match output shape.}}
+        %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "min" } : (tensor<6xi8, #SparseVec64>, i8) to tensor<9999xi8, #SparseVec64> // expected-error {{operand and result shapes must match}}
         return %answer : tensor<9999xi8, #SparseVec64>
     }
 }
@@ -166,6 +166,21 @@ module {
     func @apply_wrapper(%sparse_tensor: tensor<2x3xi8, #CSR64>, %thunk: i8) -> tensor<2x3xi8, #CSR64> {
         %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "BADOPERATOR" } : (tensor<2x3xi8, #CSR64>, i8) to tensor<2x3xi8, #CSR64> // expected-error {{"BADOPERATOR" is not a supported operator.}}
         return %answer : tensor<2x3xi8, #CSR64>
+    }
+}
+
+// -----
+
+#DenseVec64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "dense" ],
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+module {
+    func @apply_wrapper(%sparse_tensor: tensor<6xi8, #DenseVec64>, %thunk: i8) -> tensor<6xi8, #DenseVec64> {
+        %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "plus" } : (tensor<6xi8, #DenseVec64>, i8) to tensor<6xi8, #DenseVec64> // expected-error {{operand must be sparse, i.e. must have dimLevelType = [ "compressed" ] in the sparse encoding.}}
+        return %answer : tensor<6xi8, #DenseVec64>
     }
 }
 
@@ -195,7 +210,7 @@ module {
 
 module {
     func @apply_wrapper(%sparse_tensor: tensor<2x3xbf16, #CSR64>, %thunk: bf16) -> tensor<2x3xbf16, #CSR64> {
-        %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "abs" } : (tensor<2x3xbf16, #CSR64>, bf16) to tensor<2x3xbf16, #CSR64> // expected-error {{"abs" is a unary opertator, but was given a thunk.}}
+        %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "abs" } : (tensor<2x3xbf16, #CSR64>, bf16) to tensor<2x3xbf16, #CSR64> // expected-error {{"abs" is a unary operator, but was given a thunk.}}
         return %answer : tensor<2x3xbf16, #CSR64>
     }
 }

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_equal.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_equal.mlir
@@ -9,7 +9,7 @@
 module {
 
    func @vector_equals_wrapper(%argA: tensor<3xi64>, %argB: tensor<3xi64>) -> i1 {
-       %answer = graphblas.equal %argA, %argB : tensor<3xi64>, tensor<3xi64> // expected-error {{First argument must be a sparse vector or sparse matrix.}}
+       %answer = graphblas.equal %argA, %argB : tensor<3xi64>, tensor<3xi64> // expected-error {{1st operand must be a sparse tensor.}}
        return %answer : i1
    }
 
@@ -26,7 +26,7 @@ module {
 module {
 
    func @vector_equals_wrapper(%argA: tensor<3xi64, #SparseVec64>, %argB: tensor<3xf64, #SparseVec64>) -> i1 {
-       %answer = graphblas.equal %argA, %argB : tensor<3xi64, #SparseVec64>, tensor<3xf64, #SparseVec64> // expected-error {{Arguments must have the same type.}}
+       %answer = graphblas.equal %argA, %argB : tensor<3xi64, #SparseVec64>, tensor<3xf64, #SparseVec64> // expected-error {{operands must have identical types.}}
        return %answer : i1
    }
 
@@ -43,7 +43,7 @@ module {
 module {
 
    func @vector_equals_wrapper(%argA: tensor<3xi64, #SparseVec64>, %argB: tensor<99xi64, #SparseVec64>) -> i1 {
-       %answer = graphblas.equal %argA, %argB : tensor<3xi64, #SparseVec64>, tensor<99xi64, #SparseVec64> // expected-error {{Input vectors must have compatible shapes.}}
+       %answer = graphblas.equal %argA, %argB : tensor<3xi64, #SparseVec64>, tensor<99xi64, #SparseVec64> // expected-error {{Inputs must have identical shapes.}}
        return %answer : i1
    }
 

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_matrix_convert_layout.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_matrix_convert_layout.mlir
@@ -32,7 +32,7 @@ module {
 
 module {
     func @convert_layout_wrapper(%sparse_tensor: tensor<2x3xi16, #CSR64>) -> tensor<2x3xi16, #CSR_BOGUS> {
-        %answer = graphblas.convert_layout %sparse_tensor : tensor<2x3xi16, #CSR64> to tensor<2x3xi16, #CSR_BOGUS> // expected-error {{Sparse encoding pointer bit widths of input and result tensors do not match.}}
+        %answer = graphblas.convert_layout %sparse_tensor : tensor<2x3xi16, #CSR64> to tensor<2x3xi16, #CSR_BOGUS> // expected-error {{Input and output pointer bit widths do not match: 64!=32}}
         return %answer : tensor<2x3xi16, #CSR_BOGUS>
     }
 }
@@ -55,7 +55,7 @@ module {
 
 module {
     func @convert_layout_wrapper(%sparse_tensor: tensor<2x3xi16, #CSR64>) -> tensor<2x3xi16, #CSR_BOGUS> {
-        %answer = graphblas.convert_layout %sparse_tensor : tensor<2x3xi16, #CSR64> to tensor<2x3xi16, #CSR_BOGUS> // expected-error {{Sparse encoding index bit widths of input and result tensors do not match.}}
+        %answer = graphblas.convert_layout %sparse_tensor : tensor<2x3xi16, #CSR64> to tensor<2x3xi16, #CSR_BOGUS> // expected-error {{Input and output index bit widths do not match: 64!=32}}
         return %answer : tensor<2x3xi16, #CSR_BOGUS>
     }
 }

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_matrix_multiply.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_matrix_multiply.mlir
@@ -16,7 +16,7 @@
 
 module {
     func @matrix_multiply_wrapper(%argA: tensor<2x3xi64>, %argB: tensor<3x2xi64, #CSC64>) -> tensor<2x2xi64, #CSR64> {
-        %answer = graphblas.matrix_multiply %argA, %argB { semiring = "plus_times" } : (tensor<2x3xi64>, tensor<3x2xi64, #CSC64>) to tensor<2x2xi64, #CSR64> // expected-error {{First argument must be a sparse vector or sparse matrix}}
+        %answer = graphblas.matrix_multiply %argA, %argB { semiring = "plus_times" } : (tensor<2x3xi64>, tensor<3x2xi64, #CSC64>) to tensor<2x2xi64, #CSR64> // expected-error {{1st operand must be a sparse tensor.}}
         return %answer : tensor<2x2xi64, #CSR64>
     }
 }
@@ -39,7 +39,7 @@ module {
 
 module {
     func @matrix_multiply_wrapper(%argA: tensor<2x3xi64, #CSR64>, %argB: tensor<3x2xi64>) -> tensor<2x2xi64, #CSR64> {
-        %answer = graphblas.matrix_multiply %argA, %argB { semiring = "plus_pair" } : (tensor<2x3xi64, #CSR64>, tensor<3x2xi64>) to tensor<2x2xi64, #CSR64> // expected-error {{Second argument must be a sparse vector or sparse matrix}}
+        %answer = graphblas.matrix_multiply %argA, %argB { semiring = "plus_pair" } : (tensor<2x3xi64, #CSR64>, tensor<3x2xi64>) to tensor<2x2xi64, #CSR64> // expected-error {{2nd operand must be a sparse tensor.}}
         return %answer : tensor<2x2xi64, #CSR64>
     }
 }
@@ -62,7 +62,7 @@ module {
 
 module {
     func @matrix_multiply_wrapper(%argA: tensor<2x3xi64, #CSR64>, %argB: tensor<3x2xi64, #CSC64>) -> tensor<2x2xi64> {
-        %answer = graphblas.matrix_multiply %argA, %argB { semiring = "plus_plus" } : (tensor<2x3xi64, #CSR64>, tensor<3x2xi64, #CSC64>) to tensor<2x2xi64> // expected-error {{Return value must be a sparse tensor.}}
+        %answer = graphblas.matrix_multiply %argA, %argB { semiring = "plus_plus" } : (tensor<2x3xi64, #CSR64>, tensor<3x2xi64, #CSC64>) to tensor<2x2xi64> // expected-error {{result must be a sparse tensor.}}
         return %answer : tensor<2x2xi64>
     }
 }
@@ -200,7 +200,7 @@ module {
 
 module {
     func @matrix_multiply_wrapper(%argA: tensor<2x3xi64, #CSR64>, %argB: tensor<3x2xi64, #CSC64>, %mask: tensor<2x2xi64>) -> tensor<2x2xi64, #CSR64> {
-        %answer = graphblas.matrix_multiply %argA, %argB, %mask{ semiring = "plus_times" } : (tensor<2x3xi64, #CSR64>, tensor<3x2xi64, #CSC64>, tensor<2x2xi64>) to tensor<2x2xi64, #CSR64> // expected-error {{Operand #2 must be a sparse tensor.}}
+        %answer = graphblas.matrix_multiply %argA, %argB, %mask{ semiring = "plus_times" } : (tensor<2x3xi64, #CSR64>, tensor<3x2xi64, #CSC64>, tensor<2x2xi64>) to tensor<2x2xi64, #CSR64> // expected-error {{3rd operand (mask) must be a sparse tensor.}}
         return %answer : tensor<2x2xi64, #CSR64>
     }
 }
@@ -292,7 +292,7 @@ module {
 
 module {
     func @matrix_multiply_wrapper(%argA: tensor<2x2xf64, #CSC64>, %argB: tensor<2x2xf64, #CSC64>, %mask: tensor<2x2xf64, #CSR64>) -> tensor<2x2xf64, #CSR64> {
-        %answer = graphblas.matrix_multiply %argA, %argB, %mask { semiring = "plus_plus" } : (tensor<2x2xf64, #CSC64>, tensor<2x2xf64, #CSC64>, tensor<2x2xf64, #CSR64>) to tensor<2x2xf64, #CSR64> // expected-error {{Operand #0 must have CSR compression.}}
+        %answer = graphblas.matrix_multiply %argA, %argB, %mask { semiring = "plus_plus" } : (tensor<2x2xf64, #CSC64>, tensor<2x2xf64, #CSC64>, tensor<2x2xf64, #CSR64>) to tensor<2x2xf64, #CSR64> // expected-error {{1st operand must have CSR compression.}}
         return %answer : tensor<2x2xf64, #CSR64>
     }
 
@@ -309,7 +309,7 @@ module {
 
 module {
     func @matrix_multiply_wrapper(%argA: tensor<2x2xf64, #CSR64>, %argB: tensor<2x2xf64, #CSR64>) -> tensor<2x2xf64, #CSR64> {
-        %answer = graphblas.matrix_multiply %argA, %argB { semiring = "plus_plus" } : (tensor<2x2xf64, #CSR64>, tensor<2x2xf64, #CSR64>) to tensor<2x2xf64, #CSR64> // expected-error {{Operand #1 must have CSC compression.}}
+        %answer = graphblas.matrix_multiply %argA, %argB { semiring = "plus_plus" } : (tensor<2x2xf64, #CSR64>, tensor<2x2xf64, #CSR64>) to tensor<2x2xf64, #CSR64> // expected-error {{2nd operand must have CSC compression.}}
         return %answer : tensor<2x2xf64, #CSR64>
     }
 
@@ -333,7 +333,7 @@ module {
 
 module {
     func @matrix_multiply_wrapper(%argA: tensor<2x2xf64, #CSR64>, %argB: tensor<2x2xf64, #CSC64>, %mask: tensor<2x2xf64, #CSC64>) -> tensor<2x2xf64, #CSR64> {
-        %answer = graphblas.matrix_multiply %argA, %argB, %mask { semiring = "plus_plus" } : (tensor<2x2xf64, #CSR64>, tensor<2x2xf64, #CSC64>, tensor<2x2xf64, #CSC64>) to tensor<2x2xf64, #CSR64> // expected-error {{Operand #2 must have CSR compression.}}
+        %answer = graphblas.matrix_multiply %argA, %argB, %mask { semiring = "plus_plus" } : (tensor<2x2xf64, #CSR64>, tensor<2x2xf64, #CSC64>, tensor<2x2xf64, #CSC64>) to tensor<2x2xf64, #CSR64> // expected-error {{3rd operand (mask) must have CSR compression.}}
         return %answer : tensor<2x2xf64, #CSR64>
     }
 
@@ -357,7 +357,7 @@ module {
 
 module {
     func @matrix_multiply_wrapper(%argA: tensor<2x2xf64, #CSR64>, %argB: tensor<2x2xf64, #CSC64>, %mask: tensor<2x2xf64, #CSR64>) -> tensor<2x2xf64, #CSC64> {
-        %answer = graphblas.matrix_multiply %argA, %argB, %mask { semiring = "plus_plus" } : (tensor<2x2xf64, #CSR64>, tensor<2x2xf64, #CSC64>, tensor<2x2xf64, #CSR64>) to tensor<2x2xf64, #CSC64> // expected-error {{Return value must have CSR compression.}}
+        %answer = graphblas.matrix_multiply %argA, %argB, %mask { semiring = "plus_plus" } : (tensor<2x2xf64, #CSR64>, tensor<2x2xf64, #CSC64>, tensor<2x2xf64, #CSR64>) to tensor<2x2xf64, #CSC64> // expected-error {{result must have CSR compression.}}
         return %answer : tensor<2x2xf64, #CSC64>
     }
 

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_matrix_select.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_matrix_select.mlir
@@ -9,7 +9,7 @@
 
 module {
     func @matrix_select_wrapper(%sparse_tensor: tensor<2x3xbf16, #CSR64>) -> tensor<2x3xbf16> {
-        %answer = graphblas.matrix_select %sparse_tensor { selectors = ["triu"] } : tensor<2x3xbf16, #CSR64> to tensor<2x3xbf16> // expected-error {{Return value must be a sparse tensor.}}
+        %answer = graphblas.matrix_select %sparse_tensor { selectors = ["triu"] } : tensor<2x3xbf16, #CSR64> to tensor<2x3xbf16> // expected-error {{At least 1 result type does not match that of the input matrix.}}
         return %answer : tensor<2x3xbf16>
     }
 }

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_matrix_transpose.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_matrix_transpose.mlir
@@ -48,7 +48,7 @@ module {
 
 module {
     func @transpose_wrapper(%sparse_tensor: tensor<2x3xi16, #CSR64>) -> tensor<3x2xi16, #CSR_BOGUS> {
-        %answer = graphblas.transpose %sparse_tensor : tensor<2x3xi16, #CSR64> to tensor<3x2xi16, #CSR_BOGUS> // expected-error {{Sparse encoding pointer bit widths of input and result tensors do not match.}}
+        %answer = graphblas.transpose %sparse_tensor : tensor<2x3xi16, #CSR64> to tensor<3x2xi16, #CSR_BOGUS> // expected-error {{Input and output pointer bit widths do not match: 64!=32}}
         return %answer : tensor<3x2xi16, #CSR_BOGUS>
     }
 }
@@ -71,7 +71,7 @@ module {
 
 module {
     func @transpose_wrapper(%sparse_tensor: tensor<2x3xi16, #CSR64>) -> tensor<3x2xi16, #CSR_BOGUS> {
-        %answer = graphblas.transpose %sparse_tensor : tensor<2x3xi16, #CSR64> to tensor<3x2xi16, #CSR_BOGUS> // expected-error {{Sparse encoding index bit widths of input and result tensors do not match.}}
+        %answer = graphblas.transpose %sparse_tensor : tensor<2x3xi16, #CSR64> to tensor<3x2xi16, #CSR_BOGUS> // expected-error {{Input and output index bit widths do not match: 64!=32}}
         return %answer : tensor<3x2xi16, #CSR_BOGUS>
     }
 }

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_matrix_vector_multiply.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_matrix_vector_multiply.mlir
@@ -16,7 +16,7 @@
 module {
 
    func @matrix_vector_multiply_plus_times(%matrix: tensor<2x3xi64>, %vector: tensor<3xi64, #SparseVec64>) -> tensor<2xi64, #SparseVec64> {
-       %answer = graphblas.matrix_multiply %matrix, %vector { semiring = "plus_times" } : (tensor<2x3xi64>, tensor<3xi64, #SparseVec64>) to tensor<2xi64, #SparseVec64> // expected-error {{First argument must be a sparse vector or sparse matrix.}}
+       %answer = graphblas.matrix_multiply %matrix, %vector { semiring = "plus_times" } : (tensor<2x3xi64>, tensor<3xi64, #SparseVec64>) to tensor<2xi64, #SparseVec64> // expected-error {{1st operand must be a sparse tensor.}}
        return %answer : tensor<2xi64, #SparseVec64>
    }
 

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_reduce_to_scalar.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_reduce_to_scalar.mlir
@@ -11,7 +11,7 @@ module {
 
 module {
     func @reduce_to_scalar_wrapper(%sparse_tensor: tensor<?x?xf64>) -> f64 {
-        %answer = graphblas.reduce_to_scalar %sparse_tensor { aggregator = "plus" } : tensor<?x?xf64> to f64 // expected-error {{Operand #0 must be a sparse vector or sparse matrix.}}
+        %answer = graphblas.reduce_to_scalar %sparse_tensor { aggregator = "plus" } : tensor<?x?xf64> to f64 // expected-error {{operand must be a sparse tensor.}}
         return %answer : f64
     }
 }
@@ -43,7 +43,7 @@ module {
 
 module {
     func @reduce_to_scalar_wrapper(%sparse_tensor: tensor<?x?xf64, #BADENCODING>) -> f64 {
-        %answer = graphblas.reduce_to_scalar %sparse_tensor { aggregator = "plus" } : tensor<?x?xf64, #BADENCODING> to f64 // expected-error {{Operand #0 must have CSR or CSC compression, i.e. must have dimLevelType = [ "dense", "compressed" ] in the sparse encoding.}}
+        %answer = graphblas.reduce_to_scalar %sparse_tensor { aggregator = "plus" } : tensor<?x?xf64, #BADENCODING> to f64 // expected-error {{operand must have CSR or CSC compression, i.e. must have dimLevelType = [ "dense", "compressed" ] in the sparse encoding.}}
         return %answer : f64
     }
 }
@@ -59,7 +59,7 @@ module {
 
 module {
     func @reduce_to_scalar_wrapper(%sparse_tensor: tensor<?x?xf64, #BADENCODING>) -> f64 {
-        %answer = graphblas.reduce_to_scalar %sparse_tensor { aggregator = "plus" } : tensor<?x?xf64, #BADENCODING> to f64 // expected-error {{Operand #0 must have CSR or CSC compression, i.e. must have dimLevelType = [ "dense", "compressed" ] in the sparse encoding.}}
+        %answer = graphblas.reduce_to_scalar %sparse_tensor { aggregator = "plus" } : tensor<?x?xf64, #BADENCODING> to f64 // expected-error {{operand must have CSR or CSC compression, i.e. must have dimLevelType = [ "dense", "compressed" ] in the sparse encoding.}}
         return %answer : f64
     }
 }
@@ -75,7 +75,7 @@ module {
 
 module {
     func @reduce_to_scalar_wrapper(%sparse_tensor: tensor<?x?xf64, #BADENCODING>) -> f64 {
-        %answer = graphblas.reduce_to_scalar %sparse_tensor { aggregator = "plus" } : tensor<?x?xf64, #BADENCODING> to f64 // expected-error {{Operand #0 must have CSR or CSC compression, i.e. must have dimLevelType = [ "dense", "compressed" ] in the sparse encoding.}}
+        %answer = graphblas.reduce_to_scalar %sparse_tensor { aggregator = "plus" } : tensor<?x?xf64, #BADENCODING> to f64 // expected-error {{operand must have CSR or CSC compression, i.e. must have dimLevelType = [ "dense", "compressed" ] in the sparse encoding.}}
         return %answer : f64
     }
 }
@@ -91,7 +91,7 @@ module {
 
 module {
     func @reduce_to_scalar_wrapper(%sparse_tensor: tensor<?x?xf64, #BADENCODING>) -> f64 {
-        %answer = graphblas.reduce_to_scalar %sparse_tensor { aggregator = "plus" } : tensor<?x?xf64, #BADENCODING> to f64 // expected-error {{Operand #0 must have CSR or CSC compression, i.e. must have dimLevelType = [ "dense", "compressed" ] in the sparse encoding.}}
+        %answer = graphblas.reduce_to_scalar %sparse_tensor { aggregator = "plus" } : tensor<?x?xf64, #BADENCODING> to f64 // expected-error {{operand must have CSR or CSC compression, i.e. must have dimLevelType = [ "dense", "compressed" ] in the sparse encoding.}}
         return %answer : f64
     }
 }
@@ -107,7 +107,7 @@ module {
 
 module {
     func @reduce_to_scalar_wrapper(%sparse_tensor: tensor<?x?xf64, #BADENCODING>) -> f64 {
-        %answer = graphblas.reduce_to_scalar %sparse_tensor { aggregator = "plus" } : tensor<?x?xf64, #BADENCODING> to f64 // expected-error {{Operand #0 must have CSR or CSC compression, i.e. must have dimLevelType = [ "dense", "compressed" ] in the sparse encoding.}}
+        %answer = graphblas.reduce_to_scalar %sparse_tensor { aggregator = "plus" } : tensor<?x?xf64, #BADENCODING> to f64 // expected-error {{operand must have CSR or CSC compression, i.e. must have dimLevelType = [ "dense", "compressed" ] in the sparse encoding.}}
         return %answer : f64
     }
 }
@@ -123,7 +123,7 @@ module {
 
 module {
     func @reduce_to_scalar_wrapper(%sparse_tensor: tensor<?x?xf64, #BADENCODING>) -> f64 {
-        %answer = graphblas.reduce_to_scalar %sparse_tensor { aggregator = "plus" } : tensor<?x?xf64, #BADENCODING> to f64 // expected-error {{Operand #0 must have CSR or CSC compression, i.e. must have dimLevelType = [ "dense", "compressed" ] in the sparse encoding.}}
+        %answer = graphblas.reduce_to_scalar %sparse_tensor { aggregator = "plus" } : tensor<?x?xf64, #BADENCODING> to f64 // expected-error {{operand must have CSR or CSC compression, i.e. must have dimLevelType = [ "dense", "compressed" ] in the sparse encoding.}}
         return %answer : f64
     }
 }
@@ -139,7 +139,7 @@ module {
 
 module {
     func @reduce_to_scalar_wrapper(%sparse_tensor: tensor<?x?xf64, #BADENCODING>) -> f64 {
-        %answer = graphblas.reduce_to_scalar %sparse_tensor { aggregator = "plus" } : tensor<?x?xf64, #BADENCODING> to f64 // expected-error {{Operand #0 must have CSR or CSC compression, i.e. must have dimLevelType = [ "dense", "compressed" ] in the sparse encoding.}}
+        %answer = graphblas.reduce_to_scalar %sparse_tensor { aggregator = "plus" } : tensor<?x?xf64, #BADENCODING> to f64 // expected-error {{operand must have CSR or CSC compression, i.e. must have dimLevelType = [ "dense", "compressed" ] in the sparse encoding.}}
         return %answer : f64
     }
 }
@@ -155,7 +155,7 @@ module {
 
 module {
     func @reduce_to_scalar_wrapper(%sparse_tensor: tensor<?x?xf64, #BADENCODING>) -> f64 {
-        %answer = graphblas.reduce_to_scalar %sparse_tensor { aggregator = "plus" } : tensor<?x?xf64, #BADENCODING> to f64 // expected-error {{Operand #0 must have CSR or CSC compression, i.e. must have dimLevelType = [ "dense", "compressed" ] in the sparse encoding.}}
+        %answer = graphblas.reduce_to_scalar %sparse_tensor { aggregator = "plus" } : tensor<?x?xf64, #BADENCODING> to f64 // expected-error {{operand must have CSR or CSC compression, i.e. must have dimLevelType = [ "dense", "compressed" ] in the sparse encoding.}}
         return %answer : f64
     }
 }

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_reduce_to_vector.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_reduce_to_vector.mlir
@@ -23,7 +23,7 @@ module {
 
 module {
     func @reduce_to_vector_wrapper(%matrix: tensor<?x?xi32>) -> tensor<9xi32, #SparseVec64> {
-        %vec = graphblas.reduce_to_vector %matrix { aggregator = "plus", axis = 0 } : tensor<?x?xi32> to tensor<9xi32, #SparseVec64> // expected-error {{Operand #0 must be a sparse tensor.}}
+        %vec = graphblas.reduce_to_vector %matrix { aggregator = "plus", axis = 0 } : tensor<?x?xi32> to tensor<9xi32, #SparseVec64> // expected-error {{operand must be a sparse tensor.}}
         return %vec : tensor<9xi32, #SparseVec64>
     }
 }
@@ -85,7 +85,7 @@ module {
 
 module {
     func @reduce_to_vector_wrapper(%matrix: tensor<7x9xi32, #BADENCODING>) -> tensor<9xi32, #SparseVec64> {
-        %vec = graphblas.reduce_to_vector %matrix { aggregator = "plus", axis = 0 } : tensor<7x9xi32, #BADENCODING> to tensor<9xi32, #SparseVec64> // expected-error {{Operand #0 must have CSR or CSC compression, i.e. must have dimLevelType = [ "dense", "compressed" ] in the sparse encoding.}}
+        %vec = graphblas.reduce_to_vector %matrix { aggregator = "plus", axis = 0 } : tensor<7x9xi32, #BADENCODING> to tensor<9xi32, #SparseVec64> // expected-error {{operand must have CSR or CSC compression, i.e. must have dimLevelType = [ "dense", "compressed" ] in the sparse encoding.}}
         return %vec : tensor<9xi32, #SparseVec64>
     }
 }
@@ -109,7 +109,7 @@ module {
 
 module {
     func @reduce_to_vector_wrapper(%matrix: tensor<7x9xi32, #CSR64>) -> tensor<9xi32, #BADENCODING> {
-        %vec = graphblas.reduce_to_vector %matrix { aggregator = "plus", axis = 0 } : tensor<7x9xi32, #CSR64> to tensor<9xi32, #BADENCODING> // expected-error {{Return value must be sparse, i.e. must have dimLevelType = [ "compressed" ] in the sparse encoding.}}
+        %vec = graphblas.reduce_to_vector %matrix { aggregator = "plus", axis = 0 } : tensor<7x9xi32, #CSR64> to tensor<9xi32, #BADENCODING> // expected-error {{result must be sparse, i.e. must have dimLevelType = [ "compressed" ] in the sparse encoding.}}
         return %vec : tensor<9xi32, #BADENCODING>
     }
 }

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_vector_argminmax.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_vector_argminmax.mlir
@@ -20,7 +20,7 @@ module {
 module {
 
    func @vector_argminmax_wrapper(%argA: tensor<3xi64>) -> index {
-       %answer = graphblas.vector_argminmax %argA { minmax = "max" } : tensor<3xi64> // expected-error {{Operand #0 must be a sparse tensor.}}
+       %answer = graphblas.vector_argminmax %argA { minmax = "max" } : tensor<3xi64> // expected-error {{operand must be a sparse tensor.}}
        return %answer : index
    }
 
@@ -31,7 +31,7 @@ module {
 module {
 
    func @vector_argmin_wrapper(%argA: tensor<3xi64>) -> index {
-       %answer = graphblas.vector_argmin %argA : tensor<3xi64> // expected-error {{Operand #0 must be a sparse tensor.}}
+       %answer = graphblas.vector_argmin %argA : tensor<3xi64> // expected-error {{operand must be a sparse tensor.}}
        return %answer : index
    }
 
@@ -42,7 +42,7 @@ module {
 module {
 
    func @vector_argmax_wrapper(%argA: tensor<3xi64>) -> index {
-       %answer = graphblas.vector_argmax %argA : tensor<3xi64> // expected-error {{Operand #0 must be a sparse tensor.}}
+       %answer = graphblas.vector_argmax %argA : tensor<3xi64> // expected-error {{operand must be a sparse tensor.}}
        return %answer : index
    }
 

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_vector_dot_product.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_vector_dot_product.mlir
@@ -26,7 +26,7 @@ module {
 module {
 
    func @vector_dot_product_wrapper(%argA: tensor<3xi64>, %argB: tensor<?xi64, #SparseVec64>) -> i64 {
-       %answer = graphblas.matrix_multiply %argA, %argB { semiring = "plus_times" } : (tensor<3xi64>, tensor<?xi64, #SparseVec64>) to i64 // expected-error {{First argument must be a sparse vector or sparse matrix.}}
+       %answer = graphblas.matrix_multiply %argA, %argB { semiring = "plus_times" } : (tensor<3xi64>, tensor<?xi64, #SparseVec64>) to i64 // expected-error {{1st operand must be a sparse tensor.}}
        return %answer : i64
    }
 

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_vector_update_accumulate.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_vector_update_accumulate.mlir
@@ -23,7 +23,7 @@ module {
 
 module {
     func @vector_accumulate_wrapper(%argA: tensor<8xi64>, %argB: tensor<8xi64, #SparseVec64>) -> () {
-        graphblas.update %argA -> %argB { accumulate_operator = "plus" } : tensor<8xi64> -> tensor<8xi64, #SparseVec64> // expected-error {{Input argument must be a sparse vector or sparse matrix.}}
+        graphblas.update %argA -> %argB { accumulate_operator = "plus" } : tensor<8xi64> -> tensor<8xi64, #SparseVec64> // expected-error {{input must be a sparse tensor.}}
     }
 }
 
@@ -37,7 +37,7 @@ module {
 
 module {
     func @vector_accumulate_wrapper(%argA: tensor<8xi64, #SparseVec64>, %argB: tensor<8xf64, #SparseVec64>) -> () {
-        graphblas.update %argA -> %argB { accumulate_operator = "plus" } : tensor<8xi64, #SparseVec64> -> tensor<8xf64, #SparseVec64> // expected-error {{Arguments must have the same type.}}
+        graphblas.update %argA -> %argB { accumulate_operator = "plus" } : tensor<8xi64, #SparseVec64> -> tensor<8xf64, #SparseVec64> // expected-error {{input and output must have identical types.}}
     }
 }
 
@@ -51,6 +51,6 @@ module {
 
 module {
     func @vector_accumulate_wrapper(%argA: tensor<3xi64, #SparseVec64>, %argB: tensor<8xi64, #SparseVec64>) -> () {
-        graphblas.update %argA -> %argB { accumulate_operator = "plus" } : tensor<3xi64, #SparseVec64> -> tensor<8xi64, #SparseVec64> // expected-error {{Input and Output arguments must have compatible shapes.}}
+        graphblas.update %argA -> %argB { accumulate_operator = "plus" } : tensor<3xi64, #SparseVec64> -> tensor<8xi64, #SparseVec64> // expected-error {{Input and Output arguments must have identical shapes.}}
     }
 }


### PR DESCRIPTION
New checks for CSR/CSC were added in PR#110. Unfortunately, those checks were incorrect (see discussion #165).

This PR fixes the CSR/CSC checks and consolidates them with the existing checks. The general approach was to use the framework of the existing checks (return optional<str>, message if error, None if success). But instead of passing an index to indicate the operand number (or return value if negative), that piece is left to the caller to make the check less magical and to give greater flexibility to the caller.