### PR TITLE
Support "argmin" and "argmax" in graphblas.reduce_to_vector

### DIFF
--- a/mlir_graphblas/SparseUtils.cpp
+++ b/mlir_graphblas/SparseUtils.cpp
@@ -839,6 +839,9 @@ void *vector_f32_p64i64_to_ptr8(void *tensor) {
 void *vector_i64_p64i64_to_ptr8(void *tensor) {
     return tensor;
 }
+void *vector_i32_p64i64_to_ptr8(void *tensor) {
+    return tensor;
+}
 // Combinations of !llvm.ptr<i8> to real types
 void *ptr8_to_matrix_csr_f64_p64i64(void *tensor) {
     return tensor;
@@ -865,6 +868,9 @@ void *ptr8_to_vector_f32_p64i64(void *tensor) {
     return tensor;
 }
 void *ptr8_to_vector_i64_p64i64(void *tensor) {
+    return tensor;
+}
+void *ptr8_to_vector_i32_p64i64(void *tensor) {
     return tensor;
 }
 // New tensor generic constructors
@@ -915,6 +921,10 @@ void *new_vector_f32_p64i64(uint64_t size) {
 }
 void *new_vector_i64_p64i64(uint64_t size) {
     SparseTensorStorageBase *tensor = new SparseTensorStorage<uint64_t, uint64_t, int64_t>(1);
+    return vector_prep_size(tensor, size);
+}
+void *new_vector_i32_p64i64(uint64_t size) {
+    SparseTensorStorageBase *tensor = new SparseTensorStorage<uint64_t, uint64_t, int32_t>(1);
     return vector_prep_size(tensor, size);
 }
 

--- a/mlir_graphblas/ops.py
+++ b/mlir_graphblas/ops.py
@@ -541,7 +541,7 @@ class GraphBLAS_ReduceToVector(BaseOp):
             input.type.encoding.index_bit_width,
         )
         return_element_type = (
-            IntType(64) if aggregator in ("argmin", "argmax") else input.type.value_type
+            IntType(32) if aggregator in ("argmin", "argmax") else input.type.value_type
         )
         return_type = TensorType([-1], return_element_type, sparse_vec_encoding)
         ret_val = irbuilder.new_var(return_type)

--- a/mlir_graphblas/ops.py
+++ b/mlir_graphblas/ops.py
@@ -523,7 +523,7 @@ class GraphBLAS_MatrixSelect(BaseOp):
 class GraphBLAS_ReduceToVector(BaseOp):
     dialect = "graphblas"
     name = "reduce_to_vector"
-    allowed_aggregators = {"plus", "count"}
+    allowed_aggregators = {"plus", "count", "argmin", "argmax"}
 
     @classmethod
     def call(cls, irbuilder, input, aggregator, axis):
@@ -540,7 +540,10 @@ class GraphBLAS_ReduceToVector(BaseOp):
             input.type.encoding.pointer_bit_width,
             input.type.encoding.index_bit_width,
         )
-        return_type = TensorType([-1], input.type.value_type, sparse_vec_encoding)
+        return_element_type = (
+            IntType(64) if aggregator in ("argmin", "argmax") else input.type.value_type
+        )
+        return_type = TensorType([-1], return_element_type, sparse_vec_encoding)
         ret_val = irbuilder.new_var(return_type)
         return ret_val, (
             f"{ret_val.assign} = graphblas.reduce_to_vector {input} "
@@ -551,7 +554,7 @@ class GraphBLAS_ReduceToVector(BaseOp):
 class GraphBLAS_ReduceToScalar(BaseOp):
     dialect = "graphblas"
     name = "reduce_to_scalar"
-    allowed_aggregators = {"plus", "count"}
+    allowed_aggregators = {"plus", "count", "argmin", "argmax"}
 
     @classmethod
     def call(cls, irbuilder, input, aggregator):

--- a/mlir_graphblas/sparse_utils.pyx
+++ b/mlir_graphblas/sparse_utils.pyx
@@ -208,6 +208,7 @@ cdef extern from "SparseUtils.cpp" nogil:
     void *vector_f64_p64i64_to_ptr8(void *tensor)
     void *vector_f32_p64i64_to_ptr8(void *tensor)
     void *vector_i64_p64i64_to_ptr8(void *tensor)
+    void *vector_i32_p64i64_to_ptr8(void *tensor)
     void *ptr8_to_matrix_csr_f64_p64i64(void *tensor)
     void *ptr8_to_matrix_csr_f32_p64i64(void *tensor)
     void *ptr8_to_matrix_csr_i64_p64i64(void *tensor)
@@ -217,6 +218,7 @@ cdef extern from "SparseUtils.cpp" nogil:
     void *ptr8_to_vector_f64_p64i64(void *tensor)
     void *ptr8_to_vector_f32_p64i64(void *tensor)
     void *ptr8_to_vector_i64_p64i64(void *tensor)
+    void *ptr8_to_vector_i32_p64i64(void *tensor)
 
     # Typed constructors
     void *new_matrix_csr_f64_p64i64(uint64_t nrows, uint64_t ncols)
@@ -228,6 +230,7 @@ cdef extern from "SparseUtils.cpp" nogil:
     void *new_vector_f64_p64i64(uint64_t size)
     void *new_vector_f32_p64i64(uint64_t size)
     void *new_vector_i64_p64i64(uint64_t size)
+    void *new_vector_i32_p64i64(uint64_t size)
 
 
 # st for "sparse tensor"

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
@@ -239,13 +239,13 @@ def GraphBLAS_ReduceToVectorOp : GraphBLAS_Op<"reduce_to_vector", [NoSideEffect]
         vector's size must be the  number of rows in the input tensor.
         The supported aggregators are "plus", "count", "argmin", and "argmax".
 
-        When using the aggregators "argmin" and "argmax", the output tensor must have 64-bit integer elements.
+        When using the aggregators "argmin" and "argmax", the output tensor must have 32-bit integer elements.
 
         Example:
         ```mlir
-        %vec1 = graphblas.reduce_to_vector %matrix { aggregator = "plus", axis = 0 } : tensor<7x9xi32, #CSR64> to tensor<9xi32, #SparseVec64>
-        %vec2 = graphblas.reduce_to_vector %matrix { aggregator = "count", axis = 1 } : tensor<7x9xi32, #CSR64> to tensor<7xi32, #SparseVec64>
-        %vec3 = graphblas.reduce_to_vector %matrix { aggregator = "argmin", axis = 1 } : tensor<7x9xf32, #CSR64> to tensor<7xi64, #SparseVec64>
+        %vec1 = graphblas.reduce_to_vector %matrix { aggregator = "plus", axis = 0 } : tensor<7x9xf16, #CSR64> to tensor<9xf16, #SparseVec64>
+        %vec2 = graphblas.reduce_to_vector %matrix { aggregator = "count", axis = 1 } : tensor<7x9xf16, #CSR64> to tensor<7xf16, #SparseVec64>
+        %vec3 = graphblas.reduce_to_vector %matrix { aggregator = "argmin", axis = 1 } : tensor<7x9xf32, #CSR64> to tensor<7xi32, #SparseVec64>
         ```
     }];
 

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
@@ -237,12 +237,15 @@ def GraphBLAS_ReduceToVectorOp : GraphBLAS_Op<"reduce_to_vector", [NoSideEffect]
         vector's size must be the number of columns in the input tensor.
         If the axis attribute is 1, the input tensor will be reduced row-wise, so the resulting
         vector's size must be the  number of rows in the input tensor.
-        The supported aggregators are "plus" and "count".
+        The supported aggregators are "plus", "count", "argmin", and "argmax".
+
+        When using the aggregators "argmin" and "argmax", the output tensor must have 64-bit integer elements.
 
         Example:
         ```mlir
         %vec1 = graphblas.reduce_to_vector %matrix { aggregator = "plus", axis = 0 } : tensor<7x9xi32, #CSR64> to tensor<9xi32, #SparseVec64>
         %vec2 = graphblas.reduce_to_vector %matrix { aggregator = "count", axis = 1 } : tensor<7x9xi32, #CSR64> to tensor<7xi32, #SparseVec64>
+        %vec3 = graphblas.reduce_to_vector %matrix { aggregator = "argmin", axis = 1 } : tensor<7x9xf32, #CSR64> to tensor<7xi64, #SparseVec64>
         ```
     }];
 
@@ -262,10 +265,15 @@ def GraphBLAS_ReduceToScalarOp : GraphBLAS_Op<"reduce_to_scalar", [NoSideEffect]
         Reduces a sparse matrix or sparse vector to a scalar according to the given aggregator.
         Matrices must have a CSR sparsity or a CSC sparsity.  The resulting
         scalar's type will depend on the type of the input tensor.
+        The supported aggregators are "plus", "count", "argmin", and "argmax".
+
+        When using the aggregators "argmin" and "argmax", the output must be a 64-bit integer,
+        and the input type must be a vector.
 
         Example:
         ```mlir
-        %answer = graphblas.reduce_to_scalar %sparse_matrix { aggregator = "plus" } : tensor<?x?xi64, #CSR64> to i64
+        %answer_1 = graphblas.reduce_to_scalar %sparse_matrix { aggregator = "plus" } : tensor<?x?xf32, #CSR64> to f32
+        %answer_2 = graphblas.reduce_to_scalar %sparse_vector { aggregator = "argmax" } : tensor<?xf64, #CSR64> to i64
         ```
     }];
 

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASUtils.h
@@ -30,7 +30,8 @@ static const llvm::StringSet<> supportedSemiringAddNames{"plus", "any", "min"};
 static const llvm::StringSet<> supportedSemiringMultiplyNames{
     "pair", "times", "plus", "first", "second"};
 
-static const llvm::StringSet<> supportedReduceAggregators{"plus", "count"};
+static const llvm::StringSet<> supportedReduceAggregators{"plus", "count",
+                                                          "argmin", "argmax"};
 
 static const llvm::StringSet<> supportedSelectors{"triu", "tril", "gt"};
 static const llvm::StringSet<> supportedThunkNeedingSelectors{"gt"};

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASLowerPass.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASLowerPass.cpp
@@ -681,10 +681,12 @@ public:
     }*/
 
     Type indexType = rewriter.getIndexType();
+    Type int32Type = rewriter.getIntegerType(32);
     Type int64Type = rewriter.getIntegerType(64);
 
     Type memref1DValueType = MemRefType::get({-1}, elementType);
     MemRefType memref1DI64Type = MemRefType::get({-1}, int64Type);
+    MemRefType memref1DI32Type = MemRefType::get({-1}, int32Type);
 
     sparse_tensor::SparseTensorEncodingAttr sparseEncoding =
         sparse_tensor::getSparseTensorEncoding(matrixType);
@@ -717,7 +719,7 @@ public:
 
     ValueRange outputShape = {len_dense_dim};
     Type vectorElementType = (aggregator == "argmin" || aggregator == "argmax")
-                                 ? int64Type
+                                 ? int32Type
                                  : elementType;
     RankedTensorType vectorType =
         getCompressedVectorType(context, vectorElementType);
@@ -770,7 +772,7 @@ public:
     Value outputIndices = rewriter.create<sparse_tensor::ToIndicesOp>(
         loc, memref1DI64Type, output, c0);
     Type outputValuesType = (aggregator == "argmin" || aggregator == "argmax")
-                                ? memref1DI64Type
+                                ? memref1DI32Type
                                 : memref1DValueType;
     Value outputValues = rewriter.create<sparse_tensor::ToValuesOp>(
         loc, outputValuesType, output);
@@ -923,9 +925,13 @@ public:
               rewriter.setInsertionPointAfter(rowAggregationLoop);
             }
 
-            Value rowAggregation = rowAggregationLoop.getResult(1);
-            rewriter.create<memref::StoreOp>(loc, rowAggregation, outputValues,
-                                             outputValuesPosition);
+            Value rowAggregation_i64 = rowAggregationLoop.getResult(1);
+            Value rowAggregation_i32 = rewriter.create<TruncateIOp>(
+                loc, int32Type,
+                rowAggregation_i64); // TODO this is a workaround ; make this
+                                     // work is i64
+            rewriter.create<memref::StoreOp>(
+                loc, rowAggregation_i32, outputValues, outputValuesPosition);
             Value rowIndex64 =
                 rewriter.create<IndexCastOp>(loc, rowIndex, int64Type);
             rewriter.create<memref::StoreOp>(loc, rowIndex64, outputIndices,
@@ -3261,7 +3267,6 @@ public:
   using OpRewritePattern<graphblas::MatrixSelectRandomOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(graphblas::MatrixSelectRandomOp op,
                                 PatternRewriter &rewriter) const override {
-    ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
 
     Value input = op.input();

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASLowerPass.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASLowerPass.cpp
@@ -716,8 +716,11 @@ public:
         loc, memref1DPointerType, matrix, c1);
 
     ValueRange outputShape = {len_dense_dim};
-
-    RankedTensorType vectorType = getCompressedVectorType(context, elementType);
+    Type vectorElementType = (aggregator == "argmin" || aggregator == "argmax")
+                                 ? int64Type
+                                 : elementType;
+    RankedTensorType vectorType =
+        getCompressedVectorType(context, vectorElementType);
     Value output =
         callNewTensor(rewriter, module, loc, outputShape, vectorType);
 
@@ -766,8 +769,11 @@ public:
 
     Value outputIndices = rewriter.create<sparse_tensor::ToIndicesOp>(
         loc, memref1DI64Type, output, c0);
+    Type outputValuesType = (aggregator == "argmin" || aggregator == "argmax")
+                                ? memref1DI64Type
+                                : memref1DValueType;
     Value outputValues = rewriter.create<sparse_tensor::ToValuesOp>(
-        loc, memref1DValueType, output);
+        loc, outputValuesType, output);
 
     scf::ForOp reduceLoop =
         rewriter.create<scf::ForOp>(loc, c0, len_dense_dim, c1, ValueRange{c0});
@@ -781,8 +787,166 @@ public:
           rewriter.create<AddIOp>(loc, rowIndex, c1).getResult();
       Value nextPtr64 =
           rewriter.create<memref::LoadOp>(loc, matrixPointers, nextRowIndex);
+
       scf::IfOp ifRowIsNonEmptyBlock;
-      if (aggregator == "plus") {
+      if (aggregator == "count") {
+
+        Value ptrDiff = rewriter.create<SubIOp>(loc, nextPtr64, ptr64);
+
+        Value c0_i64 = rewriter.create<ConstantOp>(
+            loc, rewriter.getIntegerAttr(int64Type, 0));
+        Value rowIsNonEmpty =
+            rewriter.create<CmpIOp>(loc, CmpIPredicate::ne, ptrDiff, c0_i64);
+
+        ifRowIsNonEmptyBlock = rewriter.create<scf::IfOp>(
+            loc, TypeRange{indexType}, rowIsNonEmpty, true);
+        {
+          rewriter.setInsertionPointToStart(ifRowIsNonEmptyBlock.thenBlock());
+          {
+            Type valueType =
+                output.getType().dyn_cast<RankedTensorType>().getElementType();
+
+            // TODO should we require the output to have the element type be
+            // index or some integer type?
+            Value rowReduction =
+                llvm::TypeSwitch<Type, Value>(valueType)
+                    .Case<IntegerType>([&](IntegerType type) {
+                      Value ans;
+                      if (type.getWidth() < 64)
+                        ans = rewriter.create<TruncateIOp>(loc, type, ptrDiff);
+                      else
+                        ans =
+                            rewriter.create<SignExtendIOp>(loc, type, ptrDiff);
+                      return ans;
+                    })
+                    .Case<FloatType>([&](FloatType type) {
+                      return rewriter.create<SIToFPOp>(loc, type, ptrDiff);
+                    });
+            rewriter.create<memref::StoreOp>(loc, rowReduction, outputValues,
+                                             outputValuesPosition);
+            Value rowIndex64 =
+                rewriter.create<IndexCastOp>(loc, rowIndex, int64Type);
+            rewriter.create<memref::StoreOp>(loc, rowIndex64, outputIndices,
+                                             outputValuesPosition);
+            Value updatedOutputValuesPosition =
+                rewriter.create<AddIOp>(loc, outputValuesPosition, c1)
+                    .getResult();
+            rewriter.create<scf::YieldOp>(
+                loc, ValueRange{updatedOutputValuesPosition});
+          }
+
+          rewriter.setInsertionPointToStart(ifRowIsNonEmptyBlock.elseBlock());
+          {
+            rewriter.create<scf::YieldOp>(loc,
+                                          ValueRange{outputValuesPosition});
+          }
+
+          rewriter.setInsertionPointAfter(ifRowIsNonEmptyBlock);
+        }
+      } else if (aggregator == "argmin" || aggregator == "argmax") {
+        Value rowIsNonEmpty =
+            rewriter.create<CmpIOp>(loc, CmpIPredicate::ne, ptr64, nextPtr64);
+        ifRowIsNonEmptyBlock = rewriter.create<scf::IfOp>(
+            loc, TypeRange{indexType}, rowIsNonEmpty, true);
+        {
+
+          rewriter.setInsertionPointAfter(matrixValues.getDefiningOp());
+          Value matrixIndices = rewriter.create<sparse_tensor::ToIndicesOp>(
+              loc, memref1DI64Type, matrix, c1);
+
+          rewriter.setInsertionPointToStart(ifRowIsNonEmptyBlock.thenBlock());
+          {
+
+            Value ptr = rewriter.create<IndexCastOp>(loc, ptr64, indexType);
+            Value initialExtremum =
+                rewriter.create<memref::LoadOp>(loc, matrixValues, ptr);
+            Value initialExtremumTensorIndex =
+                rewriter.create<memref::LoadOp>(loc, matrixIndices, ptr);
+            Value ptrPlusOne =
+                rewriter.create<AddIOp>(loc, ptr, c1).getResult();
+            Value nextPtr =
+                rewriter.create<IndexCastOp>(loc, nextPtr64, indexType);
+            scf::ForOp rowAggregationLoop = rewriter.create<scf::ForOp>(
+                loc, ptrPlusOne, nextPtr, c1,
+                ValueRange{initialExtremum, initialExtremumTensorIndex});
+            {
+              rewriter.setInsertionPointToStart(rowAggregationLoop.getBody());
+              Value currentExtremum =
+                  rowAggregationLoop.getLoopBody().getArgument(1);
+              Value currentExtremumTensorIndex =
+                  rowAggregationLoop.getLoopBody().getArgument(2);
+
+              Value currentPtr = rowAggregationLoop.getInductionVar();
+              Value rowValue = rewriter.create<memref::LoadOp>(
+                  loc, matrixValues, currentPtr);
+
+              bool useMinimum = aggregator == "argmin";
+              Value mustUpdate = llvm::TypeSwitch<Type, Value>(elementType)
+                                     .Case<IntegerType>([&](IntegerType type) {
+                                       return rewriter.create<CmpIOp>(
+                                           loc,
+                                           useMinimum ? CmpIPredicate::slt
+                                                      : CmpIPredicate::sgt,
+                                           rowValue, currentExtremum);
+                                     })
+                                     .Case<FloatType>([&](FloatType type) {
+                                       return rewriter.create<CmpFOp>(
+                                           loc,
+                                           useMinimum ? CmpFPredicate::OLT
+                                                      : CmpFPredicate::OGT,
+                                           rowValue, currentExtremum);
+                                     });
+
+              scf::IfOp ifMustUpdateBlock = rewriter.create<scf::IfOp>(
+                  loc, TypeRange{elementType, int64Type}, mustUpdate, true);
+              {
+                rewriter.setInsertionPointToStart(
+                    ifMustUpdateBlock.thenBlock());
+                Value tensorIndex = rewriter.create<memref::LoadOp>(
+                    loc, matrixIndices, currentPtr);
+                rewriter.create<scf::YieldOp>(
+                    loc, ValueRange{rowValue, tensorIndex});
+              }
+              {
+                rewriter.setInsertionPointToStart(
+                    ifMustUpdateBlock.elseBlock());
+                rewriter.create<scf::YieldOp>(
+                    loc,
+                    ValueRange{currentExtremum, currentExtremumTensorIndex});
+                rewriter.setInsertionPointAfter(ifMustUpdateBlock);
+              }
+              Value updatedExtremum = ifMustUpdateBlock.getResult(0);
+              Value updatedExtremumTensorIndex = ifMustUpdateBlock.getResult(1);
+
+              rewriter.create<scf::YieldOp>(
+                  loc, ValueRange{updatedExtremum, updatedExtremumTensorIndex});
+              rewriter.setInsertionPointAfter(rowAggregationLoop);
+            }
+
+            Value rowAggregation = rowAggregationLoop.getResult(1);
+            rewriter.create<memref::StoreOp>(loc, rowAggregation, outputValues,
+                                             outputValuesPosition);
+            Value rowIndex64 =
+                rewriter.create<IndexCastOp>(loc, rowIndex, int64Type);
+            rewriter.create<memref::StoreOp>(loc, rowIndex64, outputIndices,
+                                             outputValuesPosition);
+
+            Value updatedOutputValuesPosition =
+                rewriter.create<AddIOp>(loc, outputValuesPosition, c1)
+                    .getResult();
+            rewriter.create<scf::YieldOp>(
+                loc, ValueRange{updatedOutputValuesPosition});
+          }
+
+          rewriter.setInsertionPointToStart(ifRowIsNonEmptyBlock.elseBlock());
+          {
+            rewriter.create<scf::YieldOp>(loc,
+                                          ValueRange{outputValuesPosition});
+          }
+
+          rewriter.setInsertionPointAfter(ifRowIsNonEmptyBlock);
+        }
+      } else if (aggregator == "plus") {
         Value rowIsNonEmpty =
             rewriter.create<CmpIOp>(loc, CmpIPredicate::ne, ptr64, nextPtr64);
         ifRowIsNonEmptyBlock = rewriter.create<scf::IfOp>(
@@ -818,60 +982,6 @@ public:
             }
             Value rowSum = rowSumLoop.getResult(0);
             rewriter.create<memref::StoreOp>(loc, rowSum, outputValues,
-                                             outputValuesPosition);
-            Value rowIndex64 =
-                rewriter.create<IndexCastOp>(loc, rowIndex, int64Type);
-            rewriter.create<memref::StoreOp>(loc, rowIndex64, outputIndices,
-                                             outputValuesPosition);
-            Value updatedOutputValuesPosition =
-                rewriter.create<AddIOp>(loc, outputValuesPosition, c1)
-                    .getResult();
-            rewriter.create<scf::YieldOp>(
-                loc, ValueRange{updatedOutputValuesPosition});
-          }
-
-          rewriter.setInsertionPointToStart(ifRowIsNonEmptyBlock.elseBlock());
-          {
-            rewriter.create<scf::YieldOp>(loc,
-                                          ValueRange{outputValuesPosition});
-          }
-
-          rewriter.setInsertionPointAfter(ifRowIsNonEmptyBlock);
-        }
-      } else if (aggregator == "count") {
-
-        Value ptrDiff = rewriter.create<SubIOp>(loc, nextPtr64, ptr64);
-
-        Value c0_i64 = rewriter.create<ConstantOp>(
-            loc, rewriter.getIntegerAttr(int64Type, 0));
-        Value rowIsNonEmpty =
-            rewriter.create<CmpIOp>(loc, CmpIPredicate::ne, ptrDiff, c0_i64);
-
-        ifRowIsNonEmptyBlock = rewriter.create<scf::IfOp>(
-            loc, TypeRange{indexType}, rowIsNonEmpty, true);
-        {
-          rewriter.setInsertionPointToStart(ifRowIsNonEmptyBlock.thenBlock());
-          {
-            Type valueType =
-                output.getType().dyn_cast<RankedTensorType>().getElementType();
-
-            // TODO should we require the output to have the element type be
-            // index or some integer type?
-            Value rowReduction =
-                llvm::TypeSwitch<Type, Value>(valueType)
-                    .Case<IntegerType>([&](IntegerType type) {
-                      Value ans;
-                      if (type.getWidth() < 64)
-                        ans = rewriter.create<TruncateIOp>(loc, type, ptrDiff);
-                      else
-                        ans =
-                            rewriter.create<SignExtendIOp>(loc, type, ptrDiff);
-                      return ans;
-                    })
-                    .Case<FloatType>([&](FloatType type) {
-                      return rewriter.create<SIToFPOp>(loc, type, ptrDiff);
-                    });
-            rewriter.create<memref::StoreOp>(loc, rowReduction, outputValues,
                                              outputValuesPosition);
             Value rowIndex64 =
                 rewriter.create<IndexCastOp>(loc, rowIndex, int64Type);
@@ -960,9 +1070,17 @@ public:
               });
       rewriter.create<graphblas::YieldOp>(loc, graphblas::YieldKind::AGG,
                                           aggResult);
+    } else if (aggregator == "argmin") {
+      // TODO implement this and add tests
+      // move the LowerVectorArgMinMaxOpRewrite implementation here
+      return op.emitError("\"" + aggregator + "\" is not yet supported.");
+    } else if (aggregator == "argmin") {
+      // TODO implement this and add tests
+      // move the LowerVectorArgMinMaxOpRewrite implementation here
+      return op.emitError("\"" + aggregator + "\" is not yet supported.");
     } else if (aggregator == "count") {
-      // TODO implement this ; should just be a replacement with
-      // graphblas.num_vals
+      // TODO implement this and add tests ; should just be a replacement
+      // with graphblas.num_vals
       return op.emitError("\"" + aggregator + "\" is not yet supported.");
     } else {
       return op.emitError("\"" + aggregator +

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOps.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOps.cpp
@@ -13,6 +13,7 @@
 #include "llvm/ADT/None.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 #include "GraphBLAS/GraphBLASOpsDialect.cpp.inc"
 #include "GraphBLAS/GraphBLASOpsEnums.cpp.inc"
@@ -742,7 +743,19 @@ static LogicalResult verify(ReduceToVectorOp op) {
   if (errMsg)
     return op.emitError("result " + errMsg.getValue());
 
-  if (resultType.getElementType() != inputType.getElementType())
+  if (aggregator == "argmin" or aggregator == "argmax") {
+    Type valueType = resultType.getElementType();
+    bool valueTypeIsI64 = llvm::TypeSwitch<Type, bool>(valueType)
+                              .Case<IntegerType>([&](IntegerType type) {
+                                unsigned bitWidth = type.getWidth();
+                                return bitWidth == 64;
+                              })
+                              .Default([&](Type type) { return false; });
+    if (!valueTypeIsI64)
+      return op.emitError(
+          "\"" + aggregator +
+          "\" requires the output vector to have i64 elements.");
+  } else if (resultType.getElementType() != inputType.getElementType())
     return op.emitError("Operand and output types are incompatible.");
 
   ArrayRef<int64_t> inputShape = inputType.getShape();
@@ -784,10 +797,6 @@ static LogicalResult verifyReduceToScalarArgs(T op) {
       return op.emitError("operand " + errMsg.getValue());
   }
 
-  Type resultType = op.getResult().getType();
-  if (resultType != operandType.getElementType())
-    return op.emitError("Operand and output types are incompatible.");
-
   return success();
 }
 
@@ -801,6 +810,24 @@ static LogicalResult verify(ReduceToScalarOp op) {
   if (!supportedReduceAggregators.contains(aggregator))
     return op.emitError("\"" + aggregator +
                         "\" is not a supported aggregator.");
+
+  Type operandOrigType = op.input().getType();
+  RankedTensorType operandType = operandOrigType.cast<RankedTensorType>();
+  Type resultType = op.getResult().getType();
+  if (aggregator == "argmin" or aggregator == "argmax") {
+    if (operandType.getRank() != 1)
+      return op.emitError("\"" + aggregator + "\" only supported for vectors.");
+    bool resultTypeIsI64 = llvm::TypeSwitch<Type, bool>(resultType)
+                               .Case<IntegerType>([&](IntegerType type) {
+                                 unsigned bitWidth = type.getWidth();
+                                 return bitWidth == 64;
+                               })
+                               .Default([&](Type type) { return false; });
+    if (!resultTypeIsI64)
+      return op.emitError("\"" + aggregator +
+                          "\" requires the output type to be i64.");
+  } else if (resultType != operandType.getElementType())
+    return op.emitError("Operand and output types are incompatible.");
 
   return success();
 }

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOps.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOps.cpp
@@ -745,16 +745,16 @@ static LogicalResult verify(ReduceToVectorOp op) {
 
   if (aggregator == "argmin" or aggregator == "argmax") {
     Type valueType = resultType.getElementType();
-    bool valueTypeIsI64 = llvm::TypeSwitch<Type, bool>(valueType)
+    bool valueTypeIsI32 = llvm::TypeSwitch<Type, bool>(valueType)
                               .Case<IntegerType>([&](IntegerType type) {
                                 unsigned bitWidth = type.getWidth();
-                                return bitWidth == 64;
+                                return bitWidth == 32;
                               })
                               .Default([&](Type type) { return false; });
-    if (!valueTypeIsI64)
+    if (!valueTypeIsI32)
       return op.emitError(
           "\"" + aggregator +
-          "\" requires the output vector to have i64 elements.");
+          "\" requires the output vector to have i32 elements.");
   } else if (resultType.getElementType() != inputType.getElementType())
     return op.emitError("Operand and output types are incompatible.");
 

--- a/mlir_graphblas/src/test/GraphBLAS/check_ops.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/check_ops.mlir
@@ -92,6 +92,22 @@ module {
         return %answer : i64
     }
 
+    // CHECK: func @vector_reduce_to_scalar_argmin(%[[ARG0:.*]]: [[CV_TYPE:tensor<.*>]]) -> [[RETURN_TYPE:.*]] {
+    func @vector_reduce_to_scalar_argmin(%sparse_tensor: tensor<2xf16, #SparseVec64>) -> i64 {
+        // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.reduce_to_scalar %[[ARG0]] {aggregator = "argmin"} : [[CV_TYPE]] to [[RETURN_TYPE]]
+        %answer = graphblas.reduce_to_scalar %sparse_tensor { aggregator = "argmin" } : tensor<2xf16, #SparseVec64> to i64
+        // CHECK-NEXT: return %[[ANSWER]] : [[RETURN_TYPE]]
+        return %answer : i64
+    }
+
+    // CHECK: func @vector_reduce_to_scalar_argmax(%[[ARG0:.*]]: [[CV_TYPE:tensor<.*>]]) -> [[RETURN_TYPE:.*]] {
+    func @vector_reduce_to_scalar_argmax(%sparse_tensor: tensor<2xf16, #SparseVec64>) -> i64 {
+        // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.reduce_to_scalar %[[ARG0]] {aggregator = "argmax"} : [[CV_TYPE]] to [[RETURN_TYPE]]
+        %answer = graphblas.reduce_to_scalar %sparse_tensor { aggregator = "argmax" } : tensor<2xf16, #SparseVec64> to i64
+        // CHECK-NEXT: return %[[ANSWER]] : [[RETURN_TYPE]]
+        return %answer : i64
+    }
+
 }
 
 module {
@@ -462,6 +478,26 @@ module {
         %vec2 = graphblas.reduce_to_vector %matrix { aggregator = "count", axis = 1 } : tensor<7x9xi32, #CSR64> to tensor<7xi32, #SparseVec64>
         // CHECK-NEXT: return %[[ANSWER_0]], %[[ANSWER_1]] : [[RETURN_TYPE_0]], [[RETURN_TYPE_1]]
         return %vec1, %vec2 : tensor<9xi32, #SparseVec64>, tensor<7xi32, #SparseVec64>
+    }
+
+    // CHECK: func @reduce_to_vector_argmin(%[[MATRIX:.*]]: [[MATRIX_TYPE:tensor<.*->.*>]]) -> ([[RETURN_TYPE_0:tensor<.*>]], [[RETURN_TYPE_1:tensor<.*>]]) {
+    func @reduce_to_vector_argmin(%matrix: tensor<7x9xf32, #CSR64>) -> (tensor<9xi64, #SparseVec64>, tensor<7xi64, #SparseVec64>) {
+        // CHECK-NEXT: %[[ANSWER_0:.*]] = graphblas.reduce_to_vector %[[MATRIX]] {aggregator = "argmin", axis = 0 : i64} : [[MATRIX_TYPE]] to [[RETURN_TYPE_0]]
+        %vec1 = graphblas.reduce_to_vector %matrix { aggregator = "argmin", axis = 0 } : tensor<7x9xf32, #CSR64> to tensor<9xi64, #SparseVec64>
+        // CHECK-NEXT: %[[ANSWER_1:.*]] = graphblas.reduce_to_vector %[[MATRIX]] {aggregator = "argmin", axis = 1 : i64} : [[MATRIX_TYPE]] to [[RETURN_TYPE_1]]
+        %vec2 = graphblas.reduce_to_vector %matrix { aggregator = "argmin", axis = 1 } : tensor<7x9xf32, #CSR64> to tensor<7xi64, #SparseVec64>
+        // CHECK-NEXT: return %[[ANSWER_0]], %[[ANSWER_1]] : [[RETURN_TYPE_0]], [[RETURN_TYPE_1]]
+        return %vec1, %vec2 : tensor<9xi64, #SparseVec64>, tensor<7xi64, #SparseVec64>
+    }
+
+    // CHECK: func @reduce_to_vector_argmax(%[[MATRIX:.*]]: [[MATRIX_TYPE:tensor<.*->.*>]]) -> ([[RETURN_TYPE_0:tensor<.*>]], [[RETURN_TYPE_1:tensor<.*>]]) {
+    func @reduce_to_vector_argmax(%matrix: tensor<7x9xf32, #CSR64>) -> (tensor<9xi64, #SparseVec64>, tensor<7xi64, #SparseVec64>) {
+        // CHECK-NEXT: %[[ANSWER_0:.*]] = graphblas.reduce_to_vector %[[MATRIX]] {aggregator = "argmax", axis = 0 : i64} : [[MATRIX_TYPE]] to [[RETURN_TYPE_0]]
+        %vec1 = graphblas.reduce_to_vector %matrix { aggregator = "argmax", axis = 0 } : tensor<7x9xf32, #CSR64> to tensor<9xi64, #SparseVec64>
+        // CHECK-NEXT: %[[ANSWER_1:.*]] = graphblas.reduce_to_vector %[[MATRIX]] {aggregator = "argmax", axis = 1 : i64} : [[MATRIX_TYPE]] to [[RETURN_TYPE_1]]
+        %vec2 = graphblas.reduce_to_vector %matrix { aggregator = "argmax", axis = 1 } : tensor<7x9xf32, #CSR64> to tensor<7xi64, #SparseVec64>
+        // CHECK-NEXT: return %[[ANSWER_0]], %[[ANSWER_1]] : [[RETURN_TYPE_0]], [[RETURN_TYPE_1]]
+        return %vec1, %vec2 : tensor<9xi64, #SparseVec64>, tensor<7xi64, #SparseVec64>
     }
 
 }

--- a/mlir_graphblas/src/test/GraphBLAS/check_ops.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/check_ops.mlir
@@ -481,23 +481,23 @@ module {
     }
 
     // CHECK: func @reduce_to_vector_argmin(%[[MATRIX:.*]]: [[MATRIX_TYPE:tensor<.*->.*>]]) -> ([[RETURN_TYPE_0:tensor<.*>]], [[RETURN_TYPE_1:tensor<.*>]]) {
-    func @reduce_to_vector_argmin(%matrix: tensor<7x9xf32, #CSR64>) -> (tensor<9xi64, #SparseVec64>, tensor<7xi64, #SparseVec64>) {
+    func @reduce_to_vector_argmin(%matrix: tensor<7x9xf32, #CSR64>) -> (tensor<9xi32, #SparseVec64>, tensor<7xi32, #SparseVec64>) {
         // CHECK-NEXT: %[[ANSWER_0:.*]] = graphblas.reduce_to_vector %[[MATRIX]] {aggregator = "argmin", axis = 0 : i64} : [[MATRIX_TYPE]] to [[RETURN_TYPE_0]]
-        %vec1 = graphblas.reduce_to_vector %matrix { aggregator = "argmin", axis = 0 } : tensor<7x9xf32, #CSR64> to tensor<9xi64, #SparseVec64>
+        %vec1 = graphblas.reduce_to_vector %matrix { aggregator = "argmin", axis = 0 } : tensor<7x9xf32, #CSR64> to tensor<9xi32, #SparseVec64>
         // CHECK-NEXT: %[[ANSWER_1:.*]] = graphblas.reduce_to_vector %[[MATRIX]] {aggregator = "argmin", axis = 1 : i64} : [[MATRIX_TYPE]] to [[RETURN_TYPE_1]]
-        %vec2 = graphblas.reduce_to_vector %matrix { aggregator = "argmin", axis = 1 } : tensor<7x9xf32, #CSR64> to tensor<7xi64, #SparseVec64>
+        %vec2 = graphblas.reduce_to_vector %matrix { aggregator = "argmin", axis = 1 } : tensor<7x9xf32, #CSR64> to tensor<7xi32, #SparseVec64>
         // CHECK-NEXT: return %[[ANSWER_0]], %[[ANSWER_1]] : [[RETURN_TYPE_0]], [[RETURN_TYPE_1]]
-        return %vec1, %vec2 : tensor<9xi64, #SparseVec64>, tensor<7xi64, #SparseVec64>
+        return %vec1, %vec2 : tensor<9xi32, #SparseVec64>, tensor<7xi32, #SparseVec64>
     }
 
     // CHECK: func @reduce_to_vector_argmax(%[[MATRIX:.*]]: [[MATRIX_TYPE:tensor<.*->.*>]]) -> ([[RETURN_TYPE_0:tensor<.*>]], [[RETURN_TYPE_1:tensor<.*>]]) {
-    func @reduce_to_vector_argmax(%matrix: tensor<7x9xf32, #CSR64>) -> (tensor<9xi64, #SparseVec64>, tensor<7xi64, #SparseVec64>) {
+    func @reduce_to_vector_argmax(%matrix: tensor<7x9xf32, #CSR64>) -> (tensor<9xi32, #SparseVec64>, tensor<7xi32, #SparseVec64>) {
         // CHECK-NEXT: %[[ANSWER_0:.*]] = graphblas.reduce_to_vector %[[MATRIX]] {aggregator = "argmax", axis = 0 : i64} : [[MATRIX_TYPE]] to [[RETURN_TYPE_0]]
-        %vec1 = graphblas.reduce_to_vector %matrix { aggregator = "argmax", axis = 0 } : tensor<7x9xf32, #CSR64> to tensor<9xi64, #SparseVec64>
+        %vec1 = graphblas.reduce_to_vector %matrix { aggregator = "argmax", axis = 0 } : tensor<7x9xf32, #CSR64> to tensor<9xi32, #SparseVec64>
         // CHECK-NEXT: %[[ANSWER_1:.*]] = graphblas.reduce_to_vector %[[MATRIX]] {aggregator = "argmax", axis = 1 : i64} : [[MATRIX_TYPE]] to [[RETURN_TYPE_1]]
-        %vec2 = graphblas.reduce_to_vector %matrix { aggregator = "argmax", axis = 1 } : tensor<7x9xf32, #CSR64> to tensor<7xi64, #SparseVec64>
+        %vec2 = graphblas.reduce_to_vector %matrix { aggregator = "argmax", axis = 1 } : tensor<7x9xf32, #CSR64> to tensor<7xi32, #SparseVec64>
         // CHECK-NEXT: return %[[ANSWER_0]], %[[ANSWER_1]] : [[RETURN_TYPE_0]], [[RETURN_TYPE_1]]
-        return %vec1, %vec2 : tensor<9xi64, #SparseVec64>, tensor<7xi64, #SparseVec64>
+        return %vec1, %vec2 : tensor<9xi32, #SparseVec64>, tensor<7xi32, #SparseVec64>
     }
 
 }

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_reduce_to_scalar.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_reduce_to_scalar.mlir
@@ -18,6 +18,68 @@ module {
 
 // -----
 
+#SparseVec64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "compressed" ],
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+module {
+    func @reduce_to_scalar_wrapper(%sparse_tensor: tensor<?xf64, #SparseVec64>) -> bf16 {
+        %answer = graphblas.reduce_to_scalar %sparse_tensor { aggregator = "argmin" } : tensor<?xf64, #SparseVec64> to bf16 // expected-error {{"argmin" requires the output type to be i64.}}
+        return %answer : bf16
+    }
+}
+
+// -----
+
+#SparseVec64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "compressed" ],
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+module {
+    func @reduce_to_scalar_wrapper(%sparse_tensor: tensor<?xf64, #SparseVec64>) -> bf16 {
+        %answer = graphblas.reduce_to_scalar %sparse_tensor { aggregator = "argmax" } : tensor<?xf64, #SparseVec64> to bf16 // expected-error {{"argmax" requires the output type to be i64.}}
+        return %answer : bf16
+    }
+}
+
+// -----
+
+#CSR64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "dense", "compressed" ],
+  dimOrdering = affine_map<(i,j) -> (i,j)>,
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+module {
+    func @reduce_to_scalar_wrapper(%sparse_tensor: tensor<?x?xf64, #CSR64>) -> i64 {
+        %answer = graphblas.reduce_to_scalar %sparse_tensor { aggregator = "argmin" } : tensor<?x?xf64, #CSR64> to i64 // expected-error {{"argmin" only supported for vectors.}}
+        return %answer : i64
+    }
+}
+
+// -----
+
+#CSR64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "dense", "compressed" ],
+  dimOrdering = affine_map<(i,j) -> (i,j)>,
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+module {
+    func @reduce_to_scalar_wrapper(%sparse_tensor: tensor<?x?xf64, #CSR64>) -> i64 {
+        %answer = graphblas.reduce_to_scalar %sparse_tensor { aggregator = "argmax" } : tensor<?x?xf64, #CSR64> to i64 // expected-error {{"argmax" only supported for vectors.}}
+        return %answer : i64
+    }
+}
+
+// -----
+
 #BADENCODING = #sparse_tensor.encoding<{
   dimLevelType = [ "dense", "compressed", "dense" ],
   dimOrdering = affine_map<(i,j,k) -> (i,j,k)>,

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_reduce_to_vector.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_reduce_to_vector.mlir
@@ -45,7 +45,7 @@ module {
 
 module {
     func @reduce_to_vector_wrapper(%matrix: tensor<?x?xf32, #CSR64>) -> tensor<?xf32, #SparseVec64> {
-        %vec = graphblas.reduce_to_vector %matrix { aggregator = "argmin", axis = 0 } : tensor<?x?xf32, #CSR64> to tensor<?xf32, #SparseVec64> // expected-error {{"argmin" requires the output vector to have i64 elements.}}
+        %vec = graphblas.reduce_to_vector %matrix { aggregator = "argmin", axis = 0 } : tensor<?x?xf32, #CSR64> to tensor<?xf32, #SparseVec64> // expected-error {{"argmin" requires the output vector to have i32 elements.}}
         return %vec : tensor<?xf32, #SparseVec64>
     }
 }
@@ -67,7 +67,7 @@ module {
 
 module {
     func @reduce_to_vector_wrapper(%matrix: tensor<?x?xf32, #CSR64>) -> tensor<?xf32, #SparseVec64> {
-        %vec = graphblas.reduce_to_vector %matrix { aggregator = "argmax", axis = 0 } : tensor<?x?xf32, #CSR64> to tensor<?xf32, #SparseVec64> // expected-error {{"argmax" requires the output vector to have i64 elements.}}
+        %vec = graphblas.reduce_to_vector %matrix { aggregator = "argmax", axis = 0 } : tensor<?x?xf32, #CSR64> to tensor<?xf32, #SparseVec64> // expected-error {{"argmax" requires the output vector to have i32 elements.}}
         return %vec : tensor<?xf32, #SparseVec64>
     }
 }

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_reduce_to_vector.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_reduce_to_vector.mlir
@@ -30,6 +30,50 @@ module {
 
 // -----
 
+#SparseVec64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "compressed" ],
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+#CSR64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "dense", "compressed" ],
+  dimOrdering = affine_map<(i,j) -> (i,j)>,
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+module {
+    func @reduce_to_vector_wrapper(%matrix: tensor<?x?xf32, #CSR64>) -> tensor<?xf32, #SparseVec64> {
+        %vec = graphblas.reduce_to_vector %matrix { aggregator = "argmin", axis = 0 } : tensor<?x?xf32, #CSR64> to tensor<?xf32, #SparseVec64> // expected-error {{"argmin" requires the output vector to have i64 elements.}}
+        return %vec : tensor<?xf32, #SparseVec64>
+    }
+}
+
+// -----
+
+#SparseVec64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "compressed" ],
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+#CSR64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "dense", "compressed" ],
+  dimOrdering = affine_map<(i,j) -> (i,j)>,
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+module {
+    func @reduce_to_vector_wrapper(%matrix: tensor<?x?xf32, #CSR64>) -> tensor<?xf32, #SparseVec64> {
+        %vec = graphblas.reduce_to_vector %matrix { aggregator = "argmax", axis = 0 } : tensor<?x?xf32, #CSR64> to tensor<?xf32, #SparseVec64> // expected-error {{"argmax" requires the output vector to have i64 elements.}}
+        return %vec : tensor<?xf32, #SparseVec64>
+    }
+}
+
+// -----
+
 #BADENCODING = #sparse_tensor.encoding<{
   dimLevelType = [ "dense", "compressed", "dense" ],
   dimOrdering = affine_map<(i,j,k) -> (i,j,k)>,
@@ -68,7 +112,7 @@ module {
 
 // -----
 
-// COM: TODO when https://github.com/metagraph-dev/mlir-graphblas/issues/66 is complete, try alll sorts of bad values for dimLevelType in the bad encoding 
+// COM: TODO when https://github.com/metagraph-dev/mlir-graphblas/issues/66 is complete, try all sorts of bad values for dimLevelType in the bad encoding 
 
 #BADENCODING = #sparse_tensor.encoding<{
   dimLevelType = [ "compressed", "compressed" ],

--- a/mlir_graphblas/tests/test_mlir_builder.py
+++ b/mlir_graphblas/tests/test_mlir_builder.py
@@ -647,6 +647,8 @@ def test_ir_reduce_to_vector(
             reduce_columns_output_type,
             reduce_rows_output_type,
             reduce_columns_output_type,
+            "tensor<?xi64, #CV64>",
+            "tensor<?xi64, #CV64>",
         ],
         aliases=aliases,
     )
@@ -668,11 +670,16 @@ def test_ir_reduce_to_vector(
         reduced_columns_negative_abs, "identity"
     )
 
+    reduced_rows_argmin = ir_builder.graphblas.reduce_to_vector(matrix, "argmin", 1)
+    reduced_columns_argmax = ir_builder.graphblas.reduce_to_vector(matrix, "argmax", 0)
+
     ir_builder.return_vars(
         reduced_rows,
         reduced_columns,
         reduced_rows_clamped,
         reduced_columns_negative_abs,
+        reduced_rows_argmin,
+        reduced_columns_argmax,
     )
     reduce_func = ir_builder.compile(engine=engine, passes=GRAPHBLAS_PASSES)
 
@@ -680,10 +687,10 @@ def test_ir_reduce_to_vector(
     dense_input_tensor = np.array(
         [
             [1, 0, 0, 0],
-            [-9, 0, 1, 1],
+            [-2, 0, 3, -4],
             [0, 0, 0, 0],
-            [0, 0, 1, 1],
-            [0, 0, 0, -9],
+            [0, 0, 5, -6],
+            [0, -7, 0, 8],
         ],
         dtype=np_type,
     )
@@ -699,12 +706,16 @@ def test_ir_reduce_to_vector(
         reduced_columns,
         reduced_rows_clamped,
         reduced_columns_negative_abs,
+        reduced_rows_argmin,
+        reduced_columns_argmax,
     ) = reduce_func(input_tensor)
 
     reduced_rows = densify_vector(reduced_rows)
     reduced_columns = densify_vector(reduced_columns)
     reduced_rows_clamped = densify_vector(reduced_rows_clamped)
     reduced_columns_negative_abs = densify_vector(reduced_columns_negative_abs)
+    reduced_rows_argmin = densify_vector(reduced_rows_argmin)
+    reduced_columns_argmax = densify_vector(reduced_columns_argmax)
 
     expected_reduced_rows = dense_input_tensor.sum(axis=1)
     expected_reduced_columns = (
@@ -716,10 +727,15 @@ def test_ir_reduce_to_vector(
 
     expected_reduced_columns_negative_abs = -np.abs(expected_reduced_columns)
 
+    expected_reduced_rows_argmin = np.argmin(dense_input_tensor, axis=1)
+    expected_reduced_columns_argmax = np.argmax(dense_input_tensor, axis=0)
+
     assert np.all(reduced_rows == expected_reduced_rows)
     assert np.all(reduced_columns == expected_reduced_columns)
     assert np.all(reduced_rows_clamped == expected_reduced_rows_clamped)
     assert np.all(reduced_columns_negative_abs == expected_reduced_columns_negative_abs)
+    assert np.all(reduced_rows_argmin == expected_reduced_rows_argmin)
+    assert np.all(reduced_columns_argmax == expected_reduced_columns_argmax)
 
     return
 

--- a/mlir_graphblas/tests/test_mlir_builder.py
+++ b/mlir_graphblas/tests/test_mlir_builder.py
@@ -647,8 +647,8 @@ def test_ir_reduce_to_vector(
             reduce_columns_output_type,
             reduce_rows_output_type,
             reduce_columns_output_type,
-            "tensor<?xi64, #CV64>",
-            "tensor<?xi64, #CV64>",
+            "tensor<?xi32, #CV64>",
+            "tensor<?xi32, #CV64>",
         ],
         aliases=aliases,
     )
@@ -727,8 +727,13 @@ def test_ir_reduce_to_vector(
 
     expected_reduced_columns_negative_abs = -np.abs(expected_reduced_columns)
 
-    expected_reduced_rows_argmin = np.argmin(dense_input_tensor, axis=1)
-    expected_reduced_columns_argmax = np.argmax(dense_input_tensor, axis=0)
+    M = dense_input_tensor.copy()
+    M[dense_input_tensor == 0] = dense_input_tensor.max() + 1
+    expected_reduced_rows_argmin = np.argmin(M, axis=1)
+
+    M = dense_input_tensor.copy()
+    M[dense_input_tensor == 0] = dense_input_tensor.min() - 1
+    expected_reduced_columns_argmax = np.argmax(M, axis=0)
 
     assert np.all(reduced_rows == expected_reduced_rows)
     assert np.all(reduced_columns == expected_reduced_columns)


### PR DESCRIPTION
Note that we return tensors with 32-bit integer elements as a workaround for https://github.com/metagraph-dev/mlir-graphblas/issues/178.