### PR TITLE
JIT Engine: Check sparsity and pointer & index bitwidths for sparse tensor inputs

### DIFF
--- a/mlir_graphblas/tests/test_io.py
+++ b/mlir_graphblas/tests/test_io.py
@@ -290,5 +290,7 @@ def test_sparsity():
     values = np.array([1.2, 4.3], dtype=np.float64)
     sizes = np.array([8, 8], dtype=np.uint64)
     sparsity = np.array([False, True], dtype=np.bool8)
-    tensor = mlir_graphblas.sparse_utils.MLIRSparseTensor(indices, values, sizes, sparsity)
+    tensor = mlir_graphblas.sparse_utils.MLIRSparseTensor(
+        indices, values, sizes, sparsity
+    )
     np.testing.assert_array_equal(sparsity, tensor.sparsity)


### PR DESCRIPTION
This is intended to address https://github.com/metagraph-dev/mlir-graphblas/issues/34.

This adds more safety checking when passing in instances of `mlir_graphblas.sparse_utils.MLIRSparseTensor` to functions created by the JIT engine.

For sparse tensor inputs, the JIT engine now sanity checks:
- the rank and dimension sizes 
- the pointer bit width and index bit width
- the sparsity for each dimension
- the element type

One big benefit is that this PR will save users who accidentally pass in sparse tensors with the wrong dtype from getting seg faults. 