### PR TITLE
OpenMP support

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -122,7 +122,7 @@ jobs:
           conda list
       - name: Pytest
         run: |
-          python -m mlir_graphblas.tests
+          pytest --forked --pyargs mlir_graphblas.tests
 
   dev_deploy:
     strategy:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -51,7 +51,7 @@ jobs:
           ./run-clang-format.py -r mlir_graphblas/src/
       - name: Pytest
         run: |
-          pytest -v mlir_graphblas
+          pytest -s --forked --pyargs mlir_graphblas.tests
       - name: Coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -108,7 +108,7 @@ jobs:
           python-version: ${{ matrix.pyver }}
       - name: Update env
         run: |
-          conda install pytest coverage pytest-cov
+          conda install pytest coverage pytest-cov pytest-forked
           # Install built_packages
           cd ./artifact_storage
           tar -xvf output.tar

--- a/mlir_graphblas/algorithms.py
+++ b/mlir_graphblas/algorithms.py
@@ -15,9 +15,15 @@ class Algorithm:
         raise NotImplementedError("must override _build")
 
     def __call__(self, *args, **kwargs):
-        if self._cached is None:
-            self._cached = self.builder.compile()
-        return self._cached(*args, **kwargs)
+        compile_with_passes = kwargs.pop('compile_with_passes', None)
+        if compile_with_passes is None:
+            if self._cached is None:
+                self._cached = self.builder.compile()
+            return self._cached(*args, **kwargs)
+        else:
+            # custom build for testing, is not cached
+            func = self.builder.compile(passes=compile_with_passes)
+            return func(*args, **kwargs)
 
 
 def _build_common_aliases():
@@ -51,8 +57,8 @@ class TriangleCount(Algorithm):
 
         return irb
 
-    def __call__(self, A: MLIRSparseTensor) -> int:
-        return int(super().__call__(A))
+    def __call__(self, A: MLIRSparseTensor, **kwargs) -> int:
+        return int(super().__call__(A, **kwargs))
 
 
 triangle_count = TriangleCount()
@@ -164,12 +170,13 @@ class DenseNeuralNetwork(Algorithm):
         Bias: List[MLIRSparseTensor],
         Y0: MLIRSparseTensor,
         ymax=32.0,
+        **kwargs
     ) -> MLIRSparseTensor:
 
         if len(W) != len(Bias):
             raise TypeError(f"num_layers mismatch: {len(W)} != {len(Bias)}")
 
-        return super().__call__(W, Bias, len(W), Y0, ymax)
+        return super().__call__(W, Bias, len(W), Y0, ymax, **kwargs)
 
 
 dense_neural_network = DenseNeuralNetwork()
@@ -207,9 +214,9 @@ class SSSP(Algorithm):
         return irb
 
     def __call__(
-        self, graph: MLIRSparseTensor, vector: MLIRSparseTensor
+        self, graph: MLIRSparseTensor, vector: MLIRSparseTensor, **kwargs
     ) -> MLIRSparseTensor:
-        return super().__call__(graph, vector)
+        return super().__call__(graph, vector, **kwargs)
 
 
 sssp = SSSP()
@@ -247,9 +254,9 @@ class MSSP(Algorithm):
         return irb
 
     def __call__(
-        self, graph: MLIRSparseTensor, matrix: MLIRSparseTensor
+        self, graph: MLIRSparseTensor, matrix: MLIRSparseTensor, **kwargs
     ) -> MLIRSparseTensor:
-        return super().__call__(graph, matrix)
+        return super().__call__(graph, matrix, **kwargs)
 
 
 mssp = MSSP()
@@ -283,17 +290,22 @@ class BipartiteProjectAndFilter(Algorithm):
         return ir_builder
 
     def __call__(
-        self, graph: MLIRSparseTensor, keep_nodes: str = "row", cutoff=0.0
+        self, graph: MLIRSparseTensor, keep_nodes: str = "row", cutoff=0.0, **kwargs
     ) -> MLIRSparseTensor:
         if keep_nodes not in self.allowable_keep_nodes:
             raise ValueError(
                 f"Invalid keep_nodes argument: {keep_nodes}, must be one of {self.allowable_keep_nodes}"
             )
 
-        if keep_nodes not in self._cached:
-            self._cached[keep_nodes] = self.builder[keep_nodes].compile()
+        compile_with_passes = kwargs.pop('compile_with_passes', None)
+        if compile_with_passes is None:
+            if keep_nodes not in self._cached:
+                self._cached[keep_nodes] = self.builder[keep_nodes].compile()
 
-        return self._cached[keep_nodes](graph, cutoff)
+            return self._cached[keep_nodes](graph, cutoff)
+        else:
+            func = self.builder[keep_nodes].compile(passes=compile_with_passes)
+            return func(graph, cutoff, **kwargs)
 
 
 bipartite_project_and_filter = BipartiteProjectAndFilter()
@@ -319,9 +331,9 @@ class VertexNomination(Algorithm):
         return irb
 
     def __call__(
-        self, graph: MLIRSparseTensor, nodes_of_interest: MLIRSparseTensor
+        self, graph: MLIRSparseTensor, nodes_of_interest: MLIRSparseTensor, **kwargs
     ) -> int:
-        return super().__call__(graph, nodes_of_interest)
+        return super().__call__(graph, nodes_of_interest, **kwargs)
 
 
 vertex_nomination = VertexNomination()
@@ -344,8 +356,8 @@ class ScanStatistics(Algorithm):
         ir_builder.return_vars(answer)
         return ir_builder
 
-    def __call__(self, graph: MLIRSparseTensor) -> int:
-        return super().__call__(graph)
+    def __call__(self, graph: MLIRSparseTensor, **kwargs) -> int:
+        return super().__call__(graph, **kwargs)
 
 
 scan_statistics = ScanStatistics()
@@ -470,9 +482,9 @@ class Pagerank(Algorithm):
         return irb
 
     def __call__(
-        self, graph: MLIRSparseTensor, damping=0.85, tol=1e-6, *, maxiter=100
+        self, graph: MLIRSparseTensor, damping=0.85, tol=1e-6, *, maxiter=100, **kwargs
     ) -> MLIRSparseTensor:
-        return super().__call__(graph, damping, tol, maxiter)
+        return super().__call__(graph, damping, tol, maxiter, **kwargs)
 
 
 pagerank = Pagerank()
@@ -583,6 +595,7 @@ class GraphSearch(Algorithm):
         method="random",
         *,
         rand_seed=None,
+        **kwargs
     ) -> MLIRSparseTensor:
         if method not in self.allowable_methods:
             raise ValueError(
@@ -601,7 +614,7 @@ class GraphSearch(Algorithm):
         elif method == "random_weighted":
             extra.append(ChooseWeightedContext(rand_seed))
 
-        return self._cached[method](graph, num_steps, initial_seed_array, *extra)
+        return self._cached[method](graph, num_steps, initial_seed_array, *extra, **kwargs)
 
 
 graph_search = GraphSearch()

--- a/mlir_graphblas/algorithms.py
+++ b/mlir_graphblas/algorithms.py
@@ -15,7 +15,7 @@ class Algorithm:
         raise NotImplementedError("must override _build")
 
     def __call__(self, *args, **kwargs):
-        compile_with_passes = kwargs.pop('compile_with_passes', None)
+        compile_with_passes = kwargs.pop("compile_with_passes", None)
         if compile_with_passes is None:
             if self._cached is None:
                 self._cached = self.builder.compile()
@@ -170,7 +170,7 @@ class DenseNeuralNetwork(Algorithm):
         Bias: List[MLIRSparseTensor],
         Y0: MLIRSparseTensor,
         ymax=32.0,
-        **kwargs
+        **kwargs,
     ) -> MLIRSparseTensor:
 
         if len(W) != len(Bias):
@@ -297,7 +297,7 @@ class BipartiteProjectAndFilter(Algorithm):
                 f"Invalid keep_nodes argument: {keep_nodes}, must be one of {self.allowable_keep_nodes}"
             )
 
-        compile_with_passes = kwargs.pop('compile_with_passes', None)
+        compile_with_passes = kwargs.pop("compile_with_passes", None)
         if compile_with_passes is None:
             if keep_nodes not in self._cached:
                 self._cached[keep_nodes] = self.builder[keep_nodes].compile()
@@ -595,7 +595,7 @@ class GraphSearch(Algorithm):
         method="random",
         *,
         rand_seed=None,
-        **kwargs
+        **kwargs,
     ) -> MLIRSparseTensor:
         if method not in self.allowable_methods:
             raise ValueError(
@@ -614,7 +614,9 @@ class GraphSearch(Algorithm):
         elif method == "random_weighted":
             extra.append(ChooseWeightedContext(rand_seed))
 
-        return self._cached[method](graph, num_steps, initial_seed_array, *extra, **kwargs)
+        return self._cached[method](
+            graph, num_steps, initial_seed_array, *extra, **kwargs
+        )
 
 
 graph_search = GraphSearch()

--- a/mlir_graphblas/engine.py
+++ b/mlir_graphblas/engine.py
@@ -59,6 +59,14 @@ llvm.initialize()
 llvm.initialize_native_target()
 llvm.initialize_native_asmprinter()
 
+# try to load libomp on Linux
+SO_FILE_PATTERN = os.path.join(sys.prefix, "lib", "libomp.so")
+SO_FILES = glob.glob(SO_FILE_PATTERN)
+if len(SO_FILES) > 0:
+    print(f"Loading {SO_FILES[0]}", file=sys.stderr)
+    llvm.load_library_permanently(SO_FILES[0])
+
+
 MLIR_FLOAT_ENUM_TO_NP_TYPE = {
     mlir.astnodes.FloatTypeEnum.f16: np.float16,
     mlir.astnodes.FloatTypeEnum.f32: np.float32,

--- a/mlir_graphblas/engine.py
+++ b/mlir_graphblas/engine.py
@@ -776,10 +776,9 @@ class MlirJitEngine:
 
         llvm_ir_text = mlir_translate_run.stdout.decode()
 
-
         # Remove optional align clause from atomicrmw instructions which is
         # only present in LLVM >= 13, which is newer than llvmlite
-        llvm11_ir_text = re.sub(r'align \d+, ', '', llvm_ir_text)
+        llvm11_ir_text = re.sub(r"align \d+, ", "", llvm_ir_text)
 
         # Create a LLVM module object from the IR
         mod = llvm.parse_assembly(llvm11_ir_text)

--- a/mlir_graphblas/engine.py
+++ b/mlir_graphblas/engine.py
@@ -776,8 +776,13 @@ class MlirJitEngine:
 
         llvm_ir_text = mlir_translate_run.stdout.decode()
 
+
+        # Remove optional align clause from atomicrmw instructions which is
+        # only present in LLVM >= 13, which is newer than llvmlite
+        llvm11_ir_text = re.sub(r'align \d+, ', '', llvm_ir_text)
+
         # Create a LLVM module object from the IR
-        mod = llvm.parse_assembly(llvm_ir_text)
+        mod = llvm.parse_assembly(llvm11_ir_text)
         mod.verify()
 
         # Now add the module and make sure it is ready for execution

--- a/mlir_graphblas/mlir_builder.py
+++ b/mlir_graphblas/mlir_builder.py
@@ -28,24 +28,36 @@ class MLIRCompileError(Exception):
 
 
 DEFAULT_ENGINE = MlirJitEngine()
-GRAPHBLAS_PASSES = (
+
+GRAPHBLAS_TO_SCF_PASSES = (
     "--graphblas-structuralize",
     "--graphblas-optimize",
     "--graphblas-lower",
     "--sparsification",
     "--sparse-tensor-conversion",
     "--linalg-bufferize",
-    "--convert-scf-to-std",
     "--func-bufferize",
     "--tensor-constant-bufferize",
     "--tensor-bufferize",
     "--finalizing-bufferize",
     "--convert-linalg-to-loops",
+)
+
+SCF_TO_LLVM_PASSES = (
     "--convert-scf-to-std",
     "--convert-memref-to-llvm",
+    "--convert-openmp-to-llvm",
     "--convert-std-to-llvm",
     "--reconcile-unrealized-casts",
 )
+
+GRAPHBLAS_PASSES = GRAPHBLAS_TO_SCF_PASSES + SCF_TO_LLVM_PASSES
+GRAPHBLAS_OPENMP_PASSES = GRAPHBLAS_TO_SCF_PASSES \
+    + (
+        "--convert-scf-to-openmp",
+    ) \
+    + SCF_TO_LLVM_PASSES
+
 
 
 class MLIRVar:

--- a/mlir_graphblas/mlir_builder.py
+++ b/mlir_graphblas/mlir_builder.py
@@ -52,12 +52,9 @@ SCF_TO_LLVM_PASSES = (
 )
 
 GRAPHBLAS_PASSES = GRAPHBLAS_TO_SCF_PASSES + SCF_TO_LLVM_PASSES
-GRAPHBLAS_OPENMP_PASSES = GRAPHBLAS_TO_SCF_PASSES \
-    + (
-        "--convert-scf-to-openmp",
-    ) \
-    + SCF_TO_LLVM_PASSES
-
+GRAPHBLAS_OPENMP_PASSES = (
+    GRAPHBLAS_TO_SCF_PASSES + ("--convert-scf-to-openmp",) + SCF_TO_LLVM_PASSES
+)
 
 
 class MLIRVar:

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASLowerPass.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASLowerPass.cpp
@@ -2570,6 +2570,9 @@ public:
 
     // Types
     Type boolType = rewriter.getI1Type();
+    // Need to use a standard word size in AND-reduction for OpenMP
+    // This could be i8, i32, or i64, but we pick i32
+    Type intReduceType = rewriter.getIntegerType(32);
     Type int64Type = rewriter.getIntegerType(64);
     Type valueType = aType.getElementType();
     MemRefType memref1DI64Type = MemRefType::get({-1}, int64Type);
@@ -2579,7 +2582,7 @@ public:
     Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
     Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
     Value cfalse = rewriter.create<ConstantIntOp>(loc, 0, boolType);
-    Value ctrue = rewriter.create<ConstantIntOp>(loc, 1, boolType);
+    Value c1_reduce = rewriter.create<ConstantIntOp>(loc, 1, intReduceType);
 
     unsigned rank = aType.getRank(); // ranks guaranteed to be equal
 
@@ -2630,7 +2633,7 @@ public:
         rewriter.create<sparse_tensor::ToValuesOp>(loc, memref1DValueType, B);
 
     scf::ParallelOp indexLoop =
-        rewriter.create<scf::ParallelOp>(loc, c0, aNnz, c1, ctrue);
+        rewriter.create<scf::ParallelOp>(loc, c0, aNnz, c1, c1_reduce);
     Value loopIdx = indexLoop.getInductionVars().front();
     rewriter.setInsertionPointToStart(indexLoop.getBody());
 
@@ -2650,8 +2653,13 @@ public:
                                loc, CmpFPredicate::OEQ, aValue, bValue);
                          });
     Value cmpCombined = rewriter.create<AndOp>(loc, cmpIndex, cmpValue);
+    // Need to do reduction with a standard word size (rather than i1) for
+    // OpenMP
+    Value cmpCombined_ext =
+        rewriter.create<SignExtendIOp>(loc, cmpCombined, intReduceType);
 
-    scf::ReduceOp reducer = rewriter.create<scf::ReduceOp>(loc, cmpCombined);
+    scf::ReduceOp reducer =
+        rewriter.create<scf::ReduceOp>(loc, cmpCombined_ext);
     BlockArgument lhs = reducer.getRegion().getArgument(0);
     BlockArgument rhs = reducer.getRegion().getArgument(1);
     rewriter.setInsertionPointToStart(&reducer.getRegion().front());
@@ -2659,7 +2667,9 @@ public:
     rewriter.create<scf::ReduceReturnOp>(loc, cmpFinal);
 
     rewriter.setInsertionPointAfter(indexLoop);
-    rewriter.create<scf::YieldOp>(loc, indexLoop.getResult(0));
+    Value boolResult = rewriter.create<mlir::TruncateIOp>(
+        loc, indexLoop.getResult(0), boolType);
+    rewriter.create<scf::YieldOp>(loc, boolResult);
 
     // else cmpNnz
     rewriter.setInsertionPointToStart(ifNnz.elseBlock());

--- a/mlir_graphblas/src/test/GraphBLAS/lower_equal.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_equal.mlir
@@ -9,48 +9,50 @@
 // CHECK-LABEL:   func @vector_equal(
 // CHECK-SAME:                       %[[VAL_0:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                       %[[VAL_1:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> i1 {
-// CHECK-DAG:       %[[VAL_2:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = constant false
-// CHECK-DAG:       %[[VAL_4:.*]] = constant true
-// CHECK-DAG:       %[[VAL_5:.*]] = constant 0 : index
-// CHECK:           %[[VAL_6:.*]] = tensor.dim %[[VAL_0]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_7:.*]] = tensor.dim %[[VAL_1]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_2:.*]] = constant 0 : index
+// CHECK:           %[[VAL_3:.*]] = constant 1 : index
+// CHECK:           %[[VAL_4:.*]] = constant false
+// CHECK:           %[[VAL_5:.*]] = constant 1 : i32
+// CHECK:           %[[VAL_6:.*]] = tensor.dim %[[VAL_0]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:           %[[VAL_7:.*]] = tensor.dim %[[VAL_1]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_8:.*]] = cmpi eq, %[[VAL_6]], %[[VAL_7]] : index
 // CHECK:           %[[VAL_9:.*]] = scf.if %[[VAL_8]] -> (i1) {
-// CHECK:             %[[VAL_10:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:             %[[VAL_12:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_2]]] : memref<?xi64>
-// CHECK:             %[[VAL_16:.*]] = index_cast %[[VAL_12]] : i64 to index
-// CHECK:             %[[VAL_11:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:             %[[VAL_13:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_2]]] : memref<?xi64>
-// CHECK:             %[[VAL_116:.*]] = index_cast %[[VAL_13]] : i64 to index
-// CHECK:             %[[VAL_14:.*]] = cmpi eq, %[[VAL_16]], %[[VAL_116]] : index
-// CHECK:             %[[VAL_15:.*]] = scf.if %[[VAL_14]] -> (i1) {
-// CHECK:               %[[VAL_17:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:               %[[VAL_18:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:               %[[VAL_19:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:               %[[VAL_20:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:               %[[VAL_21:.*]] = scf.parallel (%[[VAL_22:.*]]) = (%[[VAL_5]]) to (%[[VAL_16]]) step (%[[VAL_2]]) init (%[[VAL_4]]) -> i1 {
-// CHECK:                 %[[VAL_23:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_22]]] : memref<?xi64>
-// CHECK:                 %[[VAL_24:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_22]]] : memref<?xi64>
-// CHECK:                 %[[VAL_25:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_22]]] : memref<?xf64>
-// CHECK:                 %[[VAL_26:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_22]]] : memref<?xf64>
-// CHECK:                 %[[VAL_27:.*]] = cmpi eq, %[[VAL_23]], %[[VAL_24]] : i64
-// CHECK:                 %[[VAL_28:.*]] = cmpf oeq, %[[VAL_25]], %[[VAL_26]] : f64
-// CHECK:                 %[[VAL_29:.*]] = and %[[VAL_27]], %[[VAL_28]] : i1
-// CHECK:                 scf.reduce(%[[VAL_29]])  : i1 {
-// CHECK:                 ^bb0(%[[VAL_30:.*]]: i1, %[[VAL_31:.*]]: i1):
-// CHECK:                   %[[VAL_32:.*]] = and %[[VAL_30]], %[[VAL_31]] : i1
-// CHECK:                   scf.reduce.return %[[VAL_32]] : i1
+// CHECK:             %[[VAL_10:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:             %[[VAL_11:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_3]]] : memref<?xi64>
+// CHECK:             %[[VAL_12:.*]] = index_cast %[[VAL_11]] : i64 to index
+// CHECK:             %[[VAL_13:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:             %[[VAL_14:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_3]]] : memref<?xi64>
+// CHECK:             %[[VAL_15:.*]] = index_cast %[[VAL_14]] : i64 to index
+// CHECK:             %[[VAL_16:.*]] = cmpi eq, %[[VAL_12]], %[[VAL_15]] : index
+// CHECK:             %[[VAL_17:.*]] = scf.if %[[VAL_16]] -> (i1) {
+// CHECK:               %[[VAL_18:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:               %[[VAL_19:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:               %[[VAL_20:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:               %[[VAL_21:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:               %[[VAL_22:.*]] = scf.parallel (%[[VAL_23:.*]]) = (%[[VAL_2]]) to (%[[VAL_12]]) step (%[[VAL_3]]) init (%[[VAL_5]]) -> i32 {
+// CHECK:                 %[[VAL_24:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_23]]] : memref<?xi64>
+// CHECK:                 %[[VAL_25:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_23]]] : memref<?xi64>
+// CHECK:                 %[[VAL_26:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_23]]] : memref<?xf64>
+// CHECK:                 %[[VAL_27:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_23]]] : memref<?xf64>
+// CHECK:                 %[[VAL_28:.*]] = cmpi eq, %[[VAL_24]], %[[VAL_25]] : i64
+// CHECK:                 %[[VAL_29:.*]] = cmpf oeq, %[[VAL_26]], %[[VAL_27]] : f64
+// CHECK:                 %[[VAL_30:.*]] = and %[[VAL_28]], %[[VAL_29]] : i1
+// CHECK:                 %[[VAL_31:.*]] = sexti %[[VAL_30]] : i1 to i32
+// CHECK:                 scf.reduce(%[[VAL_31]])  : i32 {
+// CHECK:                 ^bb0(%[[VAL_32:.*]]: i32, %[[VAL_33:.*]]: i32):
+// CHECK:                   %[[VAL_34:.*]] = and %[[VAL_32]], %[[VAL_33]] : i32
+// CHECK:                   scf.reduce.return %[[VAL_34]] : i32
 // CHECK:                 }
 // CHECK:                 scf.yield
 // CHECK:               }
-// CHECK:               scf.yield %[[VAL_21:.*]] : i1
+// CHECK:               %[[VAL_35:.*]] = trunci %[[VAL_36:.*]] : i32 to i1
+// CHECK:               scf.yield %[[VAL_35]] : i1
 // CHECK:             } else {
-// CHECK:               scf.yield %[[VAL_3]] : i1
+// CHECK:               scf.yield %[[VAL_4]] : i1
 // CHECK:             }
-// CHECK:             scf.yield %[[VAL_15]] : i1
+// CHECK:             scf.yield %[[VAL_37:.*]] : i1
 // CHECK:           } else {
-// CHECK:             scf.yield %[[VAL_3]] : i1
+// CHECK:             scf.yield %[[VAL_4]] : i1
 // CHECK:           }
 // CHECK:           return %[[VAL_9]] : i1
 // CHECK:         }

--- a/mlir_graphblas/tests/test_algorithms.py
+++ b/mlir_graphblas/tests/test_algorithms.py
@@ -10,6 +10,7 @@ from mlir_graphblas.tools.utils import (
 )
 from mlir_graphblas.mlir_builder import GRAPHBLAS_OPENMP_PASSES
 
+
 @pytest.mark.parametrize("special_passes", [None, GRAPHBLAS_OPENMP_PASSES])
 def test_triangle_count(special_passes):
     # 0 - 1    5 - 6
@@ -39,6 +40,7 @@ def test_triangle_count(special_passes):
 
     num_triangles = mlalgo.triangle_count(a, compile_with_passes=special_passes)
     assert num_triangles == 5, num_triangles
+
 
 @pytest.mark.parametrize("special_passes", [None, GRAPHBLAS_OPENMP_PASSES])
 def test_sssp(special_passes):
@@ -141,7 +143,9 @@ def test_bipartite_project_and_filter(special_passes):
     assert np.all(dense_result == expected_dense_result)
 
     # Test column projection
-    result2 = mlalgo.bipartite_project_and_filter(input_tensor, "column", cutoff=1.0, compile_with_passes=special_passes)
+    result2 = mlalgo.bipartite_project_and_filter(
+        input_tensor, "column", cutoff=1.0, compile_with_passes=special_passes
+    )
     dense_result2 = densify_csr(result2)
 
     expected_dense_result2 = dense_input_tensor.T @ dense_input_tensor
@@ -236,7 +240,9 @@ def test_pagerank(special_passes):
     assert np.abs(pr.values - expected).sum() < 1e-5, pr.values
 
     # Test maxiter reached, failed to converge
-    pr, niters = mlalgo.pagerank(m, tol=1e-7, maxiter=6, compile_with_passes=special_passes)
+    pr, niters = mlalgo.pagerank(
+        m, tol=1e-7, maxiter=6, compile_with_passes=special_passes
+    )
     assert niters == 6
     assert (
         np.abs(pr.values - expected).sum() > 1e-5


### PR DESCRIPTION
This PR defines a new set of passes that lower `scf.parallel` loops to OpenMP code, rather than the standard serial execution.  The unit tests verify the results of both serial and OpenMP lowerings of the algorithms in algorithms.py (except graph_search, which requires a thread-safe RNG that we don't have yet).  For now, the standard set of passes is still the serial form, and the current interface for overriding passes is really only useful for testing.