### PR TITLE
Add more helpful message than 'Result element type differs from the input element types.' for vector-vector multiply.

### DIFF
--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOps.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOps.cpp
@@ -372,6 +372,10 @@ static LogicalResult verifyMatrixMultiplyArgs(T op,
       resultShape = resultType.getShape();
       resultRank = resultType.getRank();
       resultElementType = resultType.getElementType();
+    } else if (!resultElementType.isIntOrFloat()) {
+      assert(aRank == 1 && bRank == 1);
+      return op.emitError(
+          "Vector-vector multiplication must result in a scalar result-type.");
     }
 
     if (aType.getElementType() != resultElementType)

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_matrix_vector_multiply.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_matrix_vector_multiply.mlir
@@ -141,3 +141,17 @@ module {
    }
 
 }
+
+// -----
+ 
+#CV64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "compressed" ],
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+func @matrix_multiply_plus_times(%vecA: tensor<?xf64, #CV64>, %vecB: tensor<?xf64, #CV64>, %mask: tensor<?xf64, #CV64>) -> tensor<?xf64, #CV64> {
+    %answer = graphblas.matrix_multiply %vecA, %vecB, %mask { semiring = "any_pair" } : (tensor<?xf64, #CV64>, tensor<?xf64, #CV64>, tensor<?xf64, #CV64>) to tensor<?xf64, #CV64> // expected-error {{Vector-vector multiplication must result in a scalar result-type.}}
+    return %answer : tensor<?xf64, #CV64>
+}
+ 


### PR DESCRIPTION
This is intended to address https://github.com/metagraph-dev/mlir-graphblas/issues/195.