### PR TITLE
Update MLIR again

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Conda Version](https://img.shields.io/conda/v/metagraph/mlir-graphblas.svg)](https://anaconda.org/metagraph/mlir-graphblas)
 [![Build Status](https://github.com/metagraph-dev/mlir-graphblas/actions/workflows/test_and_deploy.yml/badge.svg?branch=main)](https://github.com/metagraph-dev/mlir-graphblas/actions/workflows/test_and_deploy.yml?query=branch%3Amain)
 
-*Note that this code currently requires [llvm-project@3a2ff98](https://github.com/llvm/llvm-project/commit/3a2ff98).*
+*Note that this code currently requires [llvm-project@bd0cae6](https://github.com/llvm/llvm-project/commit/bd0cae6).*
 
 ## graphblas-opt
 

--- a/mlir_graphblas/mlir_builder.py
+++ b/mlir_graphblas/mlir_builder.py
@@ -47,6 +47,8 @@ SCF_TO_LLVM_PASSES = (
     "--convert-scf-to-std",
     "--convert-memref-to-llvm",
     "--convert-openmp-to-llvm",
+    "--convert-math-to-llvm",
+    "--convert-arith-to-llvm",
     "--convert-std-to-llvm",
     "--reconcile-unrealized-casts",
 )
@@ -63,9 +65,9 @@ class MLIRVar:
     Upon initialization, must be assigned to exactly once, and can then be accessed many times.
 
     foo = MLIRVar('foo', 'f64')
-    add_statement(f"{foo.assign} = constant 1.0 : {foo.type}")
+    add_statement(f"{foo.assign} = arith.constant 1.0 : {foo.type}")
     bar = MLIRVar('bar', 'f64')
-    add_statement(f"{bar.assign} = addf {foo}, {baz} : {bar.type}")
+    add_statement(f"{bar.assign} = arith.addf {foo}, {baz} : {bar.type}")
     """
 
     def __init__(self, name: str, type_: Type):
@@ -394,13 +396,13 @@ class MLIRFunctionBuilder:
     ) -> Generator[ForLoopVars, None, None]:
         iter_var_index = self.new_var("index")
         lower_var_index = (
-            lower if isinstance(lower, MLIRVar) else self.constant(lower, "index")
+            lower if isinstance(lower, MLIRVar) else self.arith.constant(lower, "index")
         )
         upper_var_index = (
-            upper if isinstance(upper, MLIRVar) else self.constant(upper, "index")
+            upper if isinstance(upper, MLIRVar) else self.arith.constant(upper, "index")
         )
         step_var_index = (
-            step if isinstance(step, MLIRVar) else self.constant(step, "index")
+            step if isinstance(step, MLIRVar) else self.arith.constant(step, "index")
         )
         for_loop_open_statment = (
             f"scf.for {iter_var_index.assign} = {lower_var_index} "

--- a/mlir_graphblas/mlir_builder.py
+++ b/mlir_graphblas/mlir_builder.py
@@ -46,8 +46,8 @@ GRAPHBLAS_TO_SCF_PASSES = (
 SCF_TO_LLVM_PASSES = (
     "--convert-scf-to-std",
     "--convert-memref-to-llvm",
-    "--convert-openmp-to-llvm",
     "--convert-math-to-llvm",
+    "--convert-openmp-to-llvm",
     "--convert-arith-to-llvm",
     "--convert-std-to-llvm",
     "--reconcile-unrealized-casts",

--- a/mlir_graphblas/ops.py
+++ b/mlir_graphblas/ops.py
@@ -51,6 +51,7 @@ class BaseOp:
 
 
 class ConstantOp(BaseOp):
+    dialect = "arith"
     name = "constant"
 
     @classmethod
@@ -58,10 +59,11 @@ class ConstantOp(BaseOp):
         if str(type) in {"bf16", "f16", "f32", "f64", "f80", "f128"}:
             value = float(value)
         ret_val = irbuilder.new_var(type)
-        return ret_val, (f"{ret_val.assign} = constant {value} : {type}")
+        return ret_val, (f"{ret_val.assign} = arith.constant {value} : {type}")
 
 
 class IndexCastOp(BaseOp):
+    dialect = "arith"
     name = "index_cast"
 
     @classmethod
@@ -69,11 +71,12 @@ class IndexCastOp(BaseOp):
         cls.ensure_mlirvar(value)
         ret_val = irbuilder.new_var(result_type)
         return ret_val, (
-            f"{ret_val.assign} = std.index_cast {value} : {value.type} to {ret_val.type}"
+            f"{ret_val.assign} = arith.index_cast {value} : {value.type} to {ret_val.type}"
         )
 
 
 class SignedIntToFloatOp(BaseOp):
+    dialect = "arith"
     name = "sitofp"
 
     @classmethod
@@ -81,11 +84,12 @@ class SignedIntToFloatOp(BaseOp):
         cls.ensure_mlirvar(value)
         ret_val = irbuilder.new_var(result_type)
         return ret_val, (
-            f"{ret_val.assign} = std.sitofp {value} : {value.type} to {ret_val.type}"
+            f"{ret_val.assign} = arith.sitofp {value} : {value.type} to {ret_val.type}"
         )
 
 
 class AddIOp(BaseOp):
+    dialect = "arith"
     name = "addi"
 
     @classmethod
@@ -95,10 +99,11 @@ class AddIOp(BaseOp):
         if lhs.type != rhs.type:
             raise TypeError(f"Type mismatch: {lhs.type} != {rhs.type}")
         ret_val = irbuilder.new_var(lhs.type)
-        return ret_val, (f"{ret_val.assign} = addi {lhs}, {rhs} : {lhs.type}")
+        return ret_val, (f"{ret_val.assign} = arith.addi {lhs}, {rhs} : {lhs.type}")
 
 
 class SubIOp(BaseOp):
+    dialect = "arith"
     name = "subi"
 
     @classmethod
@@ -108,10 +113,11 @@ class SubIOp(BaseOp):
         if lhs.type != rhs.type:
             raise TypeError(f"Type mismatch: {lhs.type} != {rhs.type}")
         ret_val = irbuilder.new_var(lhs.type)
-        return ret_val, (f"{ret_val.assign} = subi {lhs}, {rhs} : {lhs.type}")
+        return ret_val, (f"{ret_val.assign} = arith.subi {lhs}, {rhs} : {lhs.type}")
 
 
 class MulIOp(BaseOp):
+    dialect = "arith"
     name = "muli"
 
     @classmethod
@@ -121,10 +127,11 @@ class MulIOp(BaseOp):
         if lhs.type != rhs.type:
             raise TypeError(f"Type mismatch: {lhs.type} != {rhs.type}")
         ret_val = irbuilder.new_var(lhs.type)
-        return ret_val, (f"{ret_val.assign} = muli {lhs}, {rhs} : {lhs.type}")
+        return ret_val, (f"{ret_val.assign} = arith.muli {lhs}, {rhs} : {lhs.type}")
 
 
 class AddFOp(BaseOp):
+    dialect = "arith"
     name = "addf"
 
     @classmethod
@@ -134,10 +141,11 @@ class AddFOp(BaseOp):
         if lhs.type != rhs.type:
             raise TypeError(f"Type mismatch: {lhs.type} != {rhs.type}")
         ret_val = irbuilder.new_var(lhs.type)
-        return ret_val, (f"{ret_val.assign} = addf {lhs}, {rhs} : {lhs.type}")
+        return ret_val, (f"{ret_val.assign} = arith.addf {lhs}, {rhs} : {lhs.type}")
 
 
 class SubFOp(BaseOp):
+    dialect = "arith"
     name = "subf"
 
     @classmethod
@@ -147,10 +155,11 @@ class SubFOp(BaseOp):
         if lhs.type != rhs.type:
             raise TypeError(f"Type mismatch: {lhs.type} != {rhs.type}")
         ret_val = irbuilder.new_var(lhs.type)
-        return ret_val, (f"{ret_val.assign} = subf {lhs}, {rhs} : {lhs.type}")
+        return ret_val, (f"{ret_val.assign} = arith.subf {lhs}, {rhs} : {lhs.type}")
 
 
 class MulFOp(BaseOp):
+    dialect = "arith"
     name = "mulf"
 
     @classmethod
@@ -160,10 +169,11 @@ class MulFOp(BaseOp):
         if lhs.type != rhs.type:
             raise TypeError(f"Type mismatch: {lhs.type} != {rhs.type}")
         ret_val = irbuilder.new_var(lhs.type)
-        return ret_val, (f"{ret_val.assign} = mulf {lhs}, {rhs} : {lhs.type}")
+        return ret_val, (f"{ret_val.assign} = arith.mulf {lhs}, {rhs} : {lhs.type}")
 
 
 class DivFOp(BaseOp):
+    dialect = "arith"
     name = "divf"
 
     @classmethod
@@ -173,7 +183,7 @@ class DivFOp(BaseOp):
         if lhs.type != rhs.type:
             raise TypeError(f"Type mismatch: {lhs.type} != {rhs.type}")
         ret_val = irbuilder.new_var(lhs.type)
-        return ret_val, (f"{ret_val.assign} = divf {lhs}, {rhs} : {lhs.type}")
+        return ret_val, (f"{ret_val.assign} = arith.divf {lhs}, {rhs} : {lhs.type}")
 
 
 class SelectOp(BaseOp):
@@ -193,6 +203,7 @@ class SelectOp(BaseOp):
 
 
 class CmpIOp(BaseOp):
+    dialect = "arith"
     name = "cmpi"
     # fmt: off
     allowed_cmpstr = {
@@ -213,11 +224,12 @@ class CmpIOp(BaseOp):
             raise ValueError(f"Unknown cmpstr: {cmpstr}")
         ret_val = irbuilder.new_var("i1")
         return ret_val, (
-            f'{ret_val.assign} = cmpi "{cmpstr}", {lhs}, {rhs} : {lhs.type}'
+            f'{ret_val.assign} = arith.cmpi "{cmpstr}", {lhs}, {rhs} : {lhs.type}'
         )
 
 
 class CmpFOp(BaseOp):
+    dialect = "arith"
     name = "cmpf"
     # fmt: off
     # See https://llvm.org/docs/LangRef.html#fcmp-instruction for explanation
@@ -238,7 +250,7 @@ class CmpFOp(BaseOp):
             raise ValueError(f"Unknown cmpstr: {cmpstr}")
         ret_val = irbuilder.new_var("i1")
         return ret_val, (
-            f'{ret_val.assign} = cmpf "{cmpstr}", {lhs}, {rhs} : {lhs.type}'
+            f'{ret_val.assign} = arith.cmpf "{cmpstr}", {lhs}, {rhs} : {lhs.type}'
         )
 
 

--- a/mlir_graphblas/sparse_utils.pyx
+++ b/mlir_graphblas/sparse_utils.pyx
@@ -81,7 +81,7 @@ cdef extern from "SparseUtils.cpp" nogil:
         # SparseTensorStorage(SparseTensorStorage[P, I, V]&) except +  # HACKED IN
         # SparseTensorStorage(vector[uint64_t]&, vector[P]&, vector[I]&, vector[V]&) except +  # HACKED IN
 
-        SparseTensorStorage(SparseTensorCOO *, uint8_t *, uint64_t *) except +
+        SparseTensorStorage(const vector[uint64_t], const uint64_t *, const uint8_t *, SparseTensorCOO[V] *) except +
         uint64_t getRank() const
         uint64_t getDimSize(uint64_t d)
         void getPointers(vector[P] **, uint64_t)
@@ -364,15 +364,15 @@ cpdef empty_mlir_sparse_tensor_safe(uint64_t[:] sizes, uint8_t[:] sparsity, uint
         if pointer_type_num == np.NPY_UINT8:
             if index_type_num == np.NPY_UINT8:
                 if value_type_num == np.NPY_FLOAT32:
-                    data = (new SparseTensorStorage[uint8_t, uint8_t, float32_t](tensor_float32, sparsity_array, perm_ptr))
+                    data = (new SparseTensorStorage[uint8_t, uint8_t, float32_t](sizes_vector, perm_ptr, sparsity_array, tensor_float32))
                 elif value_type_num == np.NPY_FLOAT64:
-                    data = (new SparseTensorStorage[uint8_t, uint8_t, float64_t](tensor_float64, sparsity_array, perm_ptr))
+                    data = (new SparseTensorStorage[uint8_t, uint8_t, float64_t](sizes_vector, perm_ptr, sparsity_array, tensor_float64))
                 elif value_type_num == np.NPY_INT8:
-                    data = (new SparseTensorStorage[uint8_t, uint8_t, int8_t](tensor_int8, sparsity_array, perm_ptr))
+                    data = (new SparseTensorStorage[uint8_t, uint8_t, int8_t](sizes_vector, perm_ptr, sparsity_array, tensor_int8))
                 elif value_type_num == np.NPY_INT16:
-                    data = (new SparseTensorStorage[uint8_t, uint8_t, int16_t](tensor_int16, sparsity_array, perm_ptr))
+                    data = (new SparseTensorStorage[uint8_t, uint8_t, int16_t](sizes_vector, perm_ptr, sparsity_array, tensor_int16))
                 elif value_type_num == np.NPY_INT32:
-                    data = (new SparseTensorStorage[uint8_t, uint8_t, int32_t](tensor_int32, sparsity_array, perm_ptr))
+                    data = (new SparseTensorStorage[uint8_t, uint8_t, int32_t](sizes_vector, perm_ptr, sparsity_array, tensor_int32))
                 else:
                     raise TypeError(f"Invalid type combo for pointers, indices, and values: {pointer_dtype}, {index_dtype}, {value_dtype}")
             else:
@@ -380,15 +380,15 @@ cpdef empty_mlir_sparse_tensor_safe(uint64_t[:] sizes, uint8_t[:] sparsity, uint
         elif pointer_type_num == np.NPY_UINT16:
             if index_type_num == np.NPY_UINT16:
                 if value_type_num == np.NPY_FLOAT32:
-                    data = (new SparseTensorStorage[uint16_t, uint16_t, float32_t](tensor_float32, sparsity_array, perm_ptr))
+                    data = (new SparseTensorStorage[uint16_t, uint16_t, float32_t](sizes_vector, perm_ptr, sparsity_array, tensor_float32))
                 elif value_type_num == np.NPY_FLOAT64:
-                    data = (new SparseTensorStorage[uint16_t, uint16_t, float64_t](tensor_float64, sparsity_array, perm_ptr))
+                    data = (new SparseTensorStorage[uint16_t, uint16_t, float64_t](sizes_vector, perm_ptr, sparsity_array, tensor_float64))
                 elif value_type_num == np.NPY_INT8:
-                    data = (new SparseTensorStorage[uint16_t, uint16_t, int8_t](tensor_int8, sparsity_array, perm_ptr))
+                    data = (new SparseTensorStorage[uint16_t, uint16_t, int8_t](sizes_vector, perm_ptr, sparsity_array, tensor_int8))
                 elif value_type_num == np.NPY_INT16:
-                    data = (new SparseTensorStorage[uint16_t, uint16_t, int16_t](tensor_int16, sparsity_array, perm_ptr))
+                    data = (new SparseTensorStorage[uint16_t, uint16_t, int16_t](sizes_vector, perm_ptr, sparsity_array, tensor_int16))
                 elif value_type_num == np.NPY_INT32:
-                    data = (new SparseTensorStorage[uint16_t, uint16_t, int32_t](tensor_int32, sparsity_array, perm_ptr))
+                    data = (new SparseTensorStorage[uint16_t, uint16_t, int32_t](sizes_vector, perm_ptr, sparsity_array, tensor_int32))
                 else:
                     raise TypeError(f"Invalid type combo for pointers, indices, and values: {pointer_dtype}, {index_dtype}, {value_dtype}")
             else:
@@ -396,22 +396,22 @@ cpdef empty_mlir_sparse_tensor_safe(uint64_t[:] sizes, uint8_t[:] sparsity, uint
         elif pointer_type_num == np.NPY_UINT32:
             if index_type_num == np.NPY_UINT32:
                 if value_type_num == np.NPY_FLOAT32:
-                    data = (new SparseTensorStorage[uint32_t, uint32_t, float32_t](tensor_float32, sparsity_array, perm_ptr))
+                    data = (new SparseTensorStorage[uint32_t, uint32_t, float32_t](sizes_vector, perm_ptr, sparsity_array, tensor_float32))
                 elif value_type_num == np.NPY_FLOAT64:
-                    data = (new SparseTensorStorage[uint32_t, uint32_t, float64_t](tensor_float64, sparsity_array, perm_ptr))
+                    data = (new SparseTensorStorage[uint32_t, uint32_t, float64_t](sizes_vector, perm_ptr, sparsity_array, tensor_float64))
                 elif value_type_num == np.NPY_INT8:
-                    data = (new SparseTensorStorage[uint32_t, uint32_t, int8_t](tensor_int8, sparsity_array, perm_ptr))
+                    data = (new SparseTensorStorage[uint32_t, uint32_t, int8_t](sizes_vector, perm_ptr, sparsity_array, tensor_int8))
                 elif value_type_num == np.NPY_INT16:
-                    data = (new SparseTensorStorage[uint32_t, uint32_t, int16_t](tensor_int16, sparsity_array, perm_ptr))
+                    data = (new SparseTensorStorage[uint32_t, uint32_t, int16_t](sizes_vector, perm_ptr, sparsity_array, tensor_int16))
                 elif value_type_num == np.NPY_INT32:
-                    data = (new SparseTensorStorage[uint32_t, uint32_t, int32_t](tensor_int32, sparsity_array, perm_ptr))
+                    data = (new SparseTensorStorage[uint32_t, uint32_t, int32_t](sizes_vector, perm_ptr, sparsity_array, tensor_int32))
                 else:
                     raise TypeError(f"Invalid type combo for pointers, indices, and values: {pointer_dtype}, {index_dtype}, {value_dtype}")
             elif index_type_num == np.NPY_UINT64:
                 if value_type_num == np.NPY_FLOAT32:
-                    data = (new SparseTensorStorage[uint32_t, uint64_t, float32_t](tensor_float32, sparsity_array, perm_ptr))
+                    data = (new SparseTensorStorage[uint32_t, uint64_t, float32_t](sizes_vector, perm_ptr, sparsity_array, tensor_float32))
                 elif value_type_num == np.NPY_FLOAT64:
-                    data = (new SparseTensorStorage[uint32_t, uint64_t, float64_t](tensor_float64, sparsity_array, perm_ptr))
+                    data = (new SparseTensorStorage[uint32_t, uint64_t, float64_t](sizes_vector, perm_ptr, sparsity_array, tensor_float64))
                 else:
                     raise TypeError(f"Invalid type combo for pointers, indices, and values: {pointer_dtype}, {index_dtype}, {value_dtype}")
             else:
@@ -419,16 +419,16 @@ cpdef empty_mlir_sparse_tensor_safe(uint64_t[:] sizes, uint8_t[:] sparsity, uint
         elif pointer_type_num == np.NPY_UINT64:
             if index_type_num == np.NPY_UINT32:
                 if value_type_num == np.NPY_FLOAT32:
-                    data = (new SparseTensorStorage[uint64_t, uint32_t, float32_t](tensor_float32, sparsity_array, perm_ptr))
+                    data = (new SparseTensorStorage[uint64_t, uint32_t, float32_t](sizes_vector, perm_ptr, sparsity_array, tensor_float32))
                 elif value_type_num == np.NPY_FLOAT64:
-                    data = (new SparseTensorStorage[uint64_t, uint32_t, float64_t](tensor_float64, sparsity_array, perm_ptr))
+                    data = (new SparseTensorStorage[uint64_t, uint32_t, float64_t](sizes_vector, perm_ptr, sparsity_array, tensor_float64))
                 else:
                     raise TypeError(f"Invalid type combo for pointers, indices, and values: {pointer_dtype}, {index_dtype}, {value_dtype}")
             elif index_type_num == np.NPY_UINT64:
                 if value_type_num == np.NPY_FLOAT32:
-                    data = (new SparseTensorStorage[uint64_t, uint64_t, float32_t](tensor_float32, sparsity_array, perm_ptr))
+                    data = (new SparseTensorStorage[uint64_t, uint64_t, float32_t](sizes_vector, perm_ptr, sparsity_array, tensor_float32))
                 elif value_type_num == np.NPY_FLOAT64:
-                    data = (new SparseTensorStorage[uint64_t, uint64_t, float64_t](tensor_float64, sparsity_array, perm_ptr))
+                    data = (new SparseTensorStorage[uint64_t, uint64_t, float64_t](sizes_vector, perm_ptr, sparsity_array, tensor_float64))
                 else:
                     raise TypeError(f"Invalid type combo for pointers, indices, and values: {pointer_dtype}, {index_dtype}, {value_dtype}")
             else:
@@ -769,13 +769,13 @@ def _build_sparse_tensor(
         perm = np.arange(D, dtype=np.uint64)
     cdef uint64_t *perm_ptr = &perm[0]
     if pointer_type_num == np.NPY_UINT8:
-        self._data = (new SparseTensorStorage[uint8_t, st_index_t, st_value_t](tensor, sparsity_array, perm_ptr))
+        self._data = (new SparseTensorStorage[uint8_t, st_index_t, st_value_t](sizes_vector, perm_ptr, sparsity_array, tensor))
     elif pointer_type_num == np.NPY_UINT16:
-        self._data = (new SparseTensorStorage[uint16_t, st_index_t, st_value_t](tensor, sparsity_array, perm_ptr))
+        self._data = (new SparseTensorStorage[uint16_t, st_index_t, st_value_t](sizes_vector, perm_ptr, sparsity_array, tensor))
     elif pointer_type_num == np.NPY_UINT32:
-        self._data = (new SparseTensorStorage[uint32_t, st_index_t, st_value_t](tensor, sparsity_array, perm_ptr))
+        self._data = (new SparseTensorStorage[uint32_t, st_index_t, st_value_t](sizes_vector, perm_ptr, sparsity_array, tensor))
     else:
-        self._data = (new SparseTensorStorage[uint64_t, st_index_t, st_value_t](tensor, sparsity_array, perm_ptr))
+        self._data = (new SparseTensorStorage[uint64_t, st_index_t, st_value_t](sizes_vector, perm_ptr, sparsity_array, tensor))
 
     free(sparsity_array)
     del tensor

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASPasses.td
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASPasses.td
@@ -22,6 +22,8 @@ def GraphBLASLowering : Pass<"graphblas-lower", "ModuleOp"> {
     "AffineDialect",
     "memref::MemRefDialect",
     "tensor::TensorDialect",
+    "math::MathDialect",
+    "arith::ArithmeticDialect",
     "scf::SCFDialect"
   ];
 }
@@ -45,6 +47,9 @@ def GraphBLASStructuralize : Pass<"graphblas-structuralize", "ModuleOp"> {
   let summary = "TODO add documentation";
   let constructor = "mlir::createGraphBLASStructuralizePass()";
   let dependentDialects = [
+    "math::MathDialect",
+    "arith::ArithmeticDialect",
+    "scf::SCFDialect"
   ];
 }
 

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASArrayUtils.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASArrayUtils.cpp
@@ -439,7 +439,8 @@ Value computeIndexOverlapSize(PatternRewriter &rewriter, Location loc,
       loc, arith::CmpIPredicate::ult, posA, aPosEnd);
   Value validPosB = rewriter.create<arith::CmpIOp>(
       loc, arith::CmpIPredicate::ult, posB, bPosEnd);
-  Value continueLoop = rewriter.create<arith::AndIOp>(loc, validPosA, validPosB);
+  Value continueLoop =
+      rewriter.create<arith::AndIOp>(loc, validPosA, validPosB);
   rewriter.create<scf::ConditionOp>(loc, continueLoop, before->getArguments());
 
   // "do" portion of while loop
@@ -596,16 +597,15 @@ Value computeUnionAggregation(PatternRewriter &rewriter, Location loc,
   Value cfalse = rewriter.create<arith::ConstantIntOp>(loc, 0, boolType);
   Value ctrue = rewriter.create<arith::ConstantIntOp>(loc, 1, boolType);
   // TODO: change this out for AGG_IDENTITY
-  Value cf0 =
-      llvm::TypeSwitch<Type, Value>(valueType)
-          .Case<IntegerType>([&](IntegerType type) {
-            return rewriter.create<arith::ConstantIntOp>(loc, 0,
-                                                         type.getWidth());
-          })
-          .Case<FloatType>([&](FloatType type) {
-            return rewriter.create<arith::ConstantFloatOp>(loc, APFloat(0.0),
-                                                           type);
-          });
+  Value cf0 = llvm::TypeSwitch<Type, Value>(valueType)
+                  .Case<IntegerType>([&](IntegerType type) {
+                    return rewriter.create<arith::ConstantIntOp>(
+                        loc, 0, type.getWidth());
+                  })
+                  .Case<FloatType>([&](FloatType type) {
+                    return rewriter.create<arith::ConstantFloatOp>(
+                        loc, APFloat(0.0), type);
+                  });
 
   // While Loop (exit when either array is exhausted)
   scf::WhileOp whileLoop = rewriter.create<scf::WhileOp>(
@@ -630,7 +630,8 @@ Value computeUnionAggregation(PatternRewriter &rewriter, Location loc,
       loc, arith::CmpIPredicate::ult, posA, aPosEnd);
   Value validPosB = rewriter.create<arith::CmpIOp>(
       loc, arith::CmpIPredicate::ult, posB, bPosEnd);
-  Value continueLoop = rewriter.create<arith::AndIOp>(loc, validPosA, validPosB);
+  Value continueLoop =
+      rewriter.create<arith::AndIOp>(loc, validPosA, validPosB);
   rewriter.create<scf::ConditionOp>(loc, continueLoop, before->getArguments());
 
   // "do" portion of while loop
@@ -745,14 +746,14 @@ Value computeUnionAggregation(PatternRewriter &rewriter, Location loc,
                    return rewriter.create<arith::MulFOp>(loc, newValA, newValB);
                  });
   } else if (agg == "div") {
-    aggVal = llvm::TypeSwitch<Type, Value>(valueType)
-                 .Case<IntegerType>([&](IntegerType type) {
-                   return rewriter.create<arith::DivSIOp>(loc, newValA,
-                                                               newValB);
-                 })
-                 .Case<FloatType>([&](FloatType type) {
-                   return rewriter.create<arith::DivFOp>(loc, newValA, newValB);
-                 });
+    aggVal =
+        llvm::TypeSwitch<Type, Value>(valueType)
+            .Case<IntegerType>([&](IntegerType type) {
+              return rewriter.create<arith::DivSIOp>(loc, newValA, newValB);
+            })
+            .Case<FloatType>([&](FloatType type) {
+              return rewriter.create<arith::DivFOp>(loc, newValA, newValB);
+            });
   } else if (agg == "min") {
     Value cmp = llvm::TypeSwitch<Type, Value>(valueType)
                     .Case<IntegerType>([&](IntegerType type) {

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASArrayUtils.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASArrayUtils.cpp
@@ -1,3 +1,4 @@
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
@@ -28,20 +29,20 @@ ValueRange buildMaskComplement(PatternRewriter &rewriter, Location loc,
   MemRefType memref1DI64Type = MemRefType::get({-1}, int64Type);
 
   // Initial constants
-  Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-  Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
+  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
 
   // Compute the size of the complemented mask
-  Value maskSize = rewriter.create<SubIOp>(loc, maskEnd, maskStart);
-  Value compSize = rewriter.create<SubIOp>(loc, fullSize, maskSize);
+  Value maskSize = rewriter.create<arith::SubIOp>(loc, maskEnd, maskStart);
+  Value compSize = rewriter.create<arith::SubIOp>(loc, fullSize, maskSize);
 
   // Allocate memref
   Value compIndices =
       rewriter.create<memref::AllocOp>(loc, memref1DI64Type, compSize);
 
   // Handle case of empty row
-  Value rowIsEmpty =
-      rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, maskStart, maskEnd);
+  Value rowIsEmpty = rewriter.create<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::eq, maskStart, maskEnd);
   scf::IfOp if_empty_row =
       rewriter.create<scf::IfOp>(loc, indexType, rowIsEmpty, true);
   {
@@ -59,7 +60,7 @@ ValueRange buildMaskComplement(PatternRewriter &rewriter, Location loc,
   Value firstMaskIndex64 =
       rewriter.create<memref::LoadOp>(loc, maskIndices, startPos);
   Value firstMaskIndex =
-      rewriter.create<IndexCastOp>(loc, firstMaskIndex64, indexType);
+      rewriter.create<arith::IndexCastOp>(loc, firstMaskIndex64, indexType);
   scf::ForOp loop = rewriter.create<scf::ForOp>(
       loc, c0, fullSize, c1, ValueRange{c0, startPos, firstMaskIndex});
   Value idx = loop.getInductionVar();
@@ -68,17 +69,17 @@ ValueRange buildMaskComplement(PatternRewriter &rewriter, Location loc,
   Value maskIndex = loop.getLoopBody().getArgument(3);
   {
     rewriter.setInsertionPointToStart(loop.getBody());
-    Value maskMatch =
-        rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, idx, maskIndex);
+    Value maskMatch = rewriter.create<arith::CmpIOp>(
+        loc, arith::CmpIPredicate::eq, idx, maskIndex);
     scf::IfOp if_match = rewriter.create<scf::IfOp>(
         loc, TypeRange{indexType, indexType, indexType}, maskMatch, true);
     {
       rewriter.setInsertionPointToStart(if_match.thenBlock());
       // Increment maskPos
-      Value nextMaskPos = rewriter.create<AddIOp>(loc, maskPos, c1);
+      Value nextMaskPos = rewriter.create<arith::AddIOp>(loc, maskPos, c1);
       // Update maskIndex (unless we're at the end)
-      Value isAtEnd = rewriter.create<CmpIOp>(loc, CmpIPredicate::uge,
-                                              nextMaskPos, maskEnd);
+      Value isAtEnd = rewriter.create<arith::CmpIOp>(
+          loc, arith::CmpIPredicate::uge, nextMaskPos, maskEnd);
       scf::IfOp if_atEnd =
           rewriter.create<scf::IfOp>(loc, indexType, isAtEnd, true);
       {
@@ -90,7 +91,7 @@ ValueRange buildMaskComplement(PatternRewriter &rewriter, Location loc,
         Value newMaskIndex64 =
             rewriter.create<memref::LoadOp>(loc, maskIndices, nextMaskPos);
         Value newMaskIndex =
-            rewriter.create<IndexCastOp>(loc, newMaskIndex64, indexType);
+            rewriter.create<arith::IndexCastOp>(loc, newMaskIndex64, indexType);
         rewriter.create<scf::YieldOp>(loc, newMaskIndex);
         rewriter.setInsertionPointAfter(if_atEnd);
       }
@@ -100,10 +101,10 @@ ValueRange buildMaskComplement(PatternRewriter &rewriter, Location loc,
     {
       rewriter.setInsertionPointToStart(if_match.elseBlock());
       // Add i to compIndices
-      Value idx64 = rewriter.create<IndexCastOp>(loc, idx, int64Type);
+      Value idx64 = rewriter.create<arith::IndexCastOp>(loc, idx, int64Type);
       rewriter.create<memref::StoreOp>(loc, idx64, compIndices, compPos);
       // Increment compPos
-      Value nextCompPos = rewriter.create<AddIOp>(loc, compPos, c1);
+      Value nextCompPos = rewriter.create<arith::AddIOp>(loc, compPos, c1);
       rewriter.create<scf::YieldOp>(
           loc, ValueRange{nextCompPos, maskPos, maskIndex});
       rewriter.setInsertionPointAfter(if_match);
@@ -130,11 +131,11 @@ Value computeNumOverlaps(PatternRewriter &rewriter, Location loc, Value nk,
   MemRefType memref1DBoolType = MemRefType::get({-1}, boolType);
 
   // Initial constants
-  Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
-  Value ci0 = rewriter.create<ConstantIntOp>(loc, 0, int64Type);
-  Value ci1 = rewriter.create<ConstantIntOp>(loc, 1, int64Type);
-  Value ctrue = rewriter.create<ConstantIntOp>(loc, 1, boolType);
-  Value cfalse = rewriter.create<ConstantIntOp>(loc, 0, boolType);
+  Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+  Value ci0 = rewriter.create<arith::ConstantIntOp>(loc, 0, int64Type);
+  Value ci1 = rewriter.create<arith::ConstantIntOp>(loc, 1, int64Type);
+  Value ctrue = rewriter.create<arith::ConstantIntOp>(loc, 1, boolType);
+  Value cfalse = rewriter.create<arith::ConstantIntOp>(loc, 0, boolType);
 
   // Construct a dense array indicating valid kk positions within fixed index
   Value kvec_i1 = rewriter.create<memref::AllocOp>(loc, memref1DBoolType, nk);
@@ -144,7 +145,7 @@ Value computeNumOverlaps(PatternRewriter &rewriter, Location loc, Value nk,
   Value jj = colLoop1.getInductionVars()[0];
   rewriter.setInsertionPointToStart(colLoop1.getBody());
   Value col64 = rewriter.create<memref::LoadOp>(loc, fixedIndices, jj);
-  Value col = rewriter.create<IndexCastOp>(loc, col64, indexType);
+  Value col = rewriter.create<arith::IndexCastOp>(loc, col64, indexType);
   rewriter.create<memref::StoreOp>(loc, ctrue, kvec_i1, col);
   rewriter.setInsertionPointAfter(colLoop1);
   // Loop thru all columns; count number of resulting nonzeros in the row
@@ -154,18 +155,18 @@ Value computeNumOverlaps(PatternRewriter &rewriter, Location loc, Value nk,
     Value mm = colLoop1.getInductionVars()[0];
     rewriter.setInsertionPointToStart(colLoop1.getBody());
     col64 = rewriter.create<memref::LoadOp>(loc, maskIndices, mm);
-    col = rewriter.create<IndexCastOp>(loc, col64, indexType);
+    col = rewriter.create<arith::IndexCastOp>(loc, col64, indexType);
   } else {
     colLoop1 =
         rewriter.create<scf::ParallelOp>(loc, maskStart, maskEnd, c1, ci0);
     col = colLoop1.getInductionVars()[0];
     rewriter.setInsertionPointToStart(colLoop1.getBody());
   }
-  Value colPlus1 = rewriter.create<AddIOp>(loc, col, c1);
+  Value colPlus1 = rewriter.create<arith::AddIOp>(loc, col, c1);
   Value rowStart64 = rewriter.create<memref::LoadOp>(loc, iterPointers, col);
   Value rowEnd64 = rewriter.create<memref::LoadOp>(loc, iterPointers, colPlus1);
-  Value cmpRowSame =
-      rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, rowStart64, rowEnd64);
+  Value cmpRowSame = rewriter.create<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::eq, rowStart64, rowEnd64);
   // Find overlap in column indices with kvec
   scf::IfOp ifBlock_overlap =
       rewriter.create<scf::IfOp>(loc, int64Type, cmpRowSame, true);
@@ -182,8 +183,8 @@ Value computeNumOverlaps(PatternRewriter &rewriter, Location loc, Value nk,
   Value ii64 = before->getArgument(0);
   rewriter.setInsertionPointToStart(&whileLoop.before().front());
   // Check if ii >= rowEnd
-  Value cmpEndReached =
-      rewriter.create<CmpIOp>(loc, CmpIPredicate::uge, ii64, rowEnd64);
+  Value cmpEndReached = rewriter.create<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::uge, ii64, rowEnd64);
   scf::IfOp ifBlock_continueSearch = rewriter.create<scf::IfOp>(
       loc, TypeRange{boolType, int64Type}, cmpEndReached, true);
   // if cmpEndReached
@@ -192,9 +193,9 @@ Value computeNumOverlaps(PatternRewriter &rewriter, Location loc, Value nk,
   // else
   rewriter.setInsertionPointToStart(ifBlock_continueSearch.elseBlock());
   // Check if row has a match in kvec
-  Value ii = rewriter.create<IndexCastOp>(loc, ii64, indexType);
+  Value ii = rewriter.create<arith::IndexCastOp>(loc, ii64, indexType);
   Value kk64 = rewriter.create<memref::LoadOp>(loc, iterIndices, ii);
-  Value kk = rewriter.create<IndexCastOp>(loc, kk64, indexType);
+  Value kk = rewriter.create<arith::IndexCastOp>(loc, kk64, indexType);
   Value cmpPair = rewriter.create<memref::LoadOp>(loc, kvec_i1, kk);
   Value cmpResult0 = rewriter.create<SelectOp>(loc, cmpPair, cfalse, ctrue);
   Value cmpResult1 = rewriter.create<SelectOp>(loc, cmpPair, ci1, ii64);
@@ -207,7 +208,7 @@ Value computeNumOverlaps(PatternRewriter &rewriter, Location loc, Value nk,
   // "do" portion of while loop
   rewriter.setInsertionPointToStart(&whileLoop.after().front());
   Value iiPrev = after->getArgument(0);
-  Value iiNext = rewriter.create<AddIOp>(loc, iiPrev, ci1);
+  Value iiNext = rewriter.create<arith::AddIOp>(loc, iiPrev, ci1);
   rewriter.create<scf::YieldOp>(loc, iiNext);
   rewriter.setInsertionPointAfter(whileLoop);
   Value res = whileLoop.getResult(0);
@@ -219,7 +220,7 @@ Value computeNumOverlaps(PatternRewriter &rewriter, Location loc, Value nk,
   Value lhs = reducer.getRegion().getArgument(0);
   Value rhs = reducer.getRegion().getArgument(1);
   rewriter.setInsertionPointToStart(&reducer.getRegion().front());
-  Value z = rewriter.create<AddIOp>(loc, lhs, rhs);
+  Value z = rewriter.create<arith::AddIOp>(loc, lhs, rhs);
   rewriter.create<scf::ReduceReturnOp>(loc, z);
   // end col loop
   rewriter.setInsertionPointAfter(colLoop1);
@@ -247,10 +248,10 @@ void computeInnerProduct(PatternRewriter &rewriter, Location loc, Value nk,
   MemRefType memref1DValueType = MemRefType::get({-1}, valueType);
 
   // Initial constants
-  Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-  Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
-  Value ctrue = rewriter.create<ConstantIntOp>(loc, 1, boolType);
-  Value cfalse = rewriter.create<ConstantIntOp>(loc, 0, boolType);
+  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+  Value ctrue = rewriter.create<arith::ConstantIntOp>(loc, 1, boolType);
+  Value cfalse = rewriter.create<arith::ConstantIntOp>(loc, 0, boolType);
 
   // Construct a dense array of row values
   Value kvec = rewriter.create<memref::AllocOp>(loc, memref1DValueType, nk);
@@ -261,7 +262,7 @@ void computeInnerProduct(PatternRewriter &rewriter, Location loc, Value nk,
   Value jj = colLoop3p.getInductionVars()[0];
   rewriter.setInsertionPointToStart(colLoop3p.getBody());
   Value fixedJ64 = rewriter.create<memref::LoadOp>(loc, fixedIndices, jj);
-  Value fixedJ = rewriter.create<IndexCastOp>(loc, fixedJ64, indexType);
+  Value fixedJ = rewriter.create<arith::IndexCastOp>(loc, fixedJ64, indexType);
   rewriter.create<memref::StoreOp>(loc, ctrue, kvec_i1, fixedJ);
   Value val = rewriter.create<memref::LoadOp>(loc, fixedValues, jj);
   rewriter.create<memref::StoreOp>(loc, val, kvec, fixedJ);
@@ -276,20 +277,20 @@ void computeInnerProduct(PatternRewriter &rewriter, Location loc, Value nk,
     Value mm = colLoop3f.getInductionVar();
     rewriter.setInsertionPointToStart(colLoop3f.getBody());
     col64 = rewriter.create<memref::LoadOp>(loc, maskIndices, mm);
-    col = rewriter.create<IndexCastOp>(loc, col64, indexType);
+    col = rewriter.create<arith::IndexCastOp>(loc, col64, indexType);
   } else {
     colLoop3f = rewriter.create<scf::ForOp>(loc, maskStart, maskEnd, c1, c0);
     col = colLoop3f.getInductionVar();
     rewriter.setInsertionPointToStart(colLoop3f.getBody());
-    col64 = rewriter.create<IndexCastOp>(loc, col, int64Type);
+    col64 = rewriter.create<arith::IndexCastOp>(loc, col, int64Type);
   }
 
   Value offset = colLoop3f.getLoopBody().getArgument(1);
-  Value colPlus1 = rewriter.create<AddIOp>(loc, col, c1);
+  Value colPlus1 = rewriter.create<arith::AddIOp>(loc, col, c1);
   Value iStart64 = rewriter.create<memref::LoadOp>(loc, iterPointers, col);
   Value iEnd64 = rewriter.create<memref::LoadOp>(loc, iterPointers, colPlus1);
-  Value iStart = rewriter.create<IndexCastOp>(loc, iStart64, indexType);
-  Value iEnd = rewriter.create<IndexCastOp>(loc, iEnd64, indexType);
+  Value iStart = rewriter.create<arith::IndexCastOp>(loc, iStart64, indexType);
+  Value iEnd = rewriter.create<arith::IndexCastOp>(loc, iEnd64, indexType);
 
   // insert add identity block
   rewriter.mergeBlocks(extBlocks.addIdentity, rewriter.getBlock(), {});
@@ -307,7 +308,7 @@ void computeInnerProduct(PatternRewriter &rewriter, Location loc, Value nk,
   rewriter.setInsertionPointToStart(kLoop.getBody());
 
   Value kk64 = rewriter.create<memref::LoadOp>(loc, iterIndices, ii);
-  Value kk = rewriter.create<IndexCastOp>(loc, kk64, indexType);
+  Value kk = rewriter.create<arith::IndexCastOp>(loc, kk64, indexType);
   Value cmpPair = rewriter.create<memref::LoadOp>(loc, kvec_i1, kk);
   scf::IfOp ifBlock_cmpPair = rewriter.create<scf::IfOp>(
       loc, TypeRange{valueType, boolType}, cmpPair, true);
@@ -360,7 +361,7 @@ void computeInnerProduct(PatternRewriter &rewriter, Location loc, Value nk,
   rewriter.setInsertionPointToStart(ifBlock_newOffset.thenBlock());
 
   // Store total in Cx
-  Value cjPos = rewriter.create<AddIOp>(loc, indexOffset, offset);
+  Value cjPos = rewriter.create<arith::AddIOp>(loc, indexOffset, offset);
   rewriter.create<memref::StoreOp>(loc, col64, outputIndices, cjPos);
 
   // Does total need to be transformed?
@@ -378,7 +379,7 @@ void computeInnerProduct(PatternRewriter &rewriter, Location loc, Value nk,
   }
 
   // Increment offset
-  Value offsetPlus1 = rewriter.create<AddIOp>(loc, offset, c1);
+  Value offsetPlus1 = rewriter.create<arith::AddIOp>(loc, offset, c1);
   rewriter.create<scf::YieldOp>(loc, offsetPlus1);
 
   // else
@@ -411,10 +412,10 @@ Value computeIndexOverlapSize(PatternRewriter &rewriter, Location loc,
   Type indexType = rewriter.getIndexType();
 
   // Initial constants
-  Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-  Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
-  Value cfalse = rewriter.create<ConstantIntOp>(loc, 0, boolType);
-  Value ctrue = rewriter.create<ConstantIntOp>(loc, 1, boolType);
+  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+  Value cfalse = rewriter.create<arith::ConstantIntOp>(loc, 0, boolType);
+  Value ctrue = rewriter.create<arith::ConstantIntOp>(loc, 1, boolType);
 
   // While Loop (exit when either array is exhausted)
   scf::WhileOp whileLoop = rewriter.create<scf::WhileOp>(
@@ -434,11 +435,11 @@ Value computeIndexOverlapSize(PatternRewriter &rewriter, Location loc,
   rewriter.setInsertionPointToStart(&whileLoop.before().front());
   Value posA = before->getArgument(0);
   Value posB = before->getArgument(1);
-  Value validPosA =
-      rewriter.create<CmpIOp>(loc, CmpIPredicate::ult, posA, aPosEnd);
-  Value validPosB =
-      rewriter.create<CmpIOp>(loc, CmpIPredicate::ult, posB, bPosEnd);
-  Value continueLoop = rewriter.create<AndOp>(loc, validPosA, validPosB);
+  Value validPosA = rewriter.create<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::ult, posA, aPosEnd);
+  Value validPosB = rewriter.create<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::ult, posB, bPosEnd);
+  Value continueLoop = rewriter.create<arith::AndIOp>(loc, validPosA, validPosB);
   rewriter.create<scf::ConditionOp>(loc, continueLoop, before->getArguments());
 
   // "do" portion of while loop
@@ -458,7 +459,7 @@ Value computeIndexOverlapSize(PatternRewriter &rewriter, Location loc,
   rewriter.setInsertionPointToStart(if_updateA.thenBlock());
   Value updatedIdxA64 = rewriter.create<memref::LoadOp>(loc, Ai, posA);
   Value updatedIdxA =
-      rewriter.create<IndexCastOp>(loc, updatedIdxA64, indexType);
+      rewriter.create<arith::IndexCastOp>(loc, updatedIdxA64, indexType);
   rewriter.create<scf::YieldOp>(loc, updatedIdxA);
   // else
   rewriter.setInsertionPointToStart(if_updateA.elseBlock());
@@ -472,7 +473,7 @@ Value computeIndexOverlapSize(PatternRewriter &rewriter, Location loc,
   rewriter.setInsertionPointToStart(if_updateB.thenBlock());
   Value updatedIdxB64 = rewriter.create<memref::LoadOp>(loc, Bi, posB);
   Value updatedIdxB =
-      rewriter.create<IndexCastOp>(loc, updatedIdxB64, indexType);
+      rewriter.create<arith::IndexCastOp>(loc, updatedIdxB64, indexType);
   rewriter.create<scf::YieldOp>(loc, updatedIdxB);
   // else
   rewriter.setInsertionPointToStart(if_updateB.elseBlock());
@@ -481,14 +482,14 @@ Value computeIndexOverlapSize(PatternRewriter &rewriter, Location loc,
 
   Value newIdxA = if_updateA.getResult(0);
   Value newIdxB = if_updateB.getResult(0);
-  Value idxA_lt_idxB =
-      rewriter.create<CmpIOp>(loc, CmpIPredicate::ult, newIdxA, newIdxB);
-  Value idxA_gt_idxB =
-      rewriter.create<CmpIOp>(loc, CmpIPredicate::ugt, newIdxA, newIdxB);
-  Value posAplus1 = rewriter.create<AddIOp>(loc, posA, c1);
-  Value posBplus1 = rewriter.create<AddIOp>(loc, posB, c1);
+  Value idxA_lt_idxB = rewriter.create<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::ult, newIdxA, newIdxB);
+  Value idxA_gt_idxB = rewriter.create<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::ugt, newIdxA, newIdxB);
+  Value posAplus1 = rewriter.create<arith::AddIOp>(loc, posA, c1);
+  Value posBplus1 = rewriter.create<arith::AddIOp>(loc, posB, c1);
 
-  Value countplus1 = rewriter.create<AddIOp>(loc, count, c1);
+  Value countplus1 = rewriter.create<arith::AddIOp>(loc, count, c1);
   Value countForUnion;
   if (intersect) {
     countForUnion = count;
@@ -538,26 +539,26 @@ Value computeIndexOverlapSize(PatternRewriter &rewriter, Location loc,
     scf::ForOp forLoop;
     count = whileLoop.getResult(6);
     posA = whileLoop.getResult(0);
-    Value remainingPosA =
-        rewriter.create<CmpIOp>(loc, CmpIPredicate::ult, posA, aPosEnd);
+    Value remainingPosA = rewriter.create<arith::CmpIOp>(
+        loc, arith::CmpIPredicate::ult, posA, aPosEnd);
     scf::IfOp if_remainingA =
         rewriter.create<scf::IfOp>(loc, indexType, remainingPosA, true);
     // if remainingA
     rewriter.setInsertionPointToStart(if_remainingA.thenBlock());
-    Value extraIndices = rewriter.create<SubIOp>(loc, aPosEnd, posA);
-    Value newCount = rewriter.create<AddIOp>(loc, count, extraIndices);
+    Value extraIndices = rewriter.create<arith::SubIOp>(loc, aPosEnd, posA);
+    Value newCount = rewriter.create<arith::AddIOp>(loc, count, extraIndices);
     rewriter.create<scf::YieldOp>(loc, newCount);
     // else
     rewriter.setInsertionPointToStart(if_remainingA.elseBlock());
     posB = whileLoop.getResult(1);
-    Value remainingPosB =
-        rewriter.create<CmpIOp>(loc, CmpIPredicate::ult, posB, bPosEnd);
+    Value remainingPosB = rewriter.create<arith::CmpIOp>(
+        loc, arith::CmpIPredicate::ult, posB, bPosEnd);
     scf::IfOp if_remainingB =
         rewriter.create<scf::IfOp>(loc, indexType, remainingPosB, true);
     // if remainingB
     rewriter.setInsertionPointToStart(if_remainingB.thenBlock());
-    extraIndices = rewriter.create<SubIOp>(loc, bPosEnd, posB);
-    newCount = rewriter.create<AddIOp>(loc, count, extraIndices);
+    extraIndices = rewriter.create<arith::SubIOp>(loc, bPosEnd, posB);
+    newCount = rewriter.create<arith::AddIOp>(loc, count, extraIndices);
     rewriter.create<scf::YieldOp>(loc, newCount);
     // else
     rewriter.setInsertionPointToStart(if_remainingB.elseBlock());
@@ -590,18 +591,20 @@ Value computeUnionAggregation(PatternRewriter &rewriter, Location loc,
   Type indexType = rewriter.getIndexType();
 
   // Initial constants
-  Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
-  Value ci0 = rewriter.create<ConstantIntOp>(loc, 0, int64Type);
-  Value cfalse = rewriter.create<ConstantIntOp>(loc, 0, boolType);
-  Value ctrue = rewriter.create<ConstantIntOp>(loc, 1, boolType);
+  Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+  Value ci0 = rewriter.create<arith::ConstantIntOp>(loc, 0, int64Type);
+  Value cfalse = rewriter.create<arith::ConstantIntOp>(loc, 0, boolType);
+  Value ctrue = rewriter.create<arith::ConstantIntOp>(loc, 1, boolType);
   // TODO: change this out for AGG_IDENTITY
   Value cf0 =
       llvm::TypeSwitch<Type, Value>(valueType)
           .Case<IntegerType>([&](IntegerType type) {
-            return rewriter.create<ConstantIntOp>(loc, 0, type.getWidth());
+            return rewriter.create<arith::ConstantIntOp>(loc, 0,
+                                                         type.getWidth());
           })
           .Case<FloatType>([&](FloatType type) {
-            return rewriter.create<ConstantFloatOp>(loc, APFloat(0.0), type);
+            return rewriter.create<arith::ConstantFloatOp>(loc, APFloat(0.0),
+                                                           type);
           });
 
   // While Loop (exit when either array is exhausted)
@@ -623,11 +626,11 @@ Value computeUnionAggregation(PatternRewriter &rewriter, Location loc,
   rewriter.setInsertionPointToStart(&whileLoop.before().front());
   Value posA = before->getArgument(0);
   Value posB = before->getArgument(1);
-  Value validPosA =
-      rewriter.create<CmpIOp>(loc, CmpIPredicate::ult, posA, aPosEnd);
-  Value validPosB =
-      rewriter.create<CmpIOp>(loc, CmpIPredicate::ult, posB, bPosEnd);
-  Value continueLoop = rewriter.create<AndOp>(loc, validPosA, validPosB);
+  Value validPosA = rewriter.create<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::ult, posA, aPosEnd);
+  Value validPosB = rewriter.create<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::ult, posB, bPosEnd);
+  Value continueLoop = rewriter.create<arith::AndIOp>(loc, validPosA, validPosB);
   rewriter.create<scf::ConditionOp>(loc, continueLoop, before->getArguments());
 
   // "do" portion of while loop
@@ -672,14 +675,14 @@ Value computeUnionAggregation(PatternRewriter &rewriter, Location loc,
   Value newValA = if_updateA.getResult(1);
   Value newIdxB = if_updateB.getResult(0);
   Value newValB = if_updateB.getResult(1);
-  Value idxA_lt_idxB =
-      rewriter.create<CmpIOp>(loc, CmpIPredicate::ult, newIdxA, newIdxB);
-  Value idxA_gt_idxB =
-      rewriter.create<CmpIOp>(loc, CmpIPredicate::ugt, newIdxA, newIdxB);
-  Value posAplus1 = rewriter.create<AddIOp>(loc, posA, c1);
-  Value posBplus1 = rewriter.create<AddIOp>(loc, posB, c1);
+  Value idxA_lt_idxB = rewriter.create<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::ult, newIdxA, newIdxB);
+  Value idxA_gt_idxB = rewriter.create<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::ugt, newIdxA, newIdxB);
+  Value posAplus1 = rewriter.create<arith::AddIOp>(loc, posA, c1);
+  Value posBplus1 = rewriter.create<arith::AddIOp>(loc, posB, c1);
 
-  Value posOplus1 = rewriter.create<AddIOp>(loc, posO, c1);
+  Value posOplus1 = rewriter.create<arith::AddIOp>(loc, posO, c1);
   Value posOForUnion;
   if (intersect) {
     posOForUnion = posO;
@@ -720,55 +723,56 @@ Value computeUnionAggregation(PatternRewriter &rewriter, Location loc,
   if (agg == "plus") {
     aggVal = llvm::TypeSwitch<Type, Value>(valueType)
                  .Case<IntegerType>([&](IntegerType type) {
-                   return rewriter.create<AddIOp>(loc, newValA, newValB);
+                   return rewriter.create<arith::AddIOp>(loc, newValA, newValB);
                  })
                  .Case<FloatType>([&](FloatType type) {
-                   return rewriter.create<AddFOp>(loc, newValA, newValB);
+                   return rewriter.create<arith::AddFOp>(loc, newValA, newValB);
                  });
   } else if (agg == "minus") {
     aggVal = llvm::TypeSwitch<Type, Value>(valueType)
                  .Case<IntegerType>([&](IntegerType type) {
-                   return rewriter.create<SubIOp>(loc, newValA, newValB);
+                   return rewriter.create<arith::SubIOp>(loc, newValA, newValB);
                  })
                  .Case<FloatType>([&](FloatType type) {
-                   return rewriter.create<SubFOp>(loc, newValA, newValB);
+                   return rewriter.create<arith::SubFOp>(loc, newValA, newValB);
                  });
   } else if (agg == "times") {
     aggVal = llvm::TypeSwitch<Type, Value>(valueType)
                  .Case<IntegerType>([&](IntegerType type) {
-                   return rewriter.create<MulIOp>(loc, newValA, newValB);
+                   return rewriter.create<arith::MulIOp>(loc, newValA, newValB);
                  })
                  .Case<FloatType>([&](FloatType type) {
-                   return rewriter.create<MulFOp>(loc, newValA, newValB);
+                   return rewriter.create<arith::MulFOp>(loc, newValA, newValB);
                  });
   } else if (agg == "div") {
     aggVal = llvm::TypeSwitch<Type, Value>(valueType)
                  .Case<IntegerType>([&](IntegerType type) {
-                   return rewriter.create<SignedDivIOp>(loc, newValA, newValB);
+                   return rewriter.create<arith::DivSIOp>(loc, newValA,
+                                                               newValB);
                  })
                  .Case<FloatType>([&](FloatType type) {
-                   return rewriter.create<DivFOp>(loc, newValA, newValB);
+                   return rewriter.create<arith::DivFOp>(loc, newValA, newValB);
                  });
   } else if (agg == "min") {
     Value cmp = llvm::TypeSwitch<Type, Value>(valueType)
                     .Case<IntegerType>([&](IntegerType type) {
-                      return rewriter.create<CmpIOp>(loc, CmpIPredicate::slt,
-                                                     newValA, newValB);
+                      return rewriter.create<arith::CmpIOp>(
+                          loc, arith::CmpIPredicate::slt, newValA, newValB);
                     })
                     .Case<FloatType>([&](FloatType type) {
-                      return rewriter.create<CmpFOp>(loc, CmpFPredicate::OLT,
-                                                     newValA, newValB);
+                      return rewriter.create<arith::CmpFOp>(
+                          loc, arith::CmpFPredicate::OLT, newValA, newValB);
                     });
     aggVal = rewriter.create<SelectOp>(loc, cmp, newValA, newValB);
   } else if (agg == "max") {
     Value cmp = llvm::TypeSwitch<Type, Value>(valueType)
                     .Case<IntegerType>([&](IntegerType type) {
-                      return rewriter.create<CmpIOp>(loc, CmpIPredicate::sgt,
-                                                     newValA, newValB);
+                      return rewriter.create<arith::CmpIOp>(
+                          loc, arith::CmpIPredicate::sgt, newValA, newValB);
                     })
                     .Case<FloatType>([&](FloatType type) {
-                      return rewriter.create<CmpFOp>(loc, CmpFPredicate::OGT,
-                                                     newValA, newValB);
+                      return rewriter.create<arith::CmpFOp>(
+                          loc, arith::CmpFPredicate::OGT, newValA, newValB);
                     });
     aggVal = rewriter.create<SelectOp>(loc, cmp, newValA, newValB);
   } else if (agg == "first") {
@@ -778,62 +782,62 @@ Value computeUnionAggregation(PatternRewriter &rewriter, Location loc,
   } else if (agg == "eq") {
     aggVal = llvm::TypeSwitch<Type, Value>(valueType)
                  .Case<IntegerType>([&](IntegerType type) {
-                   return rewriter.create<CmpIOp>(loc, CmpIPredicate::eq,
-                                                  newValA, newValB);
+                   return rewriter.create<arith::CmpIOp>(
+                       loc, arith::CmpIPredicate::eq, newValA, newValB);
                  })
                  .Case<FloatType>([&](FloatType type) {
-                   return rewriter.create<CmpFOp>(loc, CmpFPredicate::OEQ,
-                                                  newValA, newValB);
+                   return rewriter.create<arith::CmpFOp>(
+                       loc, arith::CmpFPredicate::OEQ, newValA, newValB);
                  });
   } else if (agg == "ne") {
     aggVal = llvm::TypeSwitch<Type, Value>(valueType)
                  .Case<IntegerType>([&](IntegerType type) {
-                   return rewriter.create<CmpIOp>(loc, CmpIPredicate::ne,
-                                                  newValA, newValB);
+                   return rewriter.create<arith::CmpIOp>(
+                       loc, arith::CmpIPredicate::ne, newValA, newValB);
                  })
                  .Case<FloatType>([&](FloatType type) {
-                   return rewriter.create<CmpFOp>(loc, CmpFPredicate::ONE,
-                                                  newValA, newValB);
+                   return rewriter.create<arith::CmpFOp>(
+                       loc, arith::CmpFPredicate::ONE, newValA, newValB);
                  });
   } else if (agg == "lt") {
     aggVal = llvm::TypeSwitch<Type, Value>(valueType)
                  .Case<IntegerType>([&](IntegerType type) {
-                   return rewriter.create<CmpIOp>(loc, CmpIPredicate::slt,
-                                                  newValA, newValB);
+                   return rewriter.create<arith::CmpIOp>(
+                       loc, arith::CmpIPredicate::slt, newValA, newValB);
                  })
                  .Case<FloatType>([&](FloatType type) {
-                   return rewriter.create<CmpFOp>(loc, CmpFPredicate::OLT,
-                                                  newValA, newValB);
+                   return rewriter.create<arith::CmpFOp>(
+                       loc, arith::CmpFPredicate::OLT, newValA, newValB);
                  });
   } else if (agg == "le") {
     aggVal = llvm::TypeSwitch<Type, Value>(valueType)
                  .Case<IntegerType>([&](IntegerType type) {
-                   return rewriter.create<CmpIOp>(loc, CmpIPredicate::sle,
-                                                  newValA, newValB);
+                   return rewriter.create<arith::CmpIOp>(
+                       loc, arith::CmpIPredicate::sle, newValA, newValB);
                  })
                  .Case<FloatType>([&](FloatType type) {
-                   return rewriter.create<CmpFOp>(loc, CmpFPredicate::OLE,
-                                                  newValA, newValB);
+                   return rewriter.create<arith::CmpFOp>(
+                       loc, arith::CmpFPredicate::OLE, newValA, newValB);
                  });
   } else if (agg == "gt") {
     aggVal = llvm::TypeSwitch<Type, Value>(valueType)
                  .Case<IntegerType>([&](IntegerType type) {
-                   return rewriter.create<CmpIOp>(loc, CmpIPredicate::sgt,
-                                                  newValA, newValB);
+                   return rewriter.create<arith::CmpIOp>(
+                       loc, arith::CmpIPredicate::sgt, newValA, newValB);
                  })
                  .Case<FloatType>([&](FloatType type) {
-                   return rewriter.create<CmpFOp>(loc, CmpFPredicate::OGT,
-                                                  newValA, newValB);
+                   return rewriter.create<arith::CmpFOp>(
+                       loc, arith::CmpFPredicate::OGT, newValA, newValB);
                  });
   } else if (agg == "ge") {
     aggVal = llvm::TypeSwitch<Type, Value>(valueType)
                  .Case<IntegerType>([&](IntegerType type) {
-                   return rewriter.create<CmpIOp>(loc, CmpIPredicate::sge,
-                                                  newValA, newValB);
+                   return rewriter.create<arith::CmpIOp>(
+                       loc, arith::CmpIPredicate::sge, newValA, newValB);
                  })
                  .Case<FloatType>([&](FloatType type) {
-                   return rewriter.create<CmpFOp>(loc, CmpFPredicate::OGE,
-                                                  newValA, newValB);
+                   return rewriter.create<arith::CmpFOp>(
+                       loc, arith::CmpFPredicate::OGE, newValA, newValB);
                  });
   }
 
@@ -862,8 +866,8 @@ Value computeUnionAggregation(PatternRewriter &rewriter, Location loc,
     scf::ForOp forLoop;
     posO = whileLoop.getResult(2);
     posA = whileLoop.getResult(0);
-    Value remainingPosA =
-        rewriter.create<CmpIOp>(loc, CmpIPredicate::ult, posA, aPosEnd);
+    Value remainingPosA = rewriter.create<arith::CmpIOp>(
+        loc, arith::CmpIPredicate::ult, posA, aPosEnd);
     scf::IfOp if_remainingA =
         rewriter.create<scf::IfOp>(loc, indexType, remainingPosA, true);
     // if remainingA
@@ -876,15 +880,15 @@ Value computeUnionAggregation(PatternRewriter &rewriter, Location loc,
     valA = rewriter.create<memref::LoadOp>(loc, Ax, aa);
     rewriter.create<memref::StoreOp>(loc, idxA, Oi, currPosO);
     rewriter.create<memref::StoreOp>(loc, valA, Ox, currPosO);
-    Value newPosO = rewriter.create<AddIOp>(loc, currPosO, c1);
+    Value newPosO = rewriter.create<arith::AddIOp>(loc, currPosO, c1);
     rewriter.create<scf::YieldOp>(loc, newPosO);
     rewriter.setInsertionPointAfter(forLoop);
     rewriter.create<scf::YieldOp>(loc, forLoop.getResult(0));
     // else
     rewriter.setInsertionPointToStart(if_remainingA.elseBlock());
     posB = whileLoop.getResult(1);
-    Value remainingPosB =
-        rewriter.create<CmpIOp>(loc, CmpIPredicate::ult, posB, bPosEnd);
+    Value remainingPosB = rewriter.create<arith::CmpIOp>(
+        loc, arith::CmpIPredicate::ult, posB, bPosEnd);
     scf::IfOp if_remainingB =
         rewriter.create<scf::IfOp>(loc, indexType, remainingPosB, true);
     // if remainingB
@@ -897,7 +901,7 @@ Value computeUnionAggregation(PatternRewriter &rewriter, Location loc,
     valB = rewriter.create<memref::LoadOp>(loc, Bx, bb);
     rewriter.create<memref::StoreOp>(loc, idxB, Oi, currPosO);
     rewriter.create<memref::StoreOp>(loc, valB, Ox, currPosO);
-    newPosO = rewriter.create<AddIOp>(loc, currPosO, c1);
+    newPosO = rewriter.create<arith::AddIOp>(loc, currPosO, c1);
     rewriter.create<scf::YieldOp>(loc, newPosO);
     rewriter.setInsertionPointAfter(forLoop);
     rewriter.create<scf::YieldOp>(loc, forLoop.getResult(0));
@@ -928,8 +932,8 @@ void computeVectorElementWise(PatternRewriter &rewriter, Location loc,
   MemRefType memref1DValueType = MemRefType::get({-1}, valueType);
 
   // Initial constants
-  Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-  Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
+  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
 
   // Get sparse tensor info
   Value lhsNnz = rewriter.create<graphblas::NumValsOp>(loc, lhs);
@@ -945,7 +949,8 @@ void computeVectorElementWise(PatternRewriter &rewriter, Location loc,
 
   Value ewiseSize = computeIndexOverlapSize(rewriter, loc, intersect, c0,
                                             lhsNnz, Li, c0, rhsNnz, Ri);
-  Value ewiseSize64 = rewriter.create<IndexCastOp>(loc, ewiseSize, int64Type);
+  Value ewiseSize64 =
+      rewriter.create<arith::IndexCastOp>(loc, ewiseSize, int64Type);
 
   callResizeIndex(rewriter, module, loc, output, c0, ewiseSize);
   callResizeValues(rewriter, module, loc, output, ewiseSize);
@@ -974,9 +979,9 @@ void computeMatrixElementWise(PatternRewriter &rewriter, Location loc,
   MemRefType memref1DValueType = MemRefType::get({-1}, valueType);
 
   // Initial constants
-  Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-  Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
-  Value ci0 = rewriter.create<ConstantIntOp>(loc, 0, int64Type);
+  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+  Value ci0 = rewriter.create<arith::ConstantIntOp>(loc, 0, int64Type);
 
   Value nrows = rewriter.create<graphblas::NumRowsOp>(loc, output);
 
@@ -1004,20 +1009,20 @@ void computeMatrixElementWise(PatternRewriter &rewriter, Location loc,
   Value row = rowLoop1.getInductionVars()[0];
   rewriter.setInsertionPointToStart(rowLoop1.getBody());
 
-  Value rowPlus1 = rewriter.create<AddIOp>(loc, row, c1);
+  Value rowPlus1 = rewriter.create<arith::AddIOp>(loc, row, c1);
   Value lhsColStart64 = rewriter.create<memref::LoadOp>(loc, Lp, row);
   Value lhsColEnd64 = rewriter.create<memref::LoadOp>(loc, Lp, rowPlus1);
   Value rhsColStart64 = rewriter.create<memref::LoadOp>(loc, Rp, row);
   Value rhsColEnd64 = rewriter.create<memref::LoadOp>(loc, Rp, rowPlus1);
-  Value LcmpColSame = rewriter.create<CmpIOp>(loc, CmpIPredicate::eq,
-                                              lhsColStart64, lhsColEnd64);
-  Value RcmpColSame = rewriter.create<CmpIOp>(loc, CmpIPredicate::eq,
-                                              rhsColStart64, rhsColEnd64);
+  Value LcmpColSame = rewriter.create<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::eq, lhsColStart64, lhsColEnd64);
+  Value RcmpColSame = rewriter.create<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::eq, rhsColStart64, rhsColEnd64);
   Value emptyRow;
   if (intersect) {
-    emptyRow = rewriter.create<OrOp>(loc, LcmpColSame, RcmpColSame);
+    emptyRow = rewriter.create<arith::OrIOp>(loc, LcmpColSame, RcmpColSame);
   } else {
-    emptyRow = rewriter.create<AndOp>(loc, LcmpColSame, RcmpColSame);
+    emptyRow = rewriter.create<arith::AndIOp>(loc, LcmpColSame, RcmpColSame);
   }
 
   scf::IfOp ifBlock_rowTotal =
@@ -1029,15 +1034,18 @@ void computeMatrixElementWise(PatternRewriter &rewriter, Location loc,
   // else
   rewriter.setInsertionPointToStart(ifBlock_rowTotal.elseBlock());
   Value lhsColStart =
-      rewriter.create<IndexCastOp>(loc, lhsColStart64, indexType);
-  Value lhsColEnd = rewriter.create<IndexCastOp>(loc, lhsColEnd64, indexType);
+      rewriter.create<arith::IndexCastOp>(loc, lhsColStart64, indexType);
+  Value lhsColEnd =
+      rewriter.create<arith::IndexCastOp>(loc, lhsColEnd64, indexType);
   Value rhsColStart =
-      rewriter.create<IndexCastOp>(loc, rhsColStart64, indexType);
-  Value rhsColEnd = rewriter.create<IndexCastOp>(loc, rhsColEnd64, indexType);
+      rewriter.create<arith::IndexCastOp>(loc, rhsColStart64, indexType);
+  Value rhsColEnd =
+      rewriter.create<arith::IndexCastOp>(loc, rhsColEnd64, indexType);
   Value unionSize =
       computeIndexOverlapSize(rewriter, loc, intersect, lhsColStart, lhsColEnd,
                               Li, rhsColStart, rhsColEnd, Ri);
-  Value unionSize64 = rewriter.create<IndexCastOp>(loc, unionSize, int64Type);
+  Value unionSize64 =
+      rewriter.create<arith::IndexCastOp>(loc, unionSize, int64Type);
   rewriter.create<scf::YieldOp>(loc, unionSize64);
 
   // end if cmpColSame
@@ -1059,7 +1067,7 @@ void computeMatrixElementWise(PatternRewriter &rewriter, Location loc,
   Value csTemp = rewriter.create<memref::LoadOp>(loc, Op, cs_i);
   Value cumsum = rewriter.create<memref::LoadOp>(loc, Op, nrows);
   rewriter.create<memref::StoreOp>(loc, cumsum, Op, cs_i);
-  Value cumsum2 = rewriter.create<AddIOp>(loc, cumsum, csTemp);
+  Value cumsum2 = rewriter.create<arith::AddIOp>(loc, cumsum, csTemp);
   rewriter.create<memref::StoreOp>(loc, cumsum2, Op, nrows);
 
   // end row loop
@@ -1082,25 +1090,28 @@ void computeMatrixElementWise(PatternRewriter &rewriter, Location loc,
   row = rowLoop3.getInductionVars()[0];
   rewriter.setInsertionPointToStart(rowLoop3.getBody());
 
-  rowPlus1 = rewriter.create<AddIOp>(loc, row, c1);
+  rowPlus1 = rewriter.create<arith::AddIOp>(loc, row, c1);
   Value opStart64 = rewriter.create<memref::LoadOp>(loc, Op, row);
   Value opEnd64 = rewriter.create<memref::LoadOp>(loc, Op, rowPlus1);
-  Value cmp_opDifferent =
-      rewriter.create<CmpIOp>(loc, CmpIPredicate::ne, opStart64, opEnd64);
+  Value cmp_opDifferent = rewriter.create<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::ne, opStart64, opEnd64);
   scf::IfOp ifBlock_cmpDiff = rewriter.create<scf::IfOp>(loc, cmp_opDifferent);
   rewriter.setInsertionPointToStart(ifBlock_cmpDiff.thenBlock());
 
   Value OcolStart64 = rewriter.create<memref::LoadOp>(loc, Op, row);
-  Value OcolStart = rewriter.create<IndexCastOp>(loc, OcolStart64, indexType);
+  Value OcolStart =
+      rewriter.create<arith::IndexCastOp>(loc, OcolStart64, indexType);
 
   lhsColStart64 = rewriter.create<memref::LoadOp>(loc, Lp, row);
   lhsColEnd64 = rewriter.create<memref::LoadOp>(loc, Lp, rowPlus1);
-  lhsColStart = rewriter.create<IndexCastOp>(loc, lhsColStart64, indexType);
-  lhsColEnd = rewriter.create<IndexCastOp>(loc, lhsColEnd64, indexType);
+  lhsColStart =
+      rewriter.create<arith::IndexCastOp>(loc, lhsColStart64, indexType);
+  lhsColEnd = rewriter.create<arith::IndexCastOp>(loc, lhsColEnd64, indexType);
   rhsColStart64 = rewriter.create<memref::LoadOp>(loc, Rp, row);
   rhsColEnd64 = rewriter.create<memref::LoadOp>(loc, Rp, rowPlus1);
-  rhsColStart = rewriter.create<IndexCastOp>(loc, rhsColStart64, indexType);
-  rhsColEnd = rewriter.create<IndexCastOp>(loc, rhsColEnd64, indexType);
+  rhsColStart =
+      rewriter.create<arith::IndexCastOp>(loc, rhsColStart64, indexType);
+  rhsColEnd = rewriter.create<arith::IndexCastOp>(loc, rhsColEnd64, indexType);
 
   computeUnionAggregation(rewriter, loc, intersect, op, valueType, lhsColStart,
                           lhsColEnd, Li, Lx, rhsColStart, rhsColEnd, Ri, Rx,

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASLowerPass.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASLowerPass.cpp
@@ -450,18 +450,18 @@ struct MatrixSelectOutputWriter {
     Value keep;
     if (selector == "triu") {
       keep = rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ugt,
-                                           colWise ? row : col,
-                                           colWise ? col : row);
+                                            colWise ? row : col,
+                                            colWise ? col : row);
     } else if (selector == "tril") {
       keep = rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ult,
-                                           colWise ? row : col,
-                                           colWise ? col : row);
+                                            colWise ? row : col,
+                                            colWise ? col : row);
     } else if (selector == "gt") {
       keep = rewriter.create<arith::CmpFOp>(loc, arith::CmpFPredicate::OGT, val,
-                                           thunk.getValue());
+                                            thunk.getValue());
     } else if (selector == "ge") {
       keep = rewriter.create<arith::CmpFOp>(loc, arith::CmpFPredicate::OGE, val,
-                                           thunk.getValue());
+                                            thunk.getValue());
     } else {
       // this should be impossible because of validation
       assert(0);
@@ -836,10 +836,11 @@ public:
                     .Case<IntegerType>([&](IntegerType type) {
                       Value ans;
                       if (type.getWidth() < 64)
-                        ans = rewriter.create<arith::TruncIOp>(loc, type, ptrDiff);
+                        ans = rewriter.create<arith::TruncIOp>(loc, type,
+                                                               ptrDiff);
                       else
-                        ans = rewriter.create<arith::ExtSIOp>(loc, type,
-                                                                    ptrDiff);
+                        ans =
+                            rewriter.create<arith::ExtSIOp>(loc, type, ptrDiff);
                       return ans;
                     })
                     .Case<FloatType>([&](FloatType type) {
@@ -906,23 +907,22 @@ public:
                   loc, matrixValues, currentPtr);
 
               bool useMinimum = aggregator == "argmin";
-              Value mustUpdate = llvm::TypeSwitch<Type, Value>(elementType)
-                                     .Case<IntegerType>([&](IntegerType type) {
-                                       return rewriter.create<arith::CmpIOp>(
-                                           loc,
-                                           useMinimum
-                                               ? arith::CmpIPredicate::slt
-                                               : arith::CmpIPredicate::sgt,
-                                           rowValue, currentExtremum);
-                                     })
-                                     .Case<FloatType>([&](FloatType type) {
-                                       return rewriter.create<arith::CmpFOp>(
-                                           loc,
-                                           useMinimum
-                                               ? arith::CmpFPredicate::OLT
-                                               : arith::CmpFPredicate::OGT,
-                                           rowValue, currentExtremum);
-                                     });
+              Value mustUpdate =
+                  llvm::TypeSwitch<Type, Value>(elementType)
+                      .Case<IntegerType>([&](IntegerType type) {
+                        return rewriter.create<arith::CmpIOp>(
+                            loc,
+                            useMinimum ? arith::CmpIPredicate::slt
+                                       : arith::CmpIPredicate::sgt,
+                            rowValue, currentExtremum);
+                      })
+                      .Case<FloatType>([&](FloatType type) {
+                        return rewriter.create<arith::CmpFOp>(
+                            loc,
+                            useMinimum ? arith::CmpFPredicate::OLT
+                                       : arith::CmpFPredicate::OGT,
+                            rowValue, currentExtremum);
+                      });
 
               scf::IfOp ifMustUpdateBlock = rewriter.create<scf::IfOp>(
                   loc, TypeRange{elementType, int64Type}, mustUpdate, true);
@@ -1115,22 +1115,21 @@ private:
     Value currentValue =
         rewriter.create<memref::LoadOp>(loc, values, currentValuePosition);
     bool useMinimum = aggregator == "argmin";
-    Value replace =
-        llvm::TypeSwitch<Type, Value>(inputElementType)
-            .Case<IntegerType>([&](IntegerType type) {
-              return rewriter.create<arith::CmpIOp>(
-                  loc,
-                  useMinimum ? arith::CmpIPredicate::slt
-                             : arith::CmpIPredicate::sgt,
-                  currentValue, currentExtremum);
-            })
-            .Case<FloatType>([&](FloatType type) {
-              return rewriter.create<arith::CmpFOp>(
-                  loc,
-                  useMinimum ? arith::CmpFPredicate::OLT
-                             : arith::CmpFPredicate::OGT,
-                  currentValue, currentExtremum);
-            });
+    Value replace = llvm::TypeSwitch<Type, Value>(inputElementType)
+                        .Case<IntegerType>([&](IntegerType type) {
+                          return rewriter.create<arith::CmpIOp>(
+                              loc,
+                              useMinimum ? arith::CmpIPredicate::slt
+                                         : arith::CmpIPredicate::sgt,
+                              currentValue, currentExtremum);
+                        })
+                        .Case<FloatType>([&](FloatType type) {
+                          return rewriter.create<arith::CmpFOp>(
+                              loc,
+                              useMinimum ? arith::CmpFPredicate::OLT
+                                         : arith::CmpFPredicate::OGT,
+                              currentValue, currentExtremum);
+                        });
 
     scf::IfOp ifBlock = rewriter.create<scf::IfOp>(
         loc, TypeRange{inputElementType, indexType}, replace, true);
@@ -1178,16 +1177,15 @@ private:
       /*Block *aggIdentityBlock = */ rewriter.createBlock(&aggIdentityRegion,
                                                           {}, {});
 
-      Value aggIdentity =
-          llvm::TypeSwitch<Type, Value>(valueType)
-              .Case<IntegerType>([&](IntegerType type) {
-                return rewriter.create<arith::ConstantIntOp>(loc, 0,
-                                                             type.getWidth());
-              })
-              .Case<FloatType>([&](FloatType type) {
-                return rewriter.create<arith::ConstantFloatOp>(loc, APFloat(0.0),
-                                                        type);
-              });
+      Value aggIdentity = llvm::TypeSwitch<Type, Value>(valueType)
+                              .Case<IntegerType>([&](IntegerType type) {
+                                return rewriter.create<arith::ConstantIntOp>(
+                                    loc, 0, type.getWidth());
+                              })
+                              .Case<FloatType>([&](FloatType type) {
+                                return rewriter.create<arith::ConstantFloatOp>(
+                                    loc, APFloat(0.0), type);
+                              });
       rewriter.create<graphblas::YieldOp>(
           loc, graphblas::YieldKind::AGG_IDENTITY, aggIdentity);
 
@@ -1390,15 +1388,16 @@ public:
                     loc, rewriter.getIntegerAttr(type, bitWidth - 1));
                 Value mask =
                     rewriter.create<arith::ShRSIOp>(loc, val, shiftAmount);
-                Value maskPlusVal = rewriter.create<arith::AddIOp>(loc, mask, val);
+                Value maskPlusVal =
+                    rewriter.create<arith::AddIOp>(loc, mask, val);
                 Value absVal =
                     rewriter.create<arith::XOrIOp>(loc, mask, maskPlusVal);
                 Value c1_type = rewriter.create<arith::ConstantOp>(
                     loc, rewriter.getIntegerAttr(type, 1));
                 Value absValIsOne_i1 = rewriter.create<arith::CmpIOp>(
                     loc, arith::CmpIPredicate::eq, absVal, c1_type);
-                Value absValIsOne_type = rewriter.create<arith::ExtSIOp>(
-                    loc, type, absValIsOne_i1);
+                Value absValIsOne_type =
+                    rewriter.create<arith::ExtSIOp>(loc, type, absValIsOne_i1);
                 Value multipicativeInverse =
                     rewriter.create<arith::AndIOp>(loc, absValIsOne_type, val);
                 return multipicativeInverse;
@@ -1415,19 +1414,20 @@ public:
 
     } else if (apply_operator == "ainv") {
 
-      transformResult = llvm::TypeSwitch<Type, Value>(valueType)
-                            .Case<IntegerType>([&](IntegerType type) {
-                              Value c0_type = rewriter.create<ConstantOp>(
-                                  loc, rewriter.getIntegerAttr(type, 0));
-                              Value additiveInverse =
-                                  rewriter.create<arith::SubIOp>(loc, c0_type, val);
-                              return additiveInverse;
-                            })
-                            .Case<FloatType>([&](FloatType type) {
-                              Value additiveInverse =
-                                  rewriter.create<arith::NegFOp>(loc, val);
-                              return additiveInverse;
-                            });
+      transformResult =
+          llvm::TypeSwitch<Type, Value>(valueType)
+              .Case<IntegerType>([&](IntegerType type) {
+                Value c0_type = rewriter.create<ConstantOp>(
+                    loc, rewriter.getIntegerAttr(type, 0));
+                Value additiveInverse =
+                    rewriter.create<arith::SubIOp>(loc, c0_type, val);
+                return additiveInverse;
+              })
+              .Case<FloatType>([&](FloatType type) {
+                Value additiveInverse =
+                    rewriter.create<arith::NegFOp>(loc, val);
+                return additiveInverse;
+              });
 
     } else if (apply_operator == "abs") {
 
@@ -1438,11 +1438,12 @@ public:
                 unsigned bitWidth = type.getWidth();
                 Value shiftAmount = rewriter.create<ConstantOp>(
                     loc, rewriter.getIntegerAttr(type, bitWidth - 1));
-                Value mask = rewriter.create<arith::ShRSIOp>(
-                    loc, val, shiftAmount);
+                Value mask =
+                    rewriter.create<arith::ShRSIOp>(loc, val, shiftAmount);
                 Value maskPlusVal =
                     rewriter.create<arith::AddIOp>(loc, mask, val);
-                Value absVal = rewriter.create<arith::XOrIOp>(loc, mask, maskPlusVal);
+                Value absVal =
+                    rewriter.create<arith::XOrIOp>(loc, mask, maskPlusVal);
                 return absVal;
               })
               .Case<FloatType>([&](FloatType type) {
@@ -1691,8 +1692,8 @@ private:
     Value colStart64 = rewriter.create<memref::LoadOp>(loc, Ap, row);
     Value rowPlus1 = rewriter.create<arith::AddIOp>(loc, row, c1);
     Value colEnd64 = rewriter.create<memref::LoadOp>(loc, Ap, rowPlus1);
-    Value cmpColSame = rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
-                                                      colStart64, colEnd64);
+    Value cmpColSame = rewriter.create<arith::CmpIOp>(
+        loc, arith::CmpIPredicate::eq, colStart64, colEnd64);
 
     scf::IfOp ifBlock_rowTotal =
         rewriter.create<scf::IfOp>(loc, int64Type, cmpColSame, true);
@@ -2271,15 +2272,15 @@ public:
     Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
     Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
     // TODO: make cf0 value dependent on the aggregator
-    Value cf0 =
-        llvm::TypeSwitch<Type, Value>(valueType)
-            .Case<IntegerType>([&](IntegerType type) {
-              return rewriter.create<arith::ConstantIntOp>(loc, 0,
-                                                           type.getWidth());
-            })
-            .Case<FloatType>([&](FloatType type) {
-              return rewriter.create<arith::ConstantFloatOp>(loc, APFloat(0.0), type);
-            });
+    Value cf0 = llvm::TypeSwitch<Type, Value>(valueType)
+                    .Case<IntegerType>([&](IntegerType type) {
+                      return rewriter.create<arith::ConstantIntOp>(
+                          loc, 0, type.getWidth());
+                    })
+                    .Case<FloatType>([&](FloatType type) {
+                      return rewriter.create<arith::ConstantFloatOp>(
+                          loc, APFloat(0.0), type);
+                    });
     Value ctrue = rewriter.create<arith::ConstantIntOp>(loc, 1, boolType);
     Value cfalse = rewriter.create<arith::ConstantIntOp>(loc, 0, boolType);
 
@@ -2717,7 +2718,8 @@ public:
     Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
     Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
     Value cfalse = rewriter.create<arith::ConstantIntOp>(loc, 0, boolType);
-    Value c1_reduce = rewriter.create<arith::ConstantIntOp>(loc, 1, intReduceType);
+    Value c1_reduce =
+        rewriter.create<arith::ConstantIntOp>(loc, 1, intReduceType);
 
     unsigned rank = aType.getRank(); // ranks guaranteed to be equal
 
@@ -2730,8 +2732,8 @@ public:
       Value bNrows = rewriter.create<graphblas::NumRowsOp>(loc, B);
       Value aNcols = rewriter.create<graphblas::NumColsOp>(loc, A);
       Value bNcols = rewriter.create<graphblas::NumColsOp>(loc, B);
-      Value cmpNrows = rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
-                                                      aNrows, bNrows);
+      Value cmpNrows = rewriter.create<arith::CmpIOp>(
+          loc, arith::CmpIPredicate::eq, aNrows, bNrows);
       Value cmpNcols = rewriter.create<arith::CmpIOp>(
           loc, arith::CmpIPredicate::eq, aNcols, bNcols);
       cmpShape = rewriter.create<arith::AndIOp>(loc, cmpNrows, cmpNcols);
@@ -2741,8 +2743,8 @@ public:
       // Check size
       Value aSize = rewriter.create<graphblas::SizeOp>(loc, A);
       Value bSize = rewriter.create<graphblas::SizeOp>(loc, B);
-      cmpShape =
-          rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, aSize, bSize);
+      cmpShape = rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
+                                                aSize, bSize);
     }
 
     scf::IfOp ifOuter =
@@ -2753,8 +2755,8 @@ public:
     // Check number of non-zeros
     Value aNnz = rewriter.create<graphblas::NumValsOp>(loc, A);
     Value bNnz = rewriter.create<graphblas::NumValsOp>(loc, B);
-    Value cmpNnz =
-        rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, aNnz, bNnz);
+    Value cmpNnz = rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
+                                                  aNnz, bNnz);
     scf::IfOp ifNnz = rewriter.create<scf::IfOp>(loc, boolType, cmpNnz, true);
     // if cmpNnz
     rewriter.setInsertionPointToStart(ifNnz.thenBlock());
@@ -2804,8 +2806,8 @@ public:
     rewriter.create<scf::ReduceReturnOp>(loc, cmpFinal);
 
     rewriter.setInsertionPointAfter(indexLoop);
-    Value boolResult = rewriter.create<arith::TruncIOp>(
-        loc, indexLoop.getResult(0), boolType);
+    Value boolResult =
+        rewriter.create<arith::TruncIOp>(loc, indexLoop.getResult(0), boolType);
     rewriter.create<scf::YieldOp>(loc, boolResult);
 
     // else cmpNnz
@@ -2941,7 +2943,8 @@ private:
           loc, TypeRange{int64Type, indexType, int64Type}, mustUpdate, true);
       {
         rewriter.setInsertionPointToStart(ifMustUpdateBlock.thenBlock());
-        Value nextPtr_i64 = rewriter.create<arith::AddIOp>(loc, ptr_i64, c1_i64);
+        Value nextPtr_i64 =
+            rewriter.create<arith::AddIOp>(loc, ptr_i64, c1_i64);
         Value nextVectorIndicesPosition =
             rewriter.create<arith::AddIOp>(loc, vectorIndicesPosition, c1);
         Value nextUpdatedVectorIndicesValue = rewriter.create<memref::LoadOp>(
@@ -3088,8 +3091,8 @@ private:
             findDiagonalWhileLoopBefore->getArgument(1);
         Value morePtrs = rewriter.create<arith::CmpIOp>(
             op.getLoc(), arith::CmpIPredicate::ult, ptr, secondPtr);
-        Value continueCondition =
-            rewriter.create<arith::AndIOp>(loc, diagonalPositionNotFound, morePtrs);
+        Value continueCondition = rewriter.create<arith::AndIOp>(
+            loc, diagonalPositionNotFound, morePtrs);
         rewriter.create<scf::ConditionOp>(
             loc, continueCondition, ValueRange{ptr, diagonalPositionNotFound});
       }
@@ -3201,8 +3204,8 @@ private:
             &findDiagonalWhileLoop.before().front());
         Value morePtrs = rewriter.create<arith::CmpIOp>(
             op.getLoc(), arith::CmpIPredicate::ult, ptr, secondPtr);
-        Value continueCondition =
-            rewriter.create<arith::AndIOp>(loc, diagonalPositionNotFound, morePtrs);
+        Value continueCondition = rewriter.create<arith::AndIOp>(
+            loc, diagonalPositionNotFound, morePtrs);
         rewriter.create<scf::ConditionOp>(
             loc, continueCondition,
             ValueRange{ptr, diagonalPositionNotFound, currentDiagonalValue});
@@ -3215,9 +3218,9 @@ private:
             findDiagonalWhileLoopAfter->getArgument(2);
         Value elementColumnIndex_i64 =
             rewriter.create<memref::LoadOp>(loc, matrixIndices, currentPtr);
-        Value isNotDiagonalPosition =
-            rewriter.create<arith::CmpIOp>(op.getLoc(), arith::CmpIPredicate::ne,
-                                    elementColumnIndex_i64, rowIndex_i64);
+        Value isNotDiagonalPosition = rewriter.create<arith::CmpIOp>(
+            op.getLoc(), arith::CmpIPredicate::ne, elementColumnIndex_i64,
+            rowIndex_i64);
 
         scf::IfOp ifDiagonalNotFoundBlock = rewriter.create<scf::IfOp>(
             loc, TypeRange{valueType}, isNotDiagonalPosition, true);
@@ -3416,8 +3419,8 @@ public:
     Aj_size_64 = rewriter.create<arith::IndexCastOp>(loc, Aj_size, int64Type);
     Value Bj_size = rewriter.create<arith::SubIOp>(loc, Bj_end, Bj_start);
     Bj_size_64 = rewriter.create<arith::IndexCastOp>(loc, Bj_size, int64Type);
-    Value copyRow = rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
-                                                  Aj_size, Bj_size);
+    Value copyRow = rewriter.create<arith::CmpIOp>(
+        loc, arith::CmpIPredicate::eq, Aj_size, Bj_size);
 
     // Create output subviews
     Value Bj_view =

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASLowerPass.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASLowerPass.cpp
@@ -40,7 +40,7 @@ public:
                                 PatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
 
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
     Value inputTensor = op.input();
     Value size = rewriter.create<tensor::DimOp>(loc, inputTensor, c0);
 
@@ -56,7 +56,7 @@ public:
                                 PatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
 
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
     Value inputTensor = op.input();
     Value nrows = rewriter.create<tensor::DimOp>(loc, inputTensor, c0);
 
@@ -72,7 +72,7 @@ public:
                                 PatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
 
-    Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
+    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
     Value inputTensor = op.input();
     Value ncols = rewriter.create<tensor::DimOp>(loc, inputTensor, c1);
 
@@ -99,20 +99,21 @@ public:
     // Access the pointers
     Type memref1DPointerType = MemRefType::get({-1}, pointerType);
     unsigned rank = inputType.dyn_cast<RankedTensorType>().getRank();
-    Value c_rank_minus_1 = rewriter.create<ConstantIndexOp>(loc, rank - 1);
+    Value c_rank_minus_1 =
+        rewriter.create<arith::ConstantIndexOp>(loc, rank - 1);
     Value ptrs = rewriter.create<sparse_tensor::ToPointersOp>(
         loc, memref1DPointerType, inputTensor, c_rank_minus_1);
 
     // Find length of pointer array
     Value npointers;
     if (rank == 1) {
-      npointers = rewriter.create<ConstantIndexOp>(loc, 1);
+      npointers = rewriter.create<arith::ConstantIndexOp>(loc, 1);
     } else {
       Value dimForPointers;
       if (hasRowOrdering(inputType)) {
-        dimForPointers = rewriter.create<ConstantIndexOp>(loc, 0);
+        dimForPointers = rewriter.create<arith::ConstantIndexOp>(loc, 0);
       } else {
-        dimForPointers = rewriter.create<ConstantIndexOp>(loc, 1);
+        dimForPointers = rewriter.create<arith::ConstantIndexOp>(loc, 1);
       }
       npointers =
           rewriter.create<tensor::DimOp>(loc, inputTensor, dimForPointers);
@@ -120,7 +121,7 @@ public:
 
     // The last value from the pointers is the number of nonzero values
     Value nnz_ptype = rewriter.create<memref::LoadOp>(loc, ptrs, npointers);
-    Value nnz = rewriter.create<mlir::IndexCastOp>(loc, nnz_ptype, indexType);
+    Value nnz = rewriter.create<arith::IndexCastOp>(loc, nnz_ptype, indexType);
 
     rewriter.replaceOp(op, nnz);
     return success();
@@ -174,10 +175,10 @@ public:
     Type indexType = rewriter.getIndexType();
 
     // Initial constants
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
-    Value c0_64 = rewriter.create<ConstantIntOp>(loc, 0, int64Type);
-    Value c1_64 = rewriter.create<ConstantIntOp>(loc, 1, int64Type);
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value c0_64 = rewriter.create<arith::ConstantIntOp>(loc, 0, int64Type);
+    Value c1_64 = rewriter.create<arith::ConstantIntOp>(loc, 1, int64Type);
 
     // Get sparse tensor info
     Type memref1DI64Type = MemRefType::get({-1}, int64Type);
@@ -218,7 +219,7 @@ public:
       ncol = tmp;
     }
 
-    Value ncols_plus_one = rewriter.create<mlir::AddIOp>(loc, ncol, c1);
+    Value ncols_plus_one = rewriter.create<arith::AddIOp>(loc, ncol, c1);
     callResizePointers(rewriter, module, loc, duplicate, c1, ncols_plus_one);
     callResizeIndex(rewriter, module, loc, duplicate, c1, nnz);
     callResizeValues(rewriter, module, loc, duplicate, nnz);
@@ -253,9 +254,9 @@ public:
     rewriter.setInsertionPointToStart(ptrLoop.getBody());
     Value colA64 =
         rewriter.create<memref::LoadOp>(loc, inputIndices, ptrLoopIdx);
-    Value colA = rewriter.create<mlir::IndexCastOp>(loc, colA64, indexType);
+    Value colA = rewriter.create<arith::IndexCastOp>(loc, colA64, indexType);
     Value colB = rewriter.create<memref::LoadOp>(loc, outputPtrs, colA);
-    Value colB1 = rewriter.create<mlir::AddIOp>(loc, colB, c1_64);
+    Value colB1 = rewriter.create<arith::AddIOp>(loc, colB, c1_64);
     rewriter.create<memref::StoreOp>(loc, colB1, outputPtrs, colA);
 
     rewriter.setInsertionPointAfter(ptrLoop);
@@ -271,7 +272,7 @@ public:
         rewriter.create<memref::LoadOp>(loc, outputPtrs, colAccLoopIdx);
     Value cumsum = rewriter.create<memref::LoadOp>(loc, outputPtrs, ncol);
     rewriter.create<memref::StoreOp>(loc, cumsum, outputPtrs, colAccLoopIdx);
-    Value cumsum2 = rewriter.create<mlir::AddIOp>(loc, cumsum, temp);
+    Value cumsum2 = rewriter.create<arith::AddIOp>(loc, cumsum, temp);
     rewriter.create<memref::StoreOp>(loc, cumsum2, outputPtrs, ncol);
 
     rewriter.setInsertionPointAfter(colAccLoop);
@@ -281,13 +282,13 @@ public:
     Value rowIdx = outerLoop.getInductionVar();
 
     rewriter.setInsertionPointToStart(outerLoop.getBody());
-    Value row_64 = rewriter.create<mlir::IndexCastOp>(loc, rowIdx, int64Type);
+    Value row_64 = rewriter.create<arith::IndexCastOp>(loc, rowIdx, int64Type);
     Value j_start_64 = rewriter.create<memref::LoadOp>(loc, inputPtrs, rowIdx);
     Value j_start =
-        rewriter.create<mlir::IndexCastOp>(loc, j_start_64, indexType);
-    Value row_plus1 = rewriter.create<mlir::AddIOp>(loc, rowIdx, c1);
+        rewriter.create<arith::IndexCastOp>(loc, j_start_64, indexType);
+    Value row_plus1 = rewriter.create<arith::AddIOp>(loc, rowIdx, c1);
     Value j_end_64 = rewriter.create<memref::LoadOp>(loc, inputPtrs, row_plus1);
-    Value j_end = rewriter.create<mlir::IndexCastOp>(loc, j_end_64, indexType);
+    Value j_end = rewriter.create<arith::IndexCastOp>(loc, j_end_64, indexType);
 
     scf::ForOp innerLoop = rewriter.create<scf::ForOp>(loc, j_start, j_end, c1);
     Value jj = innerLoop.getInductionVar();
@@ -295,16 +296,16 @@ public:
     rewriter.setInsertionPointToStart(innerLoop.getBody());
 
     Value col_64 = rewriter.create<memref::LoadOp>(loc, inputIndices, jj);
-    Value col = rewriter.create<mlir::IndexCastOp>(loc, col_64, indexType);
+    Value col = rewriter.create<arith::IndexCastOp>(loc, col_64, indexType);
     Value dest_64 = rewriter.create<memref::LoadOp>(loc, outputPtrs, col);
-    Value dest = rewriter.create<mlir::IndexCastOp>(loc, dest_64, indexType);
+    Value dest = rewriter.create<arith::IndexCastOp>(loc, dest_64, indexType);
     rewriter.create<memref::StoreOp>(loc, row_64, outputIndices, dest);
     Value axjj = rewriter.create<memref::LoadOp>(loc, inputValues, jj);
     rewriter.create<memref::StoreOp>(loc, axjj, outputValues, dest);
 
     // Bp[col]++
     Value bp_inc = rewriter.create<memref::LoadOp>(loc, outputPtrs, col);
-    Value bp_inc1 = rewriter.create<mlir::AddIOp>(loc, bp_inc, c1_64);
+    Value bp_inc1 = rewriter.create<arith::AddIOp>(loc, bp_inc, c1_64);
     rewriter.create<memref::StoreOp>(loc, bp_inc1, outputPtrs, col);
 
     rewriter.setInsertionPointAfter(outerLoop);
@@ -378,8 +379,8 @@ public:
 
     // Cast types
     Value output = callDupTensor(rewriter, module, loc, inputTensor);
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
     if (outputTypeIsCSR) {
       callAssignRev(rewriter, module, loc, output, c0, c0);
       callAssignRev(rewriter, module, loc, output, c1, c1);
@@ -407,10 +408,10 @@ struct MatrixSelectOutputWriter {
   void createConstants(PatternRewriter &rewriter, Location loc) {
     Type int64Type = rewriter.getIntegerType(64);
 
-    c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-    c1 = rewriter.create<ConstantIndexOp>(loc, 1);
-    c0_64 = rewriter.create<ConstantIntOp>(loc, 0, int64Type);
-    c1_64 = rewriter.create<ConstantIntOp>(loc, 1, int64Type);
+    c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    c0_64 = rewriter.create<arith::ConstantIntOp>(loc, 0, int64Type);
+    c1_64 = rewriter.create<arith::ConstantIntOp>(loc, 1, int64Type);
   }
 
   void createTensor(PatternRewriter &rewriter, Location loc, ModuleOp module,
@@ -448,18 +449,18 @@ struct MatrixSelectOutputWriter {
 
     Value keep;
     if (selector == "triu") {
-      keep = rewriter.create<mlir::CmpIOp>(loc, mlir::CmpIPredicate::ugt,
+      keep = rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ugt,
                                            colWise ? row : col,
                                            colWise ? col : row);
     } else if (selector == "tril") {
-      keep = rewriter.create<mlir::CmpIOp>(loc, mlir::CmpIPredicate::ult,
+      keep = rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ult,
                                            colWise ? row : col,
                                            colWise ? col : row);
     } else if (selector == "gt") {
-      keep = rewriter.create<mlir::CmpFOp>(loc, mlir::CmpFPredicate::OGT, val,
+      keep = rewriter.create<arith::CmpFOp>(loc, arith::CmpFPredicate::OGT, val,
                                            thunk.getValue());
     } else if (selector == "ge") {
-      keep = rewriter.create<mlir::CmpFOp>(loc, mlir::CmpFPredicate::OGE, val,
+      keep = rewriter.create<arith::CmpFOp>(loc, arith::CmpFPredicate::OGE, val,
                                            thunk.getValue());
     } else {
       // this should be impossible because of validation
@@ -473,12 +474,12 @@ struct MatrixSelectOutputWriter {
 
     Value bj_pos_64 = rewriter.create<memref::LoadOp>(loc, Bp, row_plus1);
     Value bj_pos =
-        rewriter.create<mlir::IndexCastOp>(loc, bj_pos_64, indexType);
+        rewriter.create<arith::IndexCastOp>(loc, bj_pos_64, indexType);
 
     rewriter.create<memref::StoreOp>(loc, col_64, Bj, bj_pos);
     rewriter.create<memref::StoreOp>(loc, val, Bx, bj_pos);
 
-    Value bj_pos_plus1 = rewriter.create<mlir::AddIOp>(loc, bj_pos_64, c1_64);
+    Value bj_pos_plus1 = rewriter.create<arith::AddIOp>(loc, bj_pos_64, c1_64);
     rewriter.create<memref::StoreOp>(loc, bj_pos_plus1, Bp, row_plus1);
 
     rewriter.setInsertionPointAfter(ifKeep);
@@ -531,8 +532,8 @@ public:
     ArrayAttr selectors = op.selectors();
 
     // Initial constants
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
 
     // Get sparse tensor info
     unsigned rank = inputType.getRank();
@@ -579,7 +580,7 @@ public:
     Value row = outerLoop.getInductionVar();
 
     rewriter.setInsertionPointToStart(outerLoop.getBody());
-    Value row_plus1 = rewriter.create<mlir::AddIOp>(loc, row, c1);
+    Value row_plus1 = rewriter.create<arith::AddIOp>(loc, row, c1);
 
     for (MatrixSelectOutputWriter *output : outputs) {
       output->createUpdateCurrCount(rewriter, loc, row, row_plus1);
@@ -588,8 +589,8 @@ public:
     Value j_start_64 = rewriter.create<memref::LoadOp>(loc, Ap, row);
     Value j_end_64 = rewriter.create<memref::LoadOp>(loc, Ap, row_plus1);
     Value j_start =
-        rewriter.create<mlir::IndexCastOp>(loc, j_start_64, indexType);
-    Value j_end = rewriter.create<mlir::IndexCastOp>(loc, j_end_64, indexType);
+        rewriter.create<arith::IndexCastOp>(loc, j_start_64, indexType);
+    Value j_end = rewriter.create<arith::IndexCastOp>(loc, j_end_64, indexType);
 
     scf::ForOp innerLoop = rewriter.create<scf::ForOp>(loc, j_start, j_end, c1);
 
@@ -597,7 +598,7 @@ public:
 
     rewriter.setInsertionPointToStart(innerLoop.getBody());
     Value col_64 = rewriter.create<memref::LoadOp>(loc, Aj, jj);
-    Value col = rewriter.create<mlir::IndexCastOp>(loc, col_64, indexType);
+    Value col = rewriter.create<arith::IndexCastOp>(loc, col_64, indexType);
     Value val = rewriter.create<memref::LoadOp>(loc, Ax, jj);
 
     for (MatrixSelectOutputWriter *output : outputs) {
@@ -724,9 +725,9 @@ public:
               return rewriter.create<ConstantOp>(
                   loc, rewriter.getFloatAttr(elementType, 0.0));
             });
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
-    Value c2 = rewriter.create<ConstantIndexOp>(loc, 2);
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value c2 = rewriter.create<arith::ConstantIndexOp>(loc, 2);
 
     Value len_dense_dim;
     if (axis == 1)
@@ -753,20 +754,20 @@ public:
       Value numNonEmptyRows = nnzLoop.getLoopBody().getArgument(1);
       Value matrixRowIndex = nnzLoop.getInductionVar();
       Value nextMatrixRowIndex =
-          rewriter.create<AddIOp>(loc, matrixRowIndex, c1).getResult();
+          rewriter.create<arith::AddIOp>(loc, matrixRowIndex, c1).getResult();
       Value firstPtr64 =
           rewriter.create<memref::LoadOp>(loc, matrixPointers, matrixRowIndex);
       Value secondPtr64 = rewriter.create<memref::LoadOp>(loc, matrixPointers,
                                                           nextMatrixRowIndex);
-      Value rowIsEmpty = rewriter.create<CmpIOp>(loc, CmpIPredicate::eq,
-                                                 firstPtr64, secondPtr64);
+      Value rowIsEmpty = rewriter.create<arith::CmpIOp>(
+          loc, arith::CmpIPredicate::eq, firstPtr64, secondPtr64);
       scf::IfOp ifRowIsEmptyBlock = rewriter.create<scf::IfOp>(
           loc, TypeRange{indexType}, rowIsEmpty, true);
       rewriter.setInsertionPointToStart(ifRowIsEmptyBlock.thenBlock());
       rewriter.create<scf::YieldOp>(loc, ValueRange{numNonEmptyRows});
       rewriter.setInsertionPointToStart(ifRowIsEmptyBlock.elseBlock());
       Value incrementedNumNonEmptyRows =
-          rewriter.create<AddIOp>(loc, numNonEmptyRows, c1).getResult();
+          rewriter.create<arith::AddIOp>(loc, numNonEmptyRows, c1).getResult();
       rewriter.create<scf::YieldOp>(loc,
                                     ValueRange{incrementedNumNonEmptyRows});
       rewriter.setInsertionPointAfter(ifRowIsEmptyBlock);
@@ -783,7 +784,7 @@ public:
     Value outputPointers = rewriter.create<sparse_tensor::ToPointersOp>(
         loc, memref1DPointerType, output, c0);
     Value outputNNZ_i64 =
-        rewriter.create<IndexCastOp>(loc, outputNNZ, int64Type);
+        rewriter.create<arith::IndexCastOp>(loc, outputNNZ, int64Type);
     rewriter.create<memref::StoreOp>(loc, outputNNZ_i64, outputPointers, c1);
 
     Value matrixValues = rewriter.create<sparse_tensor::ToValuesOp>(
@@ -806,19 +807,19 @@ public:
       Value ptr64 =
           rewriter.create<memref::LoadOp>(loc, matrixPointers, rowIndex);
       Value nextRowIndex =
-          rewriter.create<AddIOp>(loc, rowIndex, c1).getResult();
+          rewriter.create<arith::AddIOp>(loc, rowIndex, c1).getResult();
       Value nextPtr64 =
           rewriter.create<memref::LoadOp>(loc, matrixPointers, nextRowIndex);
 
       scf::IfOp ifRowIsNonEmptyBlock;
       if (aggregator == "count") {
 
-        Value ptrDiff = rewriter.create<SubIOp>(loc, nextPtr64, ptr64);
+        Value ptrDiff = rewriter.create<arith::SubIOp>(loc, nextPtr64, ptr64);
 
         Value c0_i64 = rewriter.create<ConstantOp>(
             loc, rewriter.getIntegerAttr(int64Type, 0));
-        Value rowIsNonEmpty =
-            rewriter.create<CmpIOp>(loc, CmpIPredicate::ne, ptrDiff, c0_i64);
+        Value rowIsNonEmpty = rewriter.create<arith::CmpIOp>(
+            loc, arith::CmpIPredicate::ne, ptrDiff, c0_i64);
 
         ifRowIsNonEmptyBlock = rewriter.create<scf::IfOp>(
             loc, TypeRange{indexType}, rowIsNonEmpty, true);
@@ -835,23 +836,24 @@ public:
                     .Case<IntegerType>([&](IntegerType type) {
                       Value ans;
                       if (type.getWidth() < 64)
-                        ans = rewriter.create<TruncateIOp>(loc, type, ptrDiff);
+                        ans = rewriter.create<arith::TruncIOp>(loc, type, ptrDiff);
                       else
-                        ans =
-                            rewriter.create<SignExtendIOp>(loc, type, ptrDiff);
+                        ans = rewriter.create<arith::ExtSIOp>(loc, type,
+                                                                    ptrDiff);
                       return ans;
                     })
                     .Case<FloatType>([&](FloatType type) {
-                      return rewriter.create<SIToFPOp>(loc, type, ptrDiff);
+                      return rewriter.create<arith::SIToFPOp>(loc, type,
+                                                              ptrDiff);
                     });
             rewriter.create<memref::StoreOp>(loc, rowReduction, outputValues,
                                              outputValuesPosition);
             Value rowIndex64 =
-                rewriter.create<IndexCastOp>(loc, rowIndex, int64Type);
+                rewriter.create<arith::IndexCastOp>(loc, rowIndex, int64Type);
             rewriter.create<memref::StoreOp>(loc, rowIndex64, outputIndices,
                                              outputValuesPosition);
             Value updatedOutputValuesPosition =
-                rewriter.create<AddIOp>(loc, outputValuesPosition, c1)
+                rewriter.create<arith::AddIOp>(loc, outputValuesPosition, c1)
                     .getResult();
             rewriter.create<scf::YieldOp>(
                 loc, ValueRange{updatedOutputValuesPosition});
@@ -866,8 +868,8 @@ public:
           rewriter.setInsertionPointAfter(ifRowIsNonEmptyBlock);
         }
       } else if (aggregator == "argmin" || aggregator == "argmax") {
-        Value rowIsNonEmpty =
-            rewriter.create<CmpIOp>(loc, CmpIPredicate::ne, ptr64, nextPtr64);
+        Value rowIsNonEmpty = rewriter.create<arith::CmpIOp>(
+            loc, arith::CmpIPredicate::ne, ptr64, nextPtr64);
         ifRowIsNonEmptyBlock = rewriter.create<scf::IfOp>(
             loc, TypeRange{indexType}, rowIsNonEmpty, true);
         {
@@ -879,15 +881,16 @@ public:
           rewriter.setInsertionPointToStart(ifRowIsNonEmptyBlock.thenBlock());
           {
 
-            Value ptr = rewriter.create<IndexCastOp>(loc, ptr64, indexType);
+            Value ptr =
+                rewriter.create<arith::IndexCastOp>(loc, ptr64, indexType);
             Value initialExtremum =
                 rewriter.create<memref::LoadOp>(loc, matrixValues, ptr);
             Value initialExtremumTensorIndex =
                 rewriter.create<memref::LoadOp>(loc, matrixIndices, ptr);
             Value ptrPlusOne =
-                rewriter.create<AddIOp>(loc, ptr, c1).getResult();
+                rewriter.create<arith::AddIOp>(loc, ptr, c1).getResult();
             Value nextPtr =
-                rewriter.create<IndexCastOp>(loc, nextPtr64, indexType);
+                rewriter.create<arith::IndexCastOp>(loc, nextPtr64, indexType);
             scf::ForOp rowAggregationLoop = rewriter.create<scf::ForOp>(
                 loc, ptrPlusOne, nextPtr, c1,
                 ValueRange{initialExtremum, initialExtremumTensorIndex});
@@ -905,17 +908,19 @@ public:
               bool useMinimum = aggregator == "argmin";
               Value mustUpdate = llvm::TypeSwitch<Type, Value>(elementType)
                                      .Case<IntegerType>([&](IntegerType type) {
-                                       return rewriter.create<CmpIOp>(
+                                       return rewriter.create<arith::CmpIOp>(
                                            loc,
-                                           useMinimum ? CmpIPredicate::slt
-                                                      : CmpIPredicate::sgt,
+                                           useMinimum
+                                               ? arith::CmpIPredicate::slt
+                                               : arith::CmpIPredicate::sgt,
                                            rowValue, currentExtremum);
                                      })
                                      .Case<FloatType>([&](FloatType type) {
-                                       return rewriter.create<CmpFOp>(
+                                       return rewriter.create<arith::CmpFOp>(
                                            loc,
-                                           useMinimum ? CmpFPredicate::OLT
-                                                      : CmpFPredicate::OGT,
+                                           useMinimum
+                                               ? arith::CmpFPredicate::OLT
+                                               : arith::CmpFPredicate::OGT,
                                            rowValue, currentExtremum);
                                      });
 
@@ -949,12 +954,12 @@ public:
             rewriter.create<memref::StoreOp>(loc, rowAggregation, outputValues,
                                              outputValuesPosition);
             Value rowIndex64 =
-                rewriter.create<IndexCastOp>(loc, rowIndex, int64Type);
+                rewriter.create<arith::IndexCastOp>(loc, rowIndex, int64Type);
             rewriter.create<memref::StoreOp>(loc, rowIndex64, outputIndices,
                                              outputValuesPosition);
 
             Value updatedOutputValuesPosition =
-                rewriter.create<AddIOp>(loc, outputValuesPosition, c1)
+                rewriter.create<arith::AddIOp>(loc, outputValuesPosition, c1)
                     .getResult();
             rewriter.create<scf::YieldOp>(
                 loc, ValueRange{updatedOutputValuesPosition});
@@ -969,16 +974,17 @@ public:
           rewriter.setInsertionPointAfter(ifRowIsNonEmptyBlock);
         }
       } else if (aggregator == "plus") {
-        Value rowIsNonEmpty =
-            rewriter.create<CmpIOp>(loc, CmpIPredicate::ne, ptr64, nextPtr64);
+        Value rowIsNonEmpty = rewriter.create<arith::CmpIOp>(
+            loc, arith::CmpIPredicate::ne, ptr64, nextPtr64);
         ifRowIsNonEmptyBlock = rewriter.create<scf::IfOp>(
             loc, TypeRange{indexType}, rowIsNonEmpty, true);
         {
           rewriter.setInsertionPointToStart(ifRowIsNonEmptyBlock.thenBlock());
           {
-            Value ptr = rewriter.create<IndexCastOp>(loc, ptr64, indexType);
+            Value ptr =
+                rewriter.create<arith::IndexCastOp>(loc, ptr64, indexType);
             Value nextPtr =
-                rewriter.create<IndexCastOp>(loc, nextPtr64, indexType);
+                rewriter.create<arith::IndexCastOp>(loc, nextPtr64, indexType);
             scf::ForOp rowSumLoop = rewriter.create<scf::ForOp>(
                 loc, ptr, nextPtr, c1, ValueRange{c0_elementType});
             {
@@ -991,12 +997,12 @@ public:
                   llvm::TypeSwitch<Type, Value>(elementType)
                       .Case<IntegerType>([&](IntegerType type) {
                         return rewriter
-                            .create<AddIOp>(loc, rowValue, currentSum)
+                            .create<arith::AddIOp>(loc, rowValue, currentSum)
                             .getResult();
                       })
                       .Case<FloatType>([&](FloatType type) {
                         return rewriter
-                            .create<AddFOp>(loc, rowValue, currentSum)
+                            .create<arith::AddFOp>(loc, rowValue, currentSum)
                             .getResult();
                       });
               rewriter.create<scf::YieldOp>(loc, ValueRange{updatedSum});
@@ -1006,11 +1012,11 @@ public:
             rewriter.create<memref::StoreOp>(loc, rowSum, outputValues,
                                              outputValuesPosition);
             Value rowIndex64 =
-                rewriter.create<IndexCastOp>(loc, rowIndex, int64Type);
+                rewriter.create<arith::IndexCastOp>(loc, rowIndex, int64Type);
             rewriter.create<memref::StoreOp>(loc, rowIndex64, outputIndices,
                                              outputValuesPosition);
             Value updatedOutputValuesPosition =
-                rewriter.create<AddIOp>(loc, outputValuesPosition, c1)
+                rewriter.create<arith::AddIOp>(loc, outputValuesPosition, c1)
                     .getResult();
             rewriter.create<scf::YieldOp>(
                 loc, ValueRange{updatedOutputValuesPosition});
@@ -1063,7 +1069,8 @@ private:
     Type int64Type = rewriter.getIntegerType(64);
 
     Value countOp = rewriter.create<graphblas::NumValsOp>(loc, input);
-    Value countOp_64 = rewriter.create<IndexCastOp>(loc, countOp, int64Type);
+    Value countOp_64 =
+        rewriter.create<arith::IndexCastOp>(loc, countOp, int64Type);
     rewriter.replaceOp(op, countOp_64);
 
     return success();
@@ -1079,8 +1086,8 @@ private:
     Value input = op.input();
     RankedTensorType inputType = input.getType().cast<RankedTensorType>();
 
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
     Type indexType = rewriter.getIndexType();
     Type int64Type = rewriter.getIntegerType(64);
     Type memref1DI64Type = MemRefType::get({-1}, int64Type);
@@ -1089,7 +1096,7 @@ private:
         loc, memref1DI64Type, input, c0);
     Value endPosition64 = rewriter.create<memref::LoadOp>(loc, pointers, c1);
     Value endPosition =
-        rewriter.create<IndexCastOp>(loc, endPosition64, indexType);
+        rewriter.create<arith::IndexCastOp>(loc, endPosition64, indexType);
 
     Type inputElementType = inputType.getElementType();
     Type memref1DValueType = MemRefType::get({-1}, inputElementType);
@@ -1111,13 +1118,17 @@ private:
     Value replace =
         llvm::TypeSwitch<Type, Value>(inputElementType)
             .Case<IntegerType>([&](IntegerType type) {
-              return rewriter.create<CmpIOp>(
-                  loc, useMinimum ? CmpIPredicate::slt : CmpIPredicate::sgt,
+              return rewriter.create<arith::CmpIOp>(
+                  loc,
+                  useMinimum ? arith::CmpIPredicate::slt
+                             : arith::CmpIPredicate::sgt,
                   currentValue, currentExtremum);
             })
             .Case<FloatType>([&](FloatType type) {
-              return rewriter.create<CmpFOp>(
-                  loc, useMinimum ? CmpFPredicate::OLT : CmpFPredicate::OGT,
+              return rewriter.create<arith::CmpFOp>(
+                  loc,
+                  useMinimum ? arith::CmpFPredicate::OLT
+                             : arith::CmpFPredicate::OGT,
                   currentValue, currentExtremum);
             });
 
@@ -1170,10 +1181,11 @@ private:
       Value aggIdentity =
           llvm::TypeSwitch<Type, Value>(valueType)
               .Case<IntegerType>([&](IntegerType type) {
-                return rewriter.create<ConstantIntOp>(loc, 0, type.getWidth());
+                return rewriter.create<arith::ConstantIntOp>(loc, 0,
+                                                             type.getWidth());
               })
               .Case<FloatType>([&](FloatType type) {
-                return rewriter.create<ConstantFloatOp>(loc, APFloat(0.0),
+                return rewriter.create<arith::ConstantFloatOp>(loc, APFloat(0.0),
                                                         type);
               });
       rewriter.create<graphblas::YieldOp>(
@@ -1189,10 +1201,12 @@ private:
       Value aggResult =
           llvm::TypeSwitch<Type, Value>(valueType)
               .Case<IntegerType>([&](IntegerType type) {
-                return rewriter.create<AddIOp>(loc, lhs, rhs).getResult();
+                return rewriter.create<arith::AddIOp>(loc, lhs, rhs)
+                    .getResult();
               })
               .Case<FloatType>([&](FloatType type) {
-                return rewriter.create<AddFOp>(loc, lhs, rhs).getResult();
+                return rewriter.create<arith::AddFOp>(loc, lhs, rhs)
+                    .getResult();
               });
       rewriter.create<graphblas::YieldOp>(loc, graphblas::YieldKind::AGG,
                                           aggResult);
@@ -1241,8 +1255,8 @@ public:
     rewriter.eraseOp(aggIdentityYield);
 
     // initial constants
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
 
     // Get sparse tensor info
     MemRefType memref1DValueType = MemRefType::get({-1}, valueType);
@@ -1329,14 +1343,14 @@ public:
                       .Case<IntegerType>([&](IntegerType type) {
                         // http://graphics.stanford.edu/~seander/bithacks.html#IntegerMinOrMax
                         // says this is best
-                        return rewriter.create<mlir::CmpIOp>(
-                            loc, mlir::CmpIPredicate::slt, val, thunk);
+                        return rewriter.create<arith::CmpIOp>(
+                            loc, arith::CmpIPredicate::slt, val, thunk);
                       })
                       .Case<FloatType>([&](FloatType type) {
-                        return rewriter.create<mlir::CmpFOp>(
-                            loc, mlir::CmpFPredicate::OLT, val, thunk);
+                        return rewriter.create<arith::CmpFOp>(
+                            loc, arith::CmpFPredicate::OLT, val, thunk);
                       });
-      transformResult = rewriter.create<mlir::SelectOp>(loc, cmp, val, thunk);
+      transformResult = rewriter.create<SelectOp>(loc, cmp, val, thunk);
 
     } else if (apply_operator == "div") {
 
@@ -1347,14 +1361,15 @@ public:
               .Case<IntegerType>([&](IntegerType type) {
                 Value quotient =
                     thunkIsLeft
-                        ? rewriter.create<SignedDivIOp>(loc, thunk, val)
-                        : rewriter.create<SignedDivIOp>(loc, val, thunk);
+                        ? rewriter.create<arith::DivSIOp>(loc, thunk, val)
+                        : rewriter.create<arith::DivSIOp>(loc, val, thunk);
                 return quotient;
               })
               .Case<FloatType>([&](FloatType type) {
-                Value quotient = thunkIsLeft
-                                     ? rewriter.create<DivFOp>(loc, thunk, val)
-                                     : rewriter.create<DivFOp>(loc, val, thunk);
+                Value quotient =
+                    thunkIsLeft
+                        ? rewriter.create<arith::DivFOp>(loc, thunk, val)
+                        : rewriter.create<arith::DivFOp>(loc, val, thunk);
                 return quotient;
               });
 
@@ -1374,26 +1389,27 @@ public:
                 Value shiftAmount = rewriter.create<ConstantOp>(
                     loc, rewriter.getIntegerAttr(type, bitWidth - 1));
                 Value mask =
-                    rewriter.create<SignedShiftRightOp>(loc, val, shiftAmount);
-                Value maskPlusVal = rewriter.create<AddIOp>(loc, mask, val);
-                Value absVal = rewriter.create<XOrOp>(loc, mask, maskPlusVal);
-                Value c1_type = rewriter.create<ConstantOp>(
+                    rewriter.create<arith::ShRSIOp>(loc, val, shiftAmount);
+                Value maskPlusVal = rewriter.create<arith::AddIOp>(loc, mask, val);
+                Value absVal =
+                    rewriter.create<arith::XOrIOp>(loc, mask, maskPlusVal);
+                Value c1_type = rewriter.create<arith::ConstantOp>(
                     loc, rewriter.getIntegerAttr(type, 1));
-                Value absValIsOne_i1 = rewriter.create<CmpIOp>(
-                    loc, CmpIPredicate::eq, absVal, c1_type);
-                Value absValIsOne_type =
-                    rewriter.create<SignExtendIOp>(loc, type, absValIsOne_i1);
+                Value absValIsOne_i1 = rewriter.create<arith::CmpIOp>(
+                    loc, arith::CmpIPredicate::eq, absVal, c1_type);
+                Value absValIsOne_type = rewriter.create<arith::ExtSIOp>(
+                    loc, type, absValIsOne_i1);
                 Value multipicativeInverse =
-                    rewriter.create<AndOp>(loc, absValIsOne_type, val);
+                    rewriter.create<arith::AndIOp>(loc, absValIsOne_type, val);
                 return multipicativeInverse;
               })
               .Case<FloatType>([&](FloatType type) {
                 // TODO is there a faster way? e.g. magic with logs or
                 // exponents?
-                Value c1_type =
-                    rewriter.create<ConstantFloatOp>(loc, APFloat(1.0), type);
+                Value c1_type = rewriter.create<arith::ConstantFloatOp>(
+                    loc, APFloat(1.0), type);
                 Value multipicativeInverse =
-                    rewriter.create<DivFOp>(loc, c1_type, val);
+                    rewriter.create<arith::DivFOp>(loc, c1_type, val);
                 return multipicativeInverse;
               });
 
@@ -1404,12 +1420,12 @@ public:
                               Value c0_type = rewriter.create<ConstantOp>(
                                   loc, rewriter.getIntegerAttr(type, 0));
                               Value additiveInverse =
-                                  rewriter.create<SubIOp>(loc, c0_type, val);
+                                  rewriter.create<arith::SubIOp>(loc, c0_type, val);
                               return additiveInverse;
                             })
                             .Case<FloatType>([&](FloatType type) {
                               Value additiveInverse =
-                                  rewriter.create<NegFOp>(loc, val);
+                                  rewriter.create<arith::NegFOp>(loc, val);
                               return additiveInverse;
                             });
 
@@ -1422,14 +1438,15 @@ public:
                 unsigned bitWidth = type.getWidth();
                 Value shiftAmount = rewriter.create<ConstantOp>(
                     loc, rewriter.getIntegerAttr(type, bitWidth - 1));
-                Value mask =
-                    rewriter.create<SignedShiftRightOp>(loc, val, shiftAmount);
-                Value maskPlusVal = rewriter.create<AddIOp>(loc, mask, val);
-                Value absVal = rewriter.create<XOrOp>(loc, mask, maskPlusVal);
+                Value mask = rewriter.create<arith::ShRSIOp>(
+                    loc, val, shiftAmount);
+                Value maskPlusVal =
+                    rewriter.create<arith::AddIOp>(loc, mask, val);
+                Value absVal = rewriter.create<arith::XOrIOp>(loc, mask, maskPlusVal);
                 return absVal;
               })
               .Case<FloatType>([&](FloatType type) {
-                return rewriter.create<AbsFOp>(loc, val);
+                return rewriter.create<math::AbsOp>(loc, val);
               });
 
     } else {
@@ -1474,8 +1491,8 @@ public:
     }
 
     // Initial constants
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
 
     // Get sparse tensor info
     Value output = rewriter.create<graphblas::DupOp>(loc, inputTensor);
@@ -1624,15 +1641,15 @@ private:
     MemRefType memref1DValueType = MemRefType::get({-1}, valueType);
 
     // Initial constants
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
-    Value ci0 = rewriter.create<ConstantIntOp>(loc, 0, int64Type);
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value ci0 = rewriter.create<arith::ConstantIntOp>(loc, 0, int64Type);
 
     Value nrow = rewriter.create<graphblas::NumRowsOp>(loc, A);
     Value ncol = rewriter.create<graphblas::NumColsOp>(loc, B);
     Value nk = rewriter.create<graphblas::NumColsOp>(
         loc, A); // guaranteed equal to B.rows
-    Value nrow_plus_one = rewriter.create<AddIOp>(loc, nrow, c1);
+    Value nrow_plus_one = rewriter.create<arith::AddIOp>(loc, nrow, c1);
 
     Value C = callEmptyLike(rewriter, module, loc, A);
     callResizeDim(rewriter, module, loc, C, c0, nrow);
@@ -1672,10 +1689,10 @@ private:
     rewriter.setInsertionPointToStart(rowLoop1.getBody());
 
     Value colStart64 = rewriter.create<memref::LoadOp>(loc, Ap, row);
-    Value rowPlus1 = rewriter.create<AddIOp>(loc, row, c1);
+    Value rowPlus1 = rewriter.create<arith::AddIOp>(loc, row, c1);
     Value colEnd64 = rewriter.create<memref::LoadOp>(loc, Ap, rowPlus1);
-    Value cmpColSame =
-        rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, colStart64, colEnd64);
+    Value cmpColSame = rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
+                                                      colStart64, colEnd64);
 
     scf::IfOp ifBlock_rowTotal =
         rewriter.create<scf::IfOp>(loc, int64Type, cmpColSame, true);
@@ -1685,15 +1702,18 @@ private:
 
     // else
     rewriter.setInsertionPointToStart(ifBlock_rowTotal.elseBlock());
-    Value colStart = rewriter.create<IndexCastOp>(loc, colStart64, indexType);
-    Value colEnd = rewriter.create<IndexCastOp>(loc, colEnd64, indexType);
+    Value colStart =
+        rewriter.create<arith::IndexCastOp>(loc, colStart64, indexType);
+    Value colEnd =
+        rewriter.create<arith::IndexCastOp>(loc, colEnd64, indexType);
     Value total;
     if (mask) {
       Value mcolStart64 = rewriter.create<memref::LoadOp>(loc, Mp, row);
       Value mcolEnd64 = rewriter.create<memref::LoadOp>(loc, Mp, rowPlus1);
       Value mcolStart =
-          rewriter.create<IndexCastOp>(loc, mcolStart64, indexType);
-      Value mcolEnd = rewriter.create<IndexCastOp>(loc, mcolEnd64, indexType);
+          rewriter.create<arith::IndexCastOp>(loc, mcolStart64, indexType);
+      Value mcolEnd =
+          rewriter.create<arith::IndexCastOp>(loc, mcolEnd64, indexType);
       if (isMaskComplement) {
         ValueRange mcResult =
             buildMaskComplement(rewriter, loc, ncol, Mj, mcolStart, mcolEnd);
@@ -1732,7 +1752,7 @@ private:
     Value csTemp = rewriter.create<memref::LoadOp>(loc, Cp, cs_i);
     Value cumsum = rewriter.create<memref::LoadOp>(loc, Cp, nrow);
     rewriter.create<memref::StoreOp>(loc, cumsum, Cp, cs_i);
-    Value cumsum2 = rewriter.create<AddIOp>(loc, cumsum, csTemp);
+    Value cumsum2 = rewriter.create<arith::AddIOp>(loc, cumsum, csTemp);
     rewriter.create<memref::StoreOp>(loc, cumsum2, Cp, nrow);
 
     // end row loop
@@ -1755,29 +1775,31 @@ private:
     row = rowLoop3.getInductionVars().front();
     rewriter.setInsertionPointToStart(rowLoop3.getBody());
 
-    rowPlus1 = rewriter.create<AddIOp>(loc, row, c1);
+    rowPlus1 = rewriter.create<arith::AddIOp>(loc, row, c1);
     Value cpStart64 = rewriter.create<memref::LoadOp>(loc, Cp, row);
     Value cpEnd64 = rewriter.create<memref::LoadOp>(loc, Cp, rowPlus1);
-    Value cmp_cpDifferent =
-        rewriter.create<CmpIOp>(loc, CmpIPredicate::ne, cpStart64, cpEnd64);
+    Value cmp_cpDifferent = rewriter.create<arith::CmpIOp>(
+        loc, arith::CmpIPredicate::ne, cpStart64, cpEnd64);
     scf::IfOp ifBlock_cmpDiff =
         rewriter.create<scf::IfOp>(loc, cmp_cpDifferent);
     rewriter.setInsertionPointToStart(ifBlock_cmpDiff.thenBlock());
 
     Value baseIndex64 = rewriter.create<memref::LoadOp>(loc, Cp, row);
-    Value baseIndex = rewriter.create<IndexCastOp>(loc, baseIndex64, indexType);
+    Value baseIndex =
+        rewriter.create<arith::IndexCastOp>(loc, baseIndex64, indexType);
 
     colStart64 = rewriter.create<memref::LoadOp>(loc, Ap, row);
     colEnd64 = rewriter.create<memref::LoadOp>(loc, Ap, rowPlus1);
-    colStart = rewriter.create<IndexCastOp>(loc, colStart64, indexType);
-    colEnd = rewriter.create<IndexCastOp>(loc, colEnd64, indexType);
+    colStart = rewriter.create<arith::IndexCastOp>(loc, colStart64, indexType);
+    colEnd = rewriter.create<arith::IndexCastOp>(loc, colEnd64, indexType);
 
     if (mask) {
       Value mcolStart64 = rewriter.create<memref::LoadOp>(loc, Mp, row);
       Value mcolEnd64 = rewriter.create<memref::LoadOp>(loc, Mp, rowPlus1);
       Value mcolStart =
-          rewriter.create<IndexCastOp>(loc, mcolStart64, indexType);
-      Value mcolEnd = rewriter.create<IndexCastOp>(loc, mcolEnd64, indexType);
+          rewriter.create<arith::IndexCastOp>(loc, mcolStart64, indexType);
+      Value mcolEnd =
+          rewriter.create<arith::IndexCastOp>(loc, mcolEnd64, indexType);
       if (isMaskComplement) {
         ValueRange mcResult =
             buildMaskComplement(rewriter, loc, ncol, Mj, mcolStart, mcolEnd);
@@ -1834,10 +1856,10 @@ private:
     MemRefType memref1DValueType = MemRefType::get({-1}, valueType);
 
     // Initial constants
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
-    Value c2 = rewriter.create<ConstantIndexOp>(loc, 2);
-    Value ci0 = rewriter.create<ConstantIntOp>(loc, 0, int64Type);
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value c2 = rewriter.create<arith::ConstantIndexOp>(loc, 2);
+    Value ci0 = rewriter.create<arith::ConstantIntOp>(loc, 0, int64Type);
 
     Value size = rewriter.create<graphblas::NumRowsOp>(loc, A);
     Value nk = rewriter.create<graphblas::SizeOp>(loc, B);
@@ -1870,8 +1892,9 @@ private:
                                                        mask, c0);
       Value maskStart64 = rewriter.create<memref::LoadOp>(loc, Mp, c0);
       Value maskEnd64 = rewriter.create<memref::LoadOp>(loc, Mp, c1);
-      maskStart = rewriter.create<IndexCastOp>(loc, maskStart64, indexType);
-      maskEnd = rewriter.create<IndexCastOp>(loc, maskEnd64, indexType);
+      maskStart =
+          rewriter.create<arith::IndexCastOp>(loc, maskStart64, indexType);
+      maskEnd = rewriter.create<arith::IndexCastOp>(loc, maskEnd64, indexType);
     }
 
     // 1st pass
@@ -1881,9 +1904,9 @@ private:
     //   iteration element
     Value fixedIndexEnd64 = rewriter.create<memref::LoadOp>(loc, Bp, c1);
     Value fixedIndexEnd =
-        rewriter.create<IndexCastOp>(loc, fixedIndexEnd64, indexType);
-    Value cmpColSame =
-        rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, c0, fixedIndexEnd);
+        rewriter.create<arith::IndexCastOp>(loc, fixedIndexEnd64, indexType);
+    Value cmpColSame = rewriter.create<arith::CmpIOp>(
+        loc, arith::CmpIPredicate::eq, c0, fixedIndexEnd);
 
     scf::IfOp ifBlock_rowTotal =
         rewriter.create<scf::IfOp>(loc, int64Type, cmpColSame, true);
@@ -1916,7 +1939,7 @@ private:
     // end if cmpColSame
     rewriter.setInsertionPointAfter(ifBlock_rowTotal);
     Value nnzTotal = ifBlock_rowTotal.getResult(0);
-    Value nnz = rewriter.create<IndexCastOp>(loc, nnzTotal, indexType);
+    Value nnz = rewriter.create<arith::IndexCastOp>(loc, nnzTotal, indexType);
     rewriter.create<memref::StoreOp>(loc, nnzTotal, Cp, c1);
 
     callResizeIndex(rewriter, module, loc, C, c0, nnz);
@@ -1932,7 +1955,7 @@ private:
     //   The vector B is the fixed element, while the rows of A are the
     //   iteration element
     Value cmp_cpDifferent =
-        rewriter.create<CmpIOp>(loc, CmpIPredicate::ne, c0, nnz);
+        rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ne, c0, nnz);
     scf::IfOp ifBlock_cmpDiff =
         rewriter.create<scf::IfOp>(loc, cmp_cpDifferent);
     rewriter.setInsertionPointToStart(ifBlock_cmpDiff.thenBlock());
@@ -1991,10 +2014,10 @@ private:
     MemRefType memref1DValueType = MemRefType::get({-1}, valueType);
 
     // Initial constants
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
-    Value c2 = rewriter.create<ConstantIndexOp>(loc, 2);
-    Value ci0 = rewriter.create<ConstantIntOp>(loc, 0, int64Type);
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value c2 = rewriter.create<arith::ConstantIndexOp>(loc, 2);
+    Value ci0 = rewriter.create<arith::ConstantIntOp>(loc, 0, int64Type);
 
     Value size = rewriter.create<graphblas::NumColsOp>(loc, B);
     Value nk = rewriter.create<graphblas::SizeOp>(
@@ -2026,8 +2049,9 @@ private:
                                                        mask, c0);
       Value maskStart64 = rewriter.create<memref::LoadOp>(loc, Mp, c0);
       Value maskEnd64 = rewriter.create<memref::LoadOp>(loc, Mp, c1);
-      maskStart = rewriter.create<IndexCastOp>(loc, maskStart64, indexType);
-      maskEnd = rewriter.create<IndexCastOp>(loc, maskEnd64, indexType);
+      maskStart =
+          rewriter.create<arith::IndexCastOp>(loc, maskStart64, indexType);
+      maskEnd = rewriter.create<arith::IndexCastOp>(loc, maskEnd64, indexType);
     }
 
     // 1st pass
@@ -2037,9 +2061,9 @@ private:
     //   iteration element
     Value fixedIndexEnd64 = rewriter.create<memref::LoadOp>(loc, Ap, c1);
     Value fixedIndexEnd =
-        rewriter.create<IndexCastOp>(loc, fixedIndexEnd64, indexType);
-    Value cmpColSame =
-        rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, c0, fixedIndexEnd);
+        rewriter.create<arith::IndexCastOp>(loc, fixedIndexEnd64, indexType);
+    Value cmpColSame = rewriter.create<arith::CmpIOp>(
+        loc, arith::CmpIPredicate::eq, c0, fixedIndexEnd);
 
     scf::IfOp ifBlock_rowTotal =
         rewriter.create<scf::IfOp>(loc, int64Type, cmpColSame, true);
@@ -2072,7 +2096,7 @@ private:
     // end if cmpColSame
     rewriter.setInsertionPointAfter(ifBlock_rowTotal);
     Value nnzTotal = ifBlock_rowTotal.getResult(0);
-    Value nnz = rewriter.create<IndexCastOp>(loc, nnzTotal, indexType);
+    Value nnz = rewriter.create<arith::IndexCastOp>(loc, nnzTotal, indexType);
     rewriter.create<memref::StoreOp>(loc, nnzTotal, Cp, c1);
 
     callResizeIndex(rewriter, module, loc, C, c0, nnz);
@@ -2088,7 +2112,7 @@ private:
     //   The vector A is the fixed element, while the columns of B are the
     //   iteration element
     Value cmp_cpDifferent =
-        rewriter.create<CmpIOp>(loc, CmpIPredicate::ne, c0, nnz);
+        rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ne, c0, nnz);
     scf::IfOp ifBlock_cmpDiff =
         rewriter.create<scf::IfOp>(loc, cmp_cpDifferent);
     rewriter.setInsertionPointToStart(ifBlock_cmpDiff.thenBlock());
@@ -2144,9 +2168,9 @@ private:
     MemRefType memref1DValueType = MemRefType::get({-1}, valueType);
 
     // Initial constants
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
-    Value c2 = rewriter.create<ConstantIndexOp>(loc, 2);
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value c2 = rewriter.create<arith::ConstantIndexOp>(loc, 2);
 
     Value size = rewriter.create<graphblas::SizeOp>(loc, A);
 
@@ -2182,7 +2206,7 @@ private:
     //   iteration element
     Value fixedIndexEnd64 = rewriter.create<memref::LoadOp>(loc, Ap, c1);
     Value fixedIndexEnd =
-        rewriter.create<IndexCastOp>(loc, fixedIndexEnd64, indexType);
+        rewriter.create<arith::IndexCastOp>(loc, fixedIndexEnd64, indexType);
 
     computeInnerProduct(rewriter, loc, size, Ai, Ax, c0, fixedIndexEnd, Bp, Bi,
                         Bx, nullptr, c0, c1, valueType, extBlocks, Ci, Cx, c0,
@@ -2244,19 +2268,20 @@ public:
     MemRefType memref1DValueType = MemRefType::get({-1}, valueType);
 
     // Initial constants
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
     // TODO: make cf0 value dependent on the aggregator
     Value cf0 =
         llvm::TypeSwitch<Type, Value>(valueType)
             .Case<IntegerType>([&](IntegerType type) {
-              return rewriter.create<ConstantIntOp>(loc, 0, type.getWidth());
+              return rewriter.create<arith::ConstantIntOp>(loc, 0,
+                                                           type.getWidth());
             })
             .Case<FloatType>([&](FloatType type) {
-              return rewriter.create<ConstantFloatOp>(loc, APFloat(0.0), type);
+              return rewriter.create<arith::ConstantFloatOp>(loc, APFloat(0.0), type);
             });
-    Value ctrue = rewriter.create<ConstantIntOp>(loc, 1, boolType);
-    Value cfalse = rewriter.create<ConstantIntOp>(loc, 0, boolType);
+    Value ctrue = rewriter.create<arith::ConstantIntOp>(loc, 1, boolType);
+    Value cfalse = rewriter.create<arith::ConstantIntOp>(loc, 0, boolType);
 
     // Get sparse tensor info
     Value Ap = rewriter.create<sparse_tensor::ToPointersOp>(
@@ -2292,11 +2317,11 @@ public:
     Value row = rowLoop.getInductionVars().front();
     rewriter.setInsertionPointToStart(rowLoop.getBody());
 
-    Value rowPlus1 = rewriter.create<AddIOp>(loc, row, c1);
+    Value rowPlus1 = rewriter.create<arith::AddIOp>(loc, row, c1);
     Value apStart64 = rewriter.create<memref::LoadOp>(loc, Ap, row);
     Value apEnd64 = rewriter.create<memref::LoadOp>(loc, Ap, rowPlus1);
-    Value cmp_cpSame =
-        rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, apStart64, apEnd64);
+    Value cmp_cpSame = rewriter.create<arith::CmpIOp>(
+        loc, arith::CmpIPredicate::eq, apStart64, apEnd64);
 
     scf::IfOp ifBlock_cmpSame =
         rewriter.create<scf::IfOp>(loc, valueType, cmp_cpSame, true);
@@ -2308,8 +2333,9 @@ public:
     rewriter.setInsertionPointToStart(ifBlock_cmpSame.elseBlock());
 
     // Construct a dense array of row values
-    Value colStart = rewriter.create<IndexCastOp>(loc, apStart64, indexType);
-    Value colEnd = rewriter.create<IndexCastOp>(loc, apEnd64, indexType);
+    Value colStart =
+        rewriter.create<arith::IndexCastOp>(loc, apStart64, indexType);
+    Value colEnd = rewriter.create<arith::IndexCastOp>(loc, apEnd64, indexType);
     Value kvec = rewriter.create<memref::AllocOp>(loc, memref1DValueType, nk);
     Value kvec_i1 = rewriter.create<memref::AllocOp>(loc, memref1DBoolType, nk);
     rewriter.create<linalg::FillOp>(loc, cfalse, kvec_i1);
@@ -2319,7 +2345,7 @@ public:
     Value jj = colLoop1.getInductionVars().front();
     rewriter.setInsertionPointToStart(colLoop1.getBody());
     Value col64 = rewriter.create<memref::LoadOp>(loc, Aj, jj);
-    Value col = rewriter.create<IndexCastOp>(loc, col64, indexType);
+    Value col = rewriter.create<arith::IndexCastOp>(loc, col64, indexType);
     rewriter.create<memref::StoreOp>(loc, ctrue, kvec_i1, col);
     Value val = rewriter.create<memref::LoadOp>(loc, Ax, jj);
     rewriter.create<memref::StoreOp>(loc, val, kvec, col);
@@ -2333,27 +2359,29 @@ public:
       Value mcolStart64 = rewriter.create<memref::LoadOp>(loc, Mp, row);
       Value mcolEnd64 = rewriter.create<memref::LoadOp>(loc, Mp, rowPlus1);
       Value mcolStart =
-          rewriter.create<IndexCastOp>(loc, mcolStart64, indexType);
-      Value mcolEnd = rewriter.create<IndexCastOp>(loc, mcolEnd64, indexType);
+          rewriter.create<arith::IndexCastOp>(loc, mcolStart64, indexType);
+      Value mcolEnd =
+          rewriter.create<arith::IndexCastOp>(loc, mcolEnd64, indexType);
 
       colLoop2 =
           rewriter.create<scf::ParallelOp>(loc, mcolStart, mcolEnd, c1, cf0);
       Value mm = colLoop2.getInductionVars().front();
       rewriter.setInsertionPointToStart(colLoop2.getBody());
       col64 = rewriter.create<memref::LoadOp>(loc, Mj, mm);
-      col = rewriter.create<IndexCastOp>(loc, col64, indexType);
+      col = rewriter.create<arith::IndexCastOp>(loc, col64, indexType);
     } else {
       colLoop2 = rewriter.create<scf::ParallelOp>(loc, c0, ncol, c1, cf0);
       col = colLoop2.getInductionVars().front();
       rewriter.setInsertionPointToStart(colLoop2.getBody());
-      col64 = rewriter.create<IndexCastOp>(loc, col, int64Type);
+      col64 = rewriter.create<arith::IndexCastOp>(loc, col, int64Type);
     }
 
-    Value colPlus1 = rewriter.create<AddIOp>(loc, col, c1);
+    Value colPlus1 = rewriter.create<arith::AddIOp>(loc, col, c1);
     Value iStart64 = rewriter.create<memref::LoadOp>(loc, Bp, col);
     Value iEnd64 = rewriter.create<memref::LoadOp>(loc, Bp, colPlus1);
-    Value iStart = rewriter.create<IndexCastOp>(loc, iStart64, indexType);
-    Value iEnd = rewriter.create<IndexCastOp>(loc, iEnd64, indexType);
+    Value iStart =
+        rewriter.create<arith::IndexCastOp>(loc, iStart64, indexType);
+    Value iEnd = rewriter.create<arith::IndexCastOp>(loc, iEnd64, indexType);
 
     // insert add identity block
     rewriter.mergeBlocks(extBlocks.addIdentity, rewriter.getBlock(), {});
@@ -2370,7 +2398,7 @@ public:
     rewriter.setInsertionPointToStart(kLoop.getBody());
 
     Value kk64 = rewriter.create<memref::LoadOp>(loc, Bi, ii);
-    Value kk = rewriter.create<IndexCastOp>(loc, kk64, indexType);
+    Value kk = rewriter.create<arith::IndexCastOp>(loc, kk64, indexType);
     Value cmpPair = rewriter.create<memref::LoadOp>(loc, kvec_i1, kk);
     scf::IfOp ifBlock_cmpPair =
         rewriter.create<scf::IfOp>(loc, valueType, cmpPair, true);
@@ -2553,7 +2581,7 @@ public:
                                 PatternRewriter &rewriter) const override {
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Location loc = op->getLoc();
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
 
     // Inputs
     Value input = op.input();
@@ -2686,10 +2714,10 @@ public:
     MemRefType memref1DValueType = MemRefType::get({-1}, valueType);
 
     // Initial constants
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
-    Value cfalse = rewriter.create<ConstantIntOp>(loc, 0, boolType);
-    Value c1_reduce = rewriter.create<ConstantIntOp>(loc, 1, intReduceType);
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value cfalse = rewriter.create<arith::ConstantIntOp>(loc, 0, boolType);
+    Value c1_reduce = rewriter.create<arith::ConstantIntOp>(loc, 1, intReduceType);
 
     unsigned rank = aType.getRank(); // ranks guaranteed to be equal
 
@@ -2702,18 +2730,19 @@ public:
       Value bNrows = rewriter.create<graphblas::NumRowsOp>(loc, B);
       Value aNcols = rewriter.create<graphblas::NumColsOp>(loc, A);
       Value bNcols = rewriter.create<graphblas::NumColsOp>(loc, B);
-      Value cmpNrows =
-          rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, aNrows, bNrows);
-      Value cmpNcols =
-          rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, aNcols, bNcols);
-      cmpShape = rewriter.create<AndOp>(loc, cmpNrows, cmpNcols);
+      Value cmpNrows = rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
+                                                      aNrows, bNrows);
+      Value cmpNcols = rewriter.create<arith::CmpIOp>(
+          loc, arith::CmpIPredicate::eq, aNcols, bNcols);
+      cmpShape = rewriter.create<arith::AndIOp>(loc, cmpNrows, cmpNcols);
     } else {
       // Vector check
       dimIndex = c0;
       // Check size
       Value aSize = rewriter.create<graphblas::SizeOp>(loc, A);
       Value bSize = rewriter.create<graphblas::SizeOp>(loc, B);
-      cmpShape = rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, aSize, bSize);
+      cmpShape =
+          rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, aSize, bSize);
     }
 
     scf::IfOp ifOuter =
@@ -2724,7 +2753,8 @@ public:
     // Check number of non-zeros
     Value aNnz = rewriter.create<graphblas::NumValsOp>(loc, A);
     Value bNnz = rewriter.create<graphblas::NumValsOp>(loc, B);
-    Value cmpNnz = rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, aNnz, bNnz);
+    Value cmpNnz =
+        rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, aNnz, bNnz);
     scf::IfOp ifNnz = rewriter.create<scf::IfOp>(loc, boolType, cmpNnz, true);
     // if cmpNnz
     rewriter.setInsertionPointToStart(ifNnz.thenBlock());
@@ -2748,33 +2778,33 @@ public:
     Value bIndex = rewriter.create<memref::LoadOp>(loc, Bi, loopIdx);
     Value aValue = rewriter.create<memref::LoadOp>(loc, Ax, loopIdx);
     Value bValue = rewriter.create<memref::LoadOp>(loc, Bx, loopIdx);
-    Value cmpIndex =
-        rewriter.create<CmpIOp>(loc, CmpIPredicate::eq, aIndex, bIndex);
+    Value cmpIndex = rewriter.create<arith::CmpIOp>(
+        loc, arith::CmpIPredicate::eq, aIndex, bIndex);
     Value cmpValue = llvm::TypeSwitch<Type, Value>(valueType)
                          .Case<IntegerType>([&](IntegerType type) {
-                           return rewriter.create<CmpIOp>(
-                               loc, CmpIPredicate::eq, aValue, bValue);
+                           return rewriter.create<arith::CmpIOp>(
+                               loc, arith::CmpIPredicate::eq, aValue, bValue);
                          })
                          .Case<FloatType>([&](FloatType type) {
-                           return rewriter.create<CmpFOp>(
-                               loc, CmpFPredicate::OEQ, aValue, bValue);
+                           return rewriter.create<arith::CmpFOp>(
+                               loc, arith::CmpFPredicate::OEQ, aValue, bValue);
                          });
-    Value cmpCombined = rewriter.create<AndOp>(loc, cmpIndex, cmpValue);
+    Value cmpCombined = rewriter.create<arith::AndIOp>(loc, cmpIndex, cmpValue);
     // Need to do reduction with a standard word size (rather than i1) for
     // OpenMP
     Value cmpCombined_ext =
-        rewriter.create<SignExtendIOp>(loc, cmpCombined, intReduceType);
+        rewriter.create<arith::ExtSIOp>(loc, cmpCombined, intReduceType);
 
     scf::ReduceOp reducer =
         rewriter.create<scf::ReduceOp>(loc, cmpCombined_ext);
     BlockArgument lhs = reducer.getRegion().getArgument(0);
     BlockArgument rhs = reducer.getRegion().getArgument(1);
     rewriter.setInsertionPointToStart(&reducer.getRegion().front());
-    Value cmpFinal = rewriter.create<AndOp>(loc, lhs, rhs);
+    Value cmpFinal = rewriter.create<arith::AndIOp>(loc, lhs, rhs);
     rewriter.create<scf::ReduceReturnOp>(loc, cmpFinal);
 
     rewriter.setInsertionPointAfter(indexLoop);
-    Value boolResult = rewriter.create<mlir::TruncateIOp>(
+    Value boolResult = rewriter.create<arith::TruncIOp>(
         loc, indexLoop.getResult(0), boolType);
     rewriter.create<scf::YieldOp>(loc, boolResult);
 
@@ -2839,8 +2869,8 @@ private:
     Value c1_i64 =
         rewriter.create<ConstantOp>(loc, rewriter.getIntegerAttr(int64Type, 1));
 
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
 
     Value vectorLength = rewriter.create<graphblas::SizeOp>(loc, vector);
     Value vectorIndices = rewriter.create<sparse_tensor::ToIndicesOp>(
@@ -2880,7 +2910,8 @@ private:
         loc, memref1DI64Type, output, c1);
     Value initialVectorIndicesValue =
         rewriter.create<memref::LoadOp>(loc, vectorIndices, c0);
-    Value vectorLengthMinusOne = rewriter.create<SubIOp>(loc, vectorLength, c1);
+    Value vectorLengthMinusOne =
+        rewriter.create<arith::SubIOp>(loc, vectorLength, c1);
     scf::ForOp pointersUpdateLoop = rewriter.create<scf::ForOp>(
         loc, c0, vectorLength, c1,
         ValueRange{c0_i64, c0, initialVectorIndicesValue});
@@ -2896,23 +2927,23 @@ private:
       rewriter.create<memref::StoreOp>(loc, ptr_i64, outputPointers,
                                        pointersPosition);
       Value pointersPosition_i64 =
-          rewriter.create<mlir::IndexCastOp>(loc, pointersPosition, int64Type);
-      Value rowHasValue =
-          rewriter.create<CmpIOp>(op.getLoc(), CmpIPredicate::eq,
-                                  vectorIndicesValue, pointersPosition_i64);
-      Value notAtLastIteration =
-          rewriter.create<CmpIOp>(op.getLoc(), CmpIPredicate::ne,
-                                  pointersPosition, vectorLengthMinusOne);
+          rewriter.create<arith::IndexCastOp>(loc, pointersPosition, int64Type);
+      Value rowHasValue = rewriter.create<arith::CmpIOp>(
+          op.getLoc(), arith::CmpIPredicate::eq, vectorIndicesValue,
+          pointersPosition_i64);
+      Value notAtLastIteration = rewriter.create<arith::CmpIOp>(
+          op.getLoc(), arith::CmpIPredicate::ne, pointersPosition,
+          vectorLengthMinusOne);
       Value mustUpdate =
-          rewriter.create<AndOp>(loc, notAtLastIteration, rowHasValue);
+          rewriter.create<arith::AndIOp>(loc, notAtLastIteration, rowHasValue);
 
       scf::IfOp ifMustUpdateBlock = rewriter.create<scf::IfOp>(
           loc, TypeRange{int64Type, indexType, int64Type}, mustUpdate, true);
       {
         rewriter.setInsertionPointToStart(ifMustUpdateBlock.thenBlock());
-        Value nextPtr_i64 = rewriter.create<mlir::AddIOp>(loc, ptr_i64, c1_i64);
+        Value nextPtr_i64 = rewriter.create<arith::AddIOp>(loc, ptr_i64, c1_i64);
         Value nextVectorIndicesPosition =
-            rewriter.create<mlir::AddIOp>(loc, vectorIndicesPosition, c1);
+            rewriter.create<arith::AddIOp>(loc, vectorIndicesPosition, c1);
         Value nextUpdatedVectorIndicesValue = rewriter.create<memref::LoadOp>(
             loc, vectorIndices, nextVectorIndicesPosition);
 
@@ -2940,7 +2971,7 @@ private:
     }
 
     Value outputNNZ_i64 =
-        rewriter.create<IndexCastOp>(loc, outputNNZ, int64Type);
+        rewriter.create<arith::IndexCastOp>(loc, outputNNZ, int64Type);
     rewriter.create<memref::StoreOp>(loc, outputNNZ_i64, outputPointers,
                                      vectorLength);
 
@@ -2983,9 +3014,9 @@ private:
                                    loc, rewriter.getFloatAttr(valueType, 1.0));
                              });
 
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
-    Value c2 = rewriter.create<ConstantIndexOp>(loc, 2);
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value c2 = rewriter.create<arith::ConstantIndexOp>(loc, 2);
 
     Value nrows = rewriter.create<graphblas::NumRowsOp>(loc, matrix);
 
@@ -3027,7 +3058,7 @@ private:
 
       Value matrixRowIndex = outputNNZLoop.getInductionVar();
       Value nextMatrixRowIndex =
-          rewriter.create<AddIOp>(loc, matrixRowIndex, c1);
+          rewriter.create<arith::AddIOp>(loc, matrixRowIndex, c1);
 
       Value firstPtr_i64 =
           rewriter.create<memref::LoadOp>(loc, matrixPointers, matrixRowIndex);
@@ -3035,12 +3066,12 @@ private:
                                                             nextMatrixRowIndex);
 
       Value firstPtr =
-          rewriter.create<IndexCastOp>(loc, firstPtr_i64, indexType);
+          rewriter.create<arith::IndexCastOp>(loc, firstPtr_i64, indexType);
       Value secondPtr =
-          rewriter.create<IndexCastOp>(loc, secondPtr_i64, indexType);
+          rewriter.create<arith::IndexCastOp>(loc, secondPtr_i64, indexType);
 
       Value matrixRowIndex_i64 =
-          rewriter.create<IndexCastOp>(loc, matrixRowIndex, int64Type);
+          rewriter.create<arith::IndexCastOp>(loc, matrixRowIndex, int64Type);
 
       scf::WhileOp findDiagonalWhileLoop = rewriter.create<scf::WhileOp>(
           loc, TypeRange{indexType, int1Type}, ValueRange{firstPtr, c1_i1});
@@ -3055,10 +3086,10 @@ private:
         Value ptr = findDiagonalWhileLoopBefore->getArgument(0);
         Value diagonalPositionNotFound =
             findDiagonalWhileLoopBefore->getArgument(1);
-        Value morePtrs = rewriter.create<CmpIOp>(
-            op.getLoc(), CmpIPredicate::ult, ptr, secondPtr);
+        Value morePtrs = rewriter.create<arith::CmpIOp>(
+            op.getLoc(), arith::CmpIPredicate::ult, ptr, secondPtr);
         Value continueCondition =
-            rewriter.create<AndOp>(loc, diagonalPositionNotFound, morePtrs);
+            rewriter.create<arith::AndIOp>(loc, diagonalPositionNotFound, morePtrs);
         rewriter.create<scf::ConditionOp>(
             loc, continueCondition, ValueRange{ptr, diagonalPositionNotFound});
       }
@@ -3068,10 +3099,10 @@ private:
         Value currentPtr = findDiagonalWhileLoopAfter->getArgument(0);
         Value elementColumnIndex_i64 =
             rewriter.create<memref::LoadOp>(loc, matrixIndices, currentPtr);
-        Value isNotDiagonalPosition =
-            rewriter.create<CmpIOp>(op.getLoc(), CmpIPredicate::ne,
-                                    elementColumnIndex_i64, matrixRowIndex_i64);
-        Value nextPtr = rewriter.create<AddIOp>(loc, currentPtr, c1);
+        Value isNotDiagonalPosition = rewriter.create<arith::CmpIOp>(
+            op.getLoc(), arith::CmpIPredicate::ne, elementColumnIndex_i64,
+            matrixRowIndex_i64);
+        Value nextPtr = rewriter.create<arith::AddIOp>(loc, currentPtr, c1);
         rewriter.create<scf::YieldOp>(
             loc, ValueRange{nextPtr, isNotDiagonalPosition});
         rewriter.setInsertionPointAfter(findDiagonalWhileLoop);
@@ -3087,7 +3118,7 @@ private:
       {
         rewriter.setInsertionPointToStart(ifDiagonalNotFoundBlock.elseBlock());
         Value nextNumDiagonalContainingRows =
-            rewriter.create<AddIOp>(loc, numDiagonalContainingRows, c1);
+            rewriter.create<arith::AddIOp>(loc, numDiagonalContainingRows, c1);
         rewriter.create<scf::YieldOp>(
             loc, ValueRange{nextNumDiagonalContainingRows});
       }
@@ -3109,7 +3140,7 @@ private:
     Value outputPointers = rewriter.create<sparse_tensor::ToPointersOp>(
         loc, memref1DI64Type, output, c0);
     Value outputNNZ_i64 =
-        rewriter.create<IndexCastOp>(loc, outputNNZ, int64Type);
+        rewriter.create<arith::IndexCastOp>(loc, outputNNZ, int64Type);
     rewriter.create<memref::StoreOp>(loc, outputNNZ_i64, outputPointers, c1);
 
     Value outputIndices = rewriter.create<sparse_tensor::ToIndicesOp>(
@@ -3126,19 +3157,19 @@ private:
       rewriter.setInsertionPointToStart(
           outputValueAndIncidesFillingLoop.getBody());
 
-      Value nextRowIndex = rewriter.create<AddIOp>(loc, rowIndex, c1);
+      Value nextRowIndex = rewriter.create<arith::AddIOp>(loc, rowIndex, c1);
       Value firstPtr_i64 =
           rewriter.create<memref::LoadOp>(loc, matrixPointers, rowIndex);
       Value secondPtr_i64 =
           rewriter.create<memref::LoadOp>(loc, matrixPointers, nextRowIndex);
 
       Value firstPtr =
-          rewriter.create<IndexCastOp>(loc, firstPtr_i64, indexType);
+          rewriter.create<arith::IndexCastOp>(loc, firstPtr_i64, indexType);
       Value secondPtr =
-          rewriter.create<IndexCastOp>(loc, secondPtr_i64, indexType);
+          rewriter.create<arith::IndexCastOp>(loc, secondPtr_i64, indexType);
 
       Value rowIndex_i64 =
-          rewriter.create<IndexCastOp>(loc, rowIndex, int64Type);
+          rewriter.create<arith::IndexCastOp>(loc, rowIndex, int64Type);
 
       // instead of having a var for whether or not a diagonal value was found
       // and the value itself, we could just track whether or not the diagonal
@@ -3168,10 +3199,10 @@ private:
             findDiagonalWhileLoopBefore->getArgument(2);
         rewriter.setInsertionPointToStart(
             &findDiagonalWhileLoop.before().front());
-        Value morePtrs = rewriter.create<CmpIOp>(
-            op.getLoc(), CmpIPredicate::ult, ptr, secondPtr);
+        Value morePtrs = rewriter.create<arith::CmpIOp>(
+            op.getLoc(), arith::CmpIPredicate::ult, ptr, secondPtr);
         Value continueCondition =
-            rewriter.create<AndOp>(loc, diagonalPositionNotFound, morePtrs);
+            rewriter.create<arith::AndIOp>(loc, diagonalPositionNotFound, morePtrs);
         rewriter.create<scf::ConditionOp>(
             loc, continueCondition,
             ValueRange{ptr, diagonalPositionNotFound, currentDiagonalValue});
@@ -3185,7 +3216,7 @@ private:
         Value elementColumnIndex_i64 =
             rewriter.create<memref::LoadOp>(loc, matrixIndices, currentPtr);
         Value isNotDiagonalPosition =
-            rewriter.create<CmpIOp>(op.getLoc(), CmpIPredicate::ne,
+            rewriter.create<arith::CmpIOp>(op.getLoc(), arith::CmpIPredicate::ne,
                                     elementColumnIndex_i64, rowIndex_i64);
 
         scf::IfOp ifDiagonalNotFoundBlock = rewriter.create<scf::IfOp>(
@@ -3207,7 +3238,7 @@ private:
         rewriter.setInsertionPointAfter(ifDiagonalNotFoundBlock);
         Value updatedDiagonalValue = ifDiagonalNotFoundBlock.getResult(0);
 
-        Value nextPtr = rewriter.create<AddIOp>(loc, currentPtr, c1);
+        Value nextPtr = rewriter.create<arith::AddIOp>(loc, currentPtr, c1);
         rewriter.create<scf::YieldOp>(
             loc,
             ValueRange{nextPtr, isNotDiagonalPosition, updatedDiagonalValue});
@@ -3229,7 +3260,7 @@ private:
                                          outputValuesPosition);
 
         Value nextOutputValuesPosition =
-            rewriter.create<AddIOp>(loc, outputValuesPosition, c1);
+            rewriter.create<arith::AddIOp>(loc, outputValuesPosition, c1);
         rewriter.create<scf::YieldOp>(loc,
                                       ValueRange{nextOutputValuesPosition});
       }
@@ -3313,9 +3344,9 @@ public:
     Type memref1DValueType = MemRefType::get({-1}, valueType);
 
     // Initial constants
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-    Value c0_64 = rewriter.create<ConstantIntOp>(loc, 0, int64Type);
-    Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value c0_64 = rewriter.create<arith::ConstantIntOp>(loc, 0, int64Type);
+    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
 
     // Get sparse tensor info
     Value nrow = rewriter.create<graphblas::NumRowsOp>(loc, input);
@@ -3341,21 +3372,21 @@ public:
     Value row = scanLoop.getInductionVar();
 
     rewriter.setInsertionPointToStart(scanLoop.getBody());
-    Value row_plus1 = rewriter.create<mlir::AddIOp>(loc, row, c1);
+    Value row_plus1 = rewriter.create<arith::AddIOp>(loc, row, c1);
     Value Aj_start_64 = rewriter.create<memref::LoadOp>(loc, Ap, row);
     Value Aj_end_64 = rewriter.create<memref::LoadOp>(loc, Ap, row_plus1);
 
     // Limit number of row values in output to n
     Value Aj_size_64 =
-        rewriter.create<mlir::SubIOp>(loc, Aj_end_64, Aj_start_64);
-    Value isRowSmall = rewriter.create<mlir::CmpIOp>(
-        loc, mlir::CmpIPredicate::ule, Aj_size_64, n);
+        rewriter.create<arith::SubIOp>(loc, Aj_end_64, Aj_start_64);
+    Value isRowSmall = rewriter.create<arith::CmpIOp>(
+        loc, arith::CmpIPredicate::ule, Aj_size_64, n);
     Value Bj_size_64 =
-        rewriter.create<mlir::SelectOp>(loc, isRowSmall, Aj_size_64, n);
+        rewriter.create<SelectOp>(loc, isRowSmall, Aj_size_64, n);
 
     Value Bj_start_64 = rewriter.create<memref::LoadOp>(loc, Bp, row);
     Value Bj_end_64 =
-        rewriter.create<mlir::AddIOp>(loc, Bj_start_64, Bj_size_64);
+        rewriter.create<arith::AddIOp>(loc, Bj_start_64, Bj_size_64);
     rewriter.create<memref::StoreOp>(loc, Bj_end_64, Bp, row_plus1);
 
     rewriter.setInsertionPointAfter(scanLoop);
@@ -3367,25 +3398,25 @@ public:
 
     rewriter.setInsertionPointToStart(rowLoop.getBody());
 
-    row_plus1 = rewriter.create<mlir::AddIOp>(loc, row, c1);
+    row_plus1 = rewriter.create<arith::AddIOp>(loc, row, c1);
     Aj_start_64 = rewriter.create<memref::LoadOp>(loc, Ap, row);
     Value Aj_start =
-        rewriter.create<mlir::IndexCastOp>(loc, Aj_start_64, indexType);
+        rewriter.create<arith::IndexCastOp>(loc, Aj_start_64, indexType);
     Aj_end_64 = rewriter.create<memref::LoadOp>(loc, Ap, row_plus1);
     Value Aj_end =
-        rewriter.create<mlir::IndexCastOp>(loc, Aj_end_64, indexType);
+        rewriter.create<arith::IndexCastOp>(loc, Aj_end_64, indexType);
     Bj_start_64 = rewriter.create<memref::LoadOp>(loc, Bp, row);
     Value Bj_start =
-        rewriter.create<mlir::IndexCastOp>(loc, Bj_start_64, indexType);
+        rewriter.create<arith::IndexCastOp>(loc, Bj_start_64, indexType);
     Bj_end_64 = rewriter.create<memref::LoadOp>(loc, Bp, row_plus1);
     Value Bj_end =
-        rewriter.create<mlir::IndexCastOp>(loc, Bj_end_64, indexType);
+        rewriter.create<arith::IndexCastOp>(loc, Bj_end_64, indexType);
 
-    Value Aj_size = rewriter.create<mlir::SubIOp>(loc, Aj_end, Aj_start);
-    Aj_size_64 = rewriter.create<mlir::IndexCastOp>(loc, Aj_size, int64Type);
-    Value Bj_size = rewriter.create<mlir::SubIOp>(loc, Bj_end, Bj_start);
-    Bj_size_64 = rewriter.create<mlir::IndexCastOp>(loc, Bj_size, int64Type);
-    Value copyRow = rewriter.create<mlir::CmpIOp>(loc, mlir::CmpIPredicate::eq,
+    Value Aj_size = rewriter.create<arith::SubIOp>(loc, Aj_end, Aj_start);
+    Aj_size_64 = rewriter.create<arith::IndexCastOp>(loc, Aj_size, int64Type);
+    Value Bj_size = rewriter.create<arith::SubIOp>(loc, Bj_end, Bj_start);
+    Bj_size_64 = rewriter.create<arith::IndexCastOp>(loc, Bj_size, int64Type);
+    Value copyRow = rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
                                                   Aj_size, Bj_size);
 
     // Create output subviews
@@ -3432,7 +3463,7 @@ public:
     Value sourceOffset_64 =
         rewriter.create<memref::LoadOp>(loc, Bj_view, offset);
     Value sourceOffset =
-        rewriter.create<mlir::IndexCastOp>(loc, sourceOffset_64, indexType);
+        rewriter.create<arith::IndexCastOp>(loc, sourceOffset_64, indexType);
     Value colIndex =
         rewriter.create<memref::LoadOp>(loc, Aj_view, sourceOffset);
     Value colValue =
@@ -3451,7 +3482,7 @@ public:
     // Resize output index and values to match total number of elements
     Value outputNNZ_64 = rewriter.create<memref::LoadOp>(loc, Bp, nrow);
     Value outputNNZ =
-        rewriter.create<mlir::IndexCastOp>(loc, outputNNZ_64, indexType);
+        rewriter.create<arith::IndexCastOp>(loc, outputNNZ_64, indexType);
     callResizeIndex(rewriter, module, loc, output, c1, outputNNZ);
     callResizeValues(rewriter, module, loc, output, outputNNZ);
 

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASUtils.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASUtils.cpp
@@ -1,3 +1,4 @@
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
@@ -237,7 +238,7 @@ void callPrintString(OpBuilder &builder, ModuleOp &mod, Location loc,
   for (char character : string) {
     int64_t character_int = (int64_t)character;
     Value character_int_i64 =
-        builder.create<ConstantIntOp>(loc, character_int, int64Type);
+        builder.create<arith::ConstantIntOp>(loc, character_int, int64Type);
     builder.create<CallOp>(loc, funcSymbol, TypeRange(),
                            llvm::ArrayRef<Value>({character_int_i64}));
   }
@@ -512,10 +513,12 @@ LogicalResult populateSemiringAdd(OpBuilder &builder, Location loc,
     addIdentity =
         llvm::TypeSwitch<Type, Value>(valueType)
             .Case<IntegerType>([&](IntegerType type) {
-              return builder.create<ConstantIntOp>(loc, 0, type.getWidth());
+              return builder.create<arith::ConstantIntOp>(loc, 0,
+                                                          type.getWidth());
             })
             .Case<FloatType>([&](FloatType type) {
-              return builder.create<ConstantFloatOp>(loc, APFloat(0.0), type);
+              return builder.create<arith::ConstantFloatOp>(loc, APFloat(0.0),
+                                                            type);
             });
   } else if (addName == "min") {
     addIdentity =
@@ -550,22 +553,27 @@ LogicalResult populateSemiringAdd(OpBuilder &builder, Location loc,
     addResult =
         llvm::TypeSwitch<Type, Value>(valueType)
             .Case<IntegerType>([&](IntegerType type) {
-              return builder.create<AddIOp>(loc, addBlockArg0, addBlockArg1);
+              return builder.create<arith::AddIOp>(loc, addBlockArg0,
+                                                   addBlockArg1);
             })
             .Case<FloatType>([&](FloatType type) {
-              return builder.create<AddFOp>(loc, addBlockArg0, addBlockArg1);
+              return builder.create<arith::AddFOp>(loc, addBlockArg0,
+                                                   addBlockArg1);
             });
   } else if (addName == "min") {
     Value cmp = llvm::TypeSwitch<Type, Value>(valueType)
                     .Case<IntegerType>([&](IntegerType type) {
-                      return builder.create<CmpIOp>(loc, CmpIPredicate::slt,
-                                                    addBlockArg0, addBlockArg1);
+                      return builder.create<arith::CmpIOp>(
+                          loc, arith::CmpIPredicate::slt, addBlockArg0,
+                          addBlockArg1);
                     })
                     .Case<FloatType>([&](FloatType type) {
-                      return builder.create<CmpFOp>(loc, CmpFPredicate::OLT,
-                                                    addBlockArg0, addBlockArg1);
+                      return builder.create<arith::CmpFOp>(
+                          loc, arith::CmpFPredicate::OLT, addBlockArg0,
+                          addBlockArg1);
                     });
-    addResult = builder.create<SelectOp>(loc, cmp, addBlockArg0, addBlockArg1);
+    addResult =
+        builder.create<SelectOp>(loc, cmp, addBlockArg0, addBlockArg1);
   } else if (addName == "any") {
     // Same as "second" for multiplicative op?
     // https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/master/GraphBLAS/Source/Template/GB_binop_factory.c#L243-L244
@@ -597,28 +605,33 @@ LogicalResult populateSemiringMultiply(OpBuilder &builder, Location loc,
     multResult =
         llvm::TypeSwitch<Type, Value>(valueType)
             .Case<IntegerType>([&](IntegerType type) {
-              return builder.create<ConstantIntOp>(loc, 1, type.getWidth());
+              return builder.create<arith::ConstantIntOp>(loc, 1, type.getWidth());
             })
             .Case<FloatType>([&](FloatType type) {
-              return builder.create<ConstantFloatOp>(loc, APFloat(1.0), type);
+              return builder.create<arith::ConstantFloatOp>(loc, APFloat(1.0),
+                                                            type);
             });
   } else if (multiplyName == "times") {
     multResult =
         llvm::TypeSwitch<Type, Value>(valueType)
             .Case<IntegerType>([&](IntegerType type) {
-              return builder.create<MulIOp>(loc, multBlockArg0, multBlockArg1);
+              return builder.create<arith::MulIOp>(loc, multBlockArg0,
+                                                   multBlockArg1);
             })
             .Case<FloatType>([&](FloatType type) {
-              return builder.create<MulFOp>(loc, multBlockArg0, multBlockArg1);
+              return builder.create<arith::MulFOp>(loc, multBlockArg0,
+                                                   multBlockArg1);
             });
   } else if (multiplyName == "plus") {
     multResult =
         llvm::TypeSwitch<Type, Value>(valueType)
             .Case<IntegerType>([&](IntegerType type) {
-              return builder.create<AddIOp>(loc, multBlockArg0, multBlockArg1);
+              return builder.create<arith::AddIOp>(loc, multBlockArg0,
+                                                   multBlockArg1);
             })
             .Case<FloatType>([&](FloatType type) {
-              return builder.create<AddFOp>(loc, multBlockArg0, multBlockArg1);
+              return builder.create<arith::AddFOp>(loc, multBlockArg0,
+                                                   multBlockArg1);
             });
   } else if (multiplyName == "first") {
     multResult = multBlockArg0;

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASUtils.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASUtils.cpp
@@ -510,16 +510,15 @@ LogicalResult populateSemiringAdd(OpBuilder &builder, Location loc,
   /*Block *addIdentityBlock = */ builder.createBlock(addIdentityRegion, {}, {});
   if (addName == "plus" || addName == "any") {
     // Add identity
-    addIdentity =
-        llvm::TypeSwitch<Type, Value>(valueType)
-            .Case<IntegerType>([&](IntegerType type) {
-              return builder.create<arith::ConstantIntOp>(loc, 0,
-                                                          type.getWidth());
-            })
-            .Case<FloatType>([&](FloatType type) {
-              return builder.create<arith::ConstantFloatOp>(loc, APFloat(0.0),
-                                                            type);
-            });
+    addIdentity = llvm::TypeSwitch<Type, Value>(valueType)
+                      .Case<IntegerType>([&](IntegerType type) {
+                        return builder.create<arith::ConstantIntOp>(
+                            loc, 0, type.getWidth());
+                      })
+                      .Case<FloatType>([&](FloatType type) {
+                        return builder.create<arith::ConstantFloatOp>(
+                            loc, APFloat(0.0), type);
+                      });
   } else if (addName == "min") {
     addIdentity =
         llvm::TypeSwitch<Type, Value>(valueType)
@@ -550,30 +549,27 @@ LogicalResult populateSemiringAdd(OpBuilder &builder, Location loc,
   Value addResult;
   if (addName == "plus") {
     // Insert add operation
-    addResult =
-        llvm::TypeSwitch<Type, Value>(valueType)
-            .Case<IntegerType>([&](IntegerType type) {
-              return builder.create<arith::AddIOp>(loc, addBlockArg0,
-                                                   addBlockArg1);
-            })
-            .Case<FloatType>([&](FloatType type) {
-              return builder.create<arith::AddFOp>(loc, addBlockArg0,
-                                                   addBlockArg1);
-            });
-  } else if (addName == "min") {
-    Value cmp = llvm::TypeSwitch<Type, Value>(valueType)
+    addResult = llvm::TypeSwitch<Type, Value>(valueType)
                     .Case<IntegerType>([&](IntegerType type) {
-                      return builder.create<arith::CmpIOp>(
-                          loc, arith::CmpIPredicate::slt, addBlockArg0,
-                          addBlockArg1);
+                      return builder.create<arith::AddIOp>(loc, addBlockArg0,
+                                                           addBlockArg1);
                     })
                     .Case<FloatType>([&](FloatType type) {
-                      return builder.create<arith::CmpFOp>(
-                          loc, arith::CmpFPredicate::OLT, addBlockArg0,
-                          addBlockArg1);
+                      return builder.create<arith::AddFOp>(loc, addBlockArg0,
+                                                           addBlockArg1);
                     });
-    addResult =
-        builder.create<SelectOp>(loc, cmp, addBlockArg0, addBlockArg1);
+  } else if (addName == "min") {
+    Value cmp =
+        llvm::TypeSwitch<Type, Value>(valueType)
+            .Case<IntegerType>([&](IntegerType type) {
+              return builder.create<arith::CmpIOp>(
+                  loc, arith::CmpIPredicate::slt, addBlockArg0, addBlockArg1);
+            })
+            .Case<FloatType>([&](FloatType type) {
+              return builder.create<arith::CmpFOp>(
+                  loc, arith::CmpFPredicate::OLT, addBlockArg0, addBlockArg1);
+            });
+    addResult = builder.create<SelectOp>(loc, cmp, addBlockArg0, addBlockArg1);
   } else if (addName == "any") {
     // Same as "second" for multiplicative op?
     // https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/master/GraphBLAS/Source/Template/GB_binop_factory.c#L243-L244
@@ -602,37 +598,35 @@ LogicalResult populateSemiringMultiply(OpBuilder &builder, Location loc,
   Value multResult;
 
   if (multiplyName == "pair") {
-    multResult =
-        llvm::TypeSwitch<Type, Value>(valueType)
-            .Case<IntegerType>([&](IntegerType type) {
-              return builder.create<arith::ConstantIntOp>(loc, 1, type.getWidth());
-            })
-            .Case<FloatType>([&](FloatType type) {
-              return builder.create<arith::ConstantFloatOp>(loc, APFloat(1.0),
-                                                            type);
-            });
+    multResult = llvm::TypeSwitch<Type, Value>(valueType)
+                     .Case<IntegerType>([&](IntegerType type) {
+                       return builder.create<arith::ConstantIntOp>(
+                           loc, 1, type.getWidth());
+                     })
+                     .Case<FloatType>([&](FloatType type) {
+                       return builder.create<arith::ConstantFloatOp>(
+                           loc, APFloat(1.0), type);
+                     });
   } else if (multiplyName == "times") {
-    multResult =
-        llvm::TypeSwitch<Type, Value>(valueType)
-            .Case<IntegerType>([&](IntegerType type) {
-              return builder.create<arith::MulIOp>(loc, multBlockArg0,
-                                                   multBlockArg1);
-            })
-            .Case<FloatType>([&](FloatType type) {
-              return builder.create<arith::MulFOp>(loc, multBlockArg0,
-                                                   multBlockArg1);
-            });
+    multResult = llvm::TypeSwitch<Type, Value>(valueType)
+                     .Case<IntegerType>([&](IntegerType type) {
+                       return builder.create<arith::MulIOp>(loc, multBlockArg0,
+                                                            multBlockArg1);
+                     })
+                     .Case<FloatType>([&](FloatType type) {
+                       return builder.create<arith::MulFOp>(loc, multBlockArg0,
+                                                            multBlockArg1);
+                     });
   } else if (multiplyName == "plus") {
-    multResult =
-        llvm::TypeSwitch<Type, Value>(valueType)
-            .Case<IntegerType>([&](IntegerType type) {
-              return builder.create<arith::AddIOp>(loc, multBlockArg0,
-                                                   multBlockArg1);
-            })
-            .Case<FloatType>([&](FloatType type) {
-              return builder.create<arith::AddFOp>(loc, multBlockArg0,
-                                                   multBlockArg1);
-            });
+    multResult = llvm::TypeSwitch<Type, Value>(valueType)
+                     .Case<IntegerType>([&](IntegerType type) {
+                       return builder.create<arith::AddIOp>(loc, multBlockArg0,
+                                                            multBlockArg1);
+                     })
+                     .Case<FloatType>([&](FloatType type) {
+                       return builder.create<arith::AddFOp>(loc, multBlockArg0,
+                                                            multBlockArg1);
+                     });
   } else if (multiplyName == "first") {
     multResult = multBlockArg0;
   } else if (multiplyName == "second") {

--- a/mlir_graphblas/src/test/GraphBLAS/check_ops.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/check_ops.mlir
@@ -64,8 +64,8 @@ module {
 
     // CHECK: func @matrix_select_gt_thunk(%[[ARG0:.*]]: [[CSR_TYPE:tensor<.*->.*>]]) -> [[CSR_TYPE]] {
     func @matrix_select_gt_thunk(%sparse_tensor: tensor<100x100xf64, #CSR64>) -> tensor<100x100xf64, #CSR64> {
-        // CHECK-NEXT: %[[THUNK:.*]] = constant 0.000000e+00 : [[THUNK_TYPE:.*]]
-        %thunk = constant 0.0 : f64
+        // CHECK-NEXT: %[[THUNK:.*]] = arith.constant 0.000000e+00 : [[THUNK_TYPE:.*]]
+        %thunk = arith.constant 0.0 : f64
         // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.select %[[ARG0]], %[[THUNK]] {selectors = ["gt"]} : [[CSR_TYPE]], [[THUNK_TYPE]] to [[CSR_TYPE]]
         %answer = graphblas.select %sparse_tensor, %thunk { selectors = ["gt"] } : tensor<100x100xf64, #CSR64>, f64 to tensor<100x100xf64, #CSR64>
         // CHECK-NEXT: return %[[ANSWER]] : [[CSR_TYPE]]
@@ -114,8 +114,8 @@ module {
 
     // CHECK: func @apply_matrix_min(%[[ARG0:.*]]: [[CSR_TYPE:tensor<.*->.*>]]) -> [[RETURN_TYPE:.*]] {
     func @apply_matrix_min(%sparse_tensor: tensor<2x3xi64, #CSR64>) -> tensor<2x3xi64, #CSR64> {
-        // CHECK-NEXT: %[[THUNK:.*]] = constant 100 : [[THUNK_TYPE:.*]]
-        %thunk = constant 100 : i64
+        // CHECK-NEXT: %[[THUNK:.*]] = arith.constant 100 : [[THUNK_TYPE:.*]]
+        %thunk = arith.constant 100 : i64
         // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.apply %[[ARG0]], %[[THUNK]] {apply_operator = "min"} : ([[CSR_TYPE]], [[THUNK_TYPE]]) to [[CSR_TYPE]]
         %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "min" } : (tensor<2x3xi64, #CSR64>, i64) to tensor<2x3xi64, #CSR64>
         // CHECK-NEXT: return %[[ANSWER]] : [[RETURN_TYPE]]
@@ -124,8 +124,8 @@ module {
    
     // CHECK: func @apply_vector_min(%[[ARG0:.*]]: [[VECTOR_TYPE:tensor<.*>]]) -> [[RETURN_TYPE:.*]] {
     func @apply_vector_min(%sparse_tensor: tensor<3xi64, #CV64>) -> tensor<3xi64, #CV64> {
-        // CHECK-NEXT: %[[THUNK:.*]] = constant 100 : [[THUNK_TYPE:.*]]
-        %thunk = constant 100 : i64
+        // CHECK-NEXT: %[[THUNK:.*]] = arith.constant 100 : [[THUNK_TYPE:.*]]
+        %thunk = arith.constant 100 : i64
         // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.apply %[[ARG0]], %[[THUNK]] {apply_operator = "min"} : ([[VECTOR_TYPE]], [[THUNK_TYPE]]) to [[VECTOR_TYPE]]
         %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "min" } : (tensor<3xi64, #CV64>, i64) to tensor<3xi64, #CV64>
         // CHECK-NEXT: return %[[ANSWER]] : [[RETURN_TYPE]]
@@ -198,8 +198,8 @@ module {
 
     // CHECK: func @apply_matrix_left_div(%[[ARG0:.*]]: [[CSR_TYPE:tensor<.*->.*>]]) -> [[RETURN_TYPE:.*]] {
     func @apply_matrix_left_div(%sparse_tensor: tensor<2x3xi64, #CSR64>) -> tensor<2x3xi64, #CSR64> {
-        // CHECK-NEXT: %[[THUNK:.*]] = constant 100 : [[THUNK_TYPE:.*]]
-        %thunk = constant 100 : i64
+        // CHECK-NEXT: %[[THUNK:.*]] = arith.constant 100 : [[THUNK_TYPE:.*]]
+        %thunk = arith.constant 100 : i64
         // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.apply %[[THUNK]], %[[ARG0]] {apply_operator = "div"} : ([[THUNK_TYPE]], [[CSR_TYPE]]) to [[CSR_TYPE]]
         %answer = graphblas.apply %thunk, %sparse_tensor { apply_operator = "div" } : (i64, tensor<2x3xi64, #CSR64>) to tensor<2x3xi64, #CSR64>
         // CHECK-NEXT: return %[[ANSWER]] : [[RETURN_TYPE]]
@@ -208,8 +208,8 @@ module {
    
     // CHECK: func @apply_vector_left_div(%[[ARG0:.*]]: [[VECTOR_TYPE:tensor<.*>]]) -> [[RETURN_TYPE:.*]] {
     func @apply_vector_left_div(%sparse_tensor: tensor<3xi64, #CV64>) -> tensor<3xi64, #CV64> {
-        // CHECK-NEXT: %[[THUNK:.*]] = constant 100 : [[THUNK_TYPE:.*]]
-        %thunk = constant 100 : i64
+        // CHECK-NEXT: %[[THUNK:.*]] = arith.constant 100 : [[THUNK_TYPE:.*]]
+        %thunk = arith.constant 100 : i64
         // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.apply %[[THUNK]], %[[ARG0]] {apply_operator = "div"} : ([[THUNK_TYPE]], [[VECTOR_TYPE]]) to [[VECTOR_TYPE]]
         %answer = graphblas.apply %thunk, %sparse_tensor { apply_operator = "div" } : (i64, tensor<3xi64, #CV64>) to tensor<3xi64, #CV64>
         // CHECK-NEXT: return %[[ANSWER]] : [[RETURN_TYPE]]
@@ -218,8 +218,8 @@ module {
 
     // CHECK: func @apply_matrix_right_div(%[[ARG0:.*]]: [[CSR_TYPE:tensor<.*->.*>]]) -> [[RETURN_TYPE:.*]] {
     func @apply_matrix_right_div(%sparse_tensor: tensor<2x3xi64, #CSR64>) -> tensor<2x3xi64, #CSR64> {
-        // CHECK-NEXT: %[[THUNK:.*]] = constant 100 : [[THUNK_TYPE:.*]]
-        %thunk = constant 100 : i64
+        // CHECK-NEXT: %[[THUNK:.*]] = arith.constant 100 : [[THUNK_TYPE:.*]]
+        %thunk = arith.constant 100 : i64
         // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.apply %[[ARG0]], %[[THUNK]] {apply_operator = "div"} : ([[CSR_TYPE]], [[THUNK_TYPE]]) to [[CSR_TYPE]]
         %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "div" } : (tensor<2x3xi64, #CSR64>, i64) to tensor<2x3xi64, #CSR64>
         // CHECK-NEXT: return %[[ANSWER]] : [[RETURN_TYPE]]
@@ -228,8 +228,8 @@ module {
    
     // CHECK: func @apply_vector_right_div(%[[ARG0:.*]]: [[VECTOR_TYPE:tensor<.*>]]) -> [[RETURN_TYPE:.*]] {
     func @apply_vector_right_div(%sparse_tensor: tensor<3xi64, #CV64>) -> tensor<3xi64, #CV64> {
-        // CHECK-NEXT: %[[THUNK:.*]] = constant 100 : [[THUNK_TYPE:.*]]
-        %thunk = constant 100 : i64
+        // CHECK-NEXT: %[[THUNK:.*]] = arith.constant 100 : [[THUNK_TYPE:.*]]
+        %thunk = arith.constant 100 : i64
         // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.apply %[[ARG0]], %[[THUNK]] {apply_operator = "div"} : ([[VECTOR_TYPE]], [[THUNK_TYPE]]) to [[VECTOR_TYPE]]
         %answer = graphblas.apply %sparse_tensor, %thunk { apply_operator = "div" } : (tensor<3xi64, #CV64>, i64) to tensor<3xi64, #CV64>
         // CHECK-NEXT: return %[[ANSWER]] : [[RETURN_TYPE]]
@@ -382,8 +382,8 @@ module {
 
     // CHECK: func @print_wrapper() {
     func @print_wrapper() -> () {
-    	// CHECK-NEXT: %[[VAL_0:.*]] = constant 0.000000e+00 : f32
-        %0 = constant 0.0 : f32
+    	// CHECK-NEXT: %[[VAL_0:.*]] = arith.constant 0.000000e+00 : f32
+        %0 = arith.constant 0.0 : f32
 	// CHECK-NEXT: graphblas.print %[[VAL_0]], %[[VAL_0]] {strings = ["start ", " middle ", " end"]} : f32, f32
 	graphblas.print %0, %0 { strings = ["start ", " middle ", " end"] } : f32, f32
         // CHECK-NEXT: return

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_select.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_select.mlir
@@ -57,7 +57,7 @@ module {
 
 module {
     func @matrix_select_wrapper(%sparse_tensor: tensor<2x3xbf16, #CSR64>) -> tensor<2x3xbf16, #CSR64> {
-        %thunk = constant 0.0 : f64
+        %thunk = arith.constant 0.0 : f64
         %answer = graphblas.select %sparse_tensor, %thunk { selectors = ["gt"] } : tensor<2x3xbf16, #CSR64>, f64 to tensor<2x3xbf16, #CSR64> // expected-error {{Operand #1 is associated with the selector "gt", but has a different type than the input tensor's element type.}}
         return %answer : tensor<2x3xbf16, #CSR64>
     }
@@ -90,7 +90,7 @@ module {
 
 module {
     func @matrix_select_wrapper(%sparse_tensor: tensor<2x3xbf16, #CSR64>) -> (tensor<2x3xbf16, #CSR64>, tensor<2x3xbf16, #CSR64>) {
-        %thunk = constant 0.0 : bf16
+        %thunk = arith.constant 0.0 : bf16
         %answer_0, %answer_1 = graphblas.select %sparse_tensor, %thunk { selectors = ["gt", "triu"] } : tensor<2x3xbf16, #CSR64> to tensor<2x3xbf16, #CSR64>, tensor<2x3xbf16, #CSR64> // expected-error {{custom op 'graphblas.select' 1 operands present, but expected 0}}
         return %answer_0, %answer_1 : tensor<2x3xbf16, #CSR64>, tensor<2x3xbf16, #CSR64>
     }
@@ -107,7 +107,7 @@ module {
 
 module {
     func @matrix_select_wrapper(%sparse_tensor: tensor<2x3xbf16, #CSR64>) -> (tensor<2x3xbf16, #CSR64>, tensor<2x3xbf16, #CSR64>) {
-        %thunk = constant 0.0 : bf16
+        %thunk = arith.constant 0.0 : bf16
         %answer_0, %answer_1 = graphblas.select %sparse_tensor, %thunk { selectors = ["gt", "triu"] } : tensor<2x3xbf16, #CSR64>, bf16, bf16 to tensor<2x3xbf16, #CSR64>, tensor<2x3xbf16, #CSR64> // expected-error {{custom op 'graphblas.select' 1 operands present, but expected 2}}
         return %answer_0, %answer_1 : tensor<2x3xbf16, #CSR64>, tensor<2x3xbf16, #CSR64>
     }
@@ -124,7 +124,7 @@ module {
 
 module {
     func @matrix_select_wrapper(%sparse_tensor: tensor<2x3xbf16, #CSR64>) -> (tensor<2x3xbf16, #CSR64>, tensor<2x3xbf16, #CSR64>) {
-        %thunk = constant 0.0 : bf16
+        %thunk = arith.constant 0.0 : bf16
         %answer_0, %answer_1 = graphblas.select %sparse_tensor, %thunk { selectors = ["triu"] } : tensor<2x3xbf16, #CSR64>, bf16 to tensor<2x3xbf16, #CSR64>, tensor<2x3xbf16, #CSR64> // expected-error {{No selectors need thunks, but 1 thunks were given.}}
         return %answer_0, %answer_1 : tensor<2x3xbf16, #CSR64>, tensor<2x3xbf16, #CSR64>
     }
@@ -141,7 +141,7 @@ module {
 
 module {
     func @matrix_select_wrapper(%sparse_tensor: tensor<2x3xbf16, #CSR64>) -> (tensor<2x3xbf16, #CSR64>, tensor<2x3xbf16, #CSR64>) {
-        %thunk = constant 0.0 : bf16
+        %thunk = arith.constant 0.0 : bf16
         %answer_0, %answer_1 = graphblas.select %sparse_tensor, %thunk { selectors = ["tril", "triu"] } : tensor<2x3xbf16, #CSR64>, bf16 to tensor<2x3xbf16, #CSR64>, tensor<2x3xbf16, #CSR64> // expected-error {{No selectors need thunks, but 1 thunks were given.}}
         return %answer_0, %answer_1 : tensor<2x3xbf16, #CSR64>, tensor<2x3xbf16, #CSR64>
     }
@@ -158,7 +158,7 @@ module {
 
 module {
     func @matrix_select_wrapper(%sparse_tensor: tensor<2x3xbf16, #CSR64>) -> (tensor<2x3xbf16, #CSR64>, tensor<2x3xbf16, #CSR64>) {
-        %thunk = constant 0.0 : bf16
+        %thunk = arith.constant 0.0 : bf16
         %answer_0, %answer_1 = graphblas.select %sparse_tensor, %thunk { selectors = ["gt", "triu"] } : tensor<2x3xbf16, #CSR64> to tensor<2x3xbf16, #CSR64>, tensor<2x3xbf16, #CSR64> // expected-error {{custom op 'graphblas.select' 1 operands present, but expected 0}}
         return %answer_0, %answer_1 : tensor<2x3xbf16, #CSR64>, tensor<2x3xbf16, #CSR64>
     }

--- a/mlir_graphblas/src/test/GraphBLAS/lower_apply_generic.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_apply_generic.mlir
@@ -16,8 +16,8 @@
 // CHECK-LABEL:   func @apply_min_matrix(
 // CHECK-SAME:                           %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                           %[[VAL_1:.*]]: f64) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK-DAG:       %[[VAL_2:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 0 : index
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_4:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_5:.*]] = call @dup_tensor(%[[VAL_4]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_6:.*]] = call @ptr8_to_matrix_csr_f64_p64i64(%[[VAL_5]]) : (!llvm.ptr<i8>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -26,10 +26,10 @@
 // CHECK:           %[[VAL_9:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_10:.*]] = tensor.dim %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_11:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_10]]] : memref<?xi64>
-// CHECK:           %[[VAL_12:.*]] = index_cast %[[VAL_11]] : i64 to index
+// CHECK:           %[[VAL_12:.*]] = arith.index_cast %[[VAL_11]] : i64 to index
 // CHECK:           scf.parallel (%[[VAL_13:.*]]) = (%[[VAL_3]]) to (%[[VAL_12]]) step (%[[VAL_2]]) {
 // CHECK:             %[[VAL_14:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_13]]] : memref<?xf64>
-// CHECK:             %[[VAL_15:.*]] = cmpf olt, %[[VAL_14]], %[[VAL_1]] : f64
+// CHECK:             %[[VAL_15:.*]] = arith.cmpf olt, %[[VAL_14]], %[[VAL_1]] : f64
 // CHECK:             %[[VAL_16:.*]] = select %[[VAL_15]], %[[VAL_14]], %[[VAL_1]] : f64
 // CHECK:             memref.store %[[VAL_16]], %[[VAL_8]]{{\[}}%[[VAL_13]]] : memref<?xf64>
 // CHECK:             scf.yield
@@ -40,7 +40,7 @@
 func @apply_min_matrix(%sparse_tensor: tensor<?x?xf64, #CSR64>, %thunk: f64) -> tensor<?x?xf64, #CSR64> {
     %answer = graphblas.apply_generic %sparse_tensor : tensor<?x?xf64, #CSR64> to tensor<?x?xf64, #CSR64> {
       ^bb0(%val: f64):
-        %pick = cmpf olt, %val, %thunk : f64
+        %pick = arith.cmpf olt, %val, %thunk : f64
         %result = select %pick, %val, %thunk : f64
         graphblas.yield transform_out %result : f64
     }
@@ -50,8 +50,8 @@ func @apply_min_matrix(%sparse_tensor: tensor<?x?xf64, #CSR64>, %thunk: f64) -> 
 // CHECK-LABEL:   func @apply_min_vector(
 // CHECK-SAME:                           %[[VAL_0:.*]]: tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                           %[[VAL_1:.*]]: f64) -> tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK-DAG:       %[[VAL_2:.*]] = constant 0 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 1 : index
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : index
 // CHECK:           %[[VAL_4:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_5:.*]] = call @dup_tensor(%[[VAL_4]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_6:.*]] = call @ptr8_to_vector_f64_p64i64(%[[VAL_5]]) : (!llvm.ptr<i8>) -> tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -59,10 +59,10 @@ func @apply_min_matrix(%sparse_tensor: tensor<?x?xf64, #CSR64>, %thunk: f64) -> 
 // CHECK:           %[[VAL_8:.*]] = sparse_tensor.values %[[VAL_6]] : tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           %[[VAL_9:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_10:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_3]]] : memref<?xi64>
-// CHECK:           %[[VAL_11:.*]] = index_cast %[[VAL_10]] : i64 to index
+// CHECK:           %[[VAL_11:.*]] = arith.index_cast %[[VAL_10]] : i64 to index
 // CHECK:           scf.parallel (%[[VAL_12:.*]]) = (%[[VAL_2]]) to (%[[VAL_11]]) step (%[[VAL_3]]) {
 // CHECK:             %[[VAL_13:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_12]]] : memref<?xf64>
-// CHECK:             %[[VAL_14:.*]] = cmpf olt, %[[VAL_13]], %[[VAL_1]] : f64
+// CHECK:             %[[VAL_14:.*]] = arith.cmpf olt, %[[VAL_13]], %[[VAL_1]] : f64
 // CHECK:             %[[VAL_15:.*]] = select %[[VAL_14]], %[[VAL_13]], %[[VAL_1]] : f64
 // CHECK:             memref.store %[[VAL_15]], %[[VAL_8]]{{\[}}%[[VAL_12]]] : memref<?xf64>
 // CHECK:             scf.yield
@@ -73,7 +73,7 @@ func @apply_min_matrix(%sparse_tensor: tensor<?x?xf64, #CSR64>, %thunk: f64) -> 
 func @apply_min_vector(%sparse_tensor: tensor<7xf64, #CV64>, %thunk: f64) -> tensor<7xf64, #CV64> {
     %answer = graphblas.apply_generic %sparse_tensor : tensor<7xf64, #CV64> to tensor<7xf64, #CV64> {
       ^bb0(%val: f64):
-        %pick = cmpf olt, %val, %thunk : f64
+        %pick = arith.cmpf olt, %val, %thunk : f64
         %result = select %pick, %val, %thunk : f64
         graphblas.yield transform_out %result : f64
     }

--- a/mlir_graphblas/src/test/GraphBLAS/lower_comment.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_comment.mlir
@@ -9,9 +9,9 @@
 
 // CHECK-LABEL:   func @select_triu(
 // CHECK-SAME:                      %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK-DAG:       %[[VAL_2:.*]] = constant 1 : i64
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_4:.*]] = constant 0 : index
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i64
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_5:.*]] = tensor.dim %[[VAL_0]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_6:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_7:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
@@ -23,24 +23,24 @@
 // CHECK:           %[[VAL_13:.*]] = sparse_tensor.indices %[[VAL_11]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_14:.*]] = sparse_tensor.values %[[VAL_11]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           scf.for %[[VAL_15:.*]] = %[[VAL_4]] to %[[VAL_5]] step %[[VAL_3]] {
-// CHECK:             %[[VAL_16:.*]] = addi %[[VAL_15]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_16:.*]] = arith.addi %[[VAL_15]], %[[VAL_3]] : index
 // CHECK:             %[[VAL_17:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_15]]] : memref<?xi64>
 // CHECK:             memref.store %[[VAL_17]], %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:             %[[VAL_18:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_15]]] : memref<?xi64>
 // CHECK:             %[[VAL_19:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_16]]] : memref<?xi64>
-// CHECK:             %[[VAL_20:.*]] = index_cast %[[VAL_18]] : i64 to index
-// CHECK:             %[[VAL_21:.*]] = index_cast %[[VAL_19]] : i64 to index
+// CHECK:             %[[VAL_20:.*]] = arith.index_cast %[[VAL_18]] : i64 to index
+// CHECK:             %[[VAL_21:.*]] = arith.index_cast %[[VAL_19]] : i64 to index
 // CHECK:             scf.for %[[VAL_22:.*]] = %[[VAL_20]] to %[[VAL_21]] step %[[VAL_3]] {
 // CHECK:               %[[VAL_23:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_22]]] : memref<?xi64>
-// CHECK:               %[[VAL_24:.*]] = index_cast %[[VAL_23]] : i64 to index
+// CHECK:               %[[VAL_24:.*]] = arith.index_cast %[[VAL_23]] : i64 to index
 // CHECK:               %[[VAL_25:.*]] = memref.load %[[VAL_8]]{{\[}}%[[VAL_22]]] : memref<?xf64>
-// CHECK:               %[[VAL_26:.*]] = cmpi ugt, %[[VAL_24]], %[[VAL_15]] : index
+// CHECK:               %[[VAL_26:.*]] = arith.cmpi ugt, %[[VAL_24]], %[[VAL_15]] : index
 // CHECK:               scf.if %[[VAL_26]] {
 // CHECK:                 %[[VAL_27:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
-// CHECK:                 %[[VAL_28:.*]] = index_cast %[[VAL_27]] : i64 to index
+// CHECK:                 %[[VAL_28:.*]] = arith.index_cast %[[VAL_27]] : i64 to index
 // CHECK:                 memref.store %[[VAL_23]], %[[VAL_13]]{{\[}}%[[VAL_28]]] : memref<?xi64>
 // CHECK:                 memref.store %[[VAL_25]], %[[VAL_14]]{{\[}}%[[VAL_28]]] : memref<?xf64>
-// CHECK:                 %[[VAL_29:.*]] = addi %[[VAL_27]], %[[VAL_2]] : i64
+// CHECK:                 %[[VAL_29:.*]] = arith.addi %[[VAL_27]], %[[VAL_2]] : i64
 // CHECK:                 memref.store %[[VAL_29]], %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:               }
 // CHECK:             }
@@ -48,7 +48,7 @@
 // CHECK:           %[[VAL_30:.*]] = sparse_tensor.pointers %[[VAL_11]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_31:.*]] = tensor.dim %[[VAL_11]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_32:.*]] = memref.load %[[VAL_30]]{{\[}}%[[VAL_31]]] : memref<?xi64>
-// CHECK:           %[[VAL_33:.*]] = index_cast %[[VAL_32]] : i64 to index
+// CHECK:           %[[VAL_33:.*]] = arith.index_cast %[[VAL_32]] : i64 to index
 // CHECK:           %[[VAL_34:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           call @resize_index(%[[VAL_34]], %[[VAL_3]], %[[VAL_33]]) : (!llvm.ptr<i8>, index, index) -> ()
 // CHECK:           %[[VAL_35:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>

--- a/mlir_graphblas/src/test/GraphBLAS/lower_convert_layout.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_convert_layout.mlir
@@ -27,10 +27,10 @@
 
 // CHECK-LABEL:   func @convert_layout(
 // CHECK-SAME:                         %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:           %[[VAL_1:.*]] = constant 0 : index
-// CHECK:           %[[VAL_2:.*]] = constant 1 : index
-// CHECK:           %[[VAL_3:.*]] = constant 0 : i64
-// CHECK:           %[[VAL_4:.*]] = constant 1 : i64
+// CHECK:           %[[VAL_1:.*]] = arith.constant 0 : index
+// CHECK:           %[[VAL_2:.*]] = arith.constant 1 : index
+// CHECK:           %[[VAL_3:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_4:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_5:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_6:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_7:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
@@ -39,7 +39,7 @@
 // CHECK:           %[[VAL_10:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_11:.*]] = tensor.dim %[[VAL_0]], %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_12:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_11]]] : memref<?xi64>
-// CHECK:           %[[VAL_13:.*]] = index_cast %[[VAL_12]] : i64 to index
+// CHECK:           %[[VAL_13:.*]] = arith.index_cast %[[VAL_12]] : i64 to index
 // CHECK:           %[[VAL_14:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_15:.*]] = call @empty_like(%[[VAL_14]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_16:.*]] = call @ptr8_to_matrix_csr_f64_p64i64(%[[VAL_15]]) : (!llvm.ptr<i8>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -51,7 +51,7 @@
 // CHECK:           call @resize_dim(%[[VAL_19]], %[[VAL_1]], %[[VAL_9]]) : (!llvm.ptr<i8>, index, index) -> ()
 // CHECK:           %[[VAL_20:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_16]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           call @resize_dim(%[[VAL_20]], %[[VAL_2]], %[[VAL_8]]) : (!llvm.ptr<i8>, index, index) -> ()
-// CHECK:           %[[VAL_21:.*]] = addi %[[VAL_9]], %[[VAL_2]] : index
+// CHECK:           %[[VAL_21:.*]] = arith.addi %[[VAL_9]], %[[VAL_2]] : index
 // CHECK:           %[[VAL_22:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_16]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           call @resize_pointers(%[[VAL_22]], %[[VAL_2]], %[[VAL_21]]) : (!llvm.ptr<i8>, index, index) -> ()
 // CHECK:           %[[VAL_23:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_16]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
@@ -68,9 +68,9 @@
 // CHECK:           }
 // CHECK:           scf.for %[[VAL_31:.*]] = %[[VAL_1]] to %[[VAL_13]] step %[[VAL_2]] {
 // CHECK:             %[[VAL_32:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_31]]] : memref<?xi64>
-// CHECK:             %[[VAL_33:.*]] = index_cast %[[VAL_32]] : i64 to index
+// CHECK:             %[[VAL_33:.*]] = arith.index_cast %[[VAL_32]] : i64 to index
 // CHECK:             %[[VAL_34:.*]] = memref.load %[[VAL_27]]{{\[}}%[[VAL_33]]] : memref<?xi64>
-// CHECK:             %[[VAL_35:.*]] = addi %[[VAL_34]], %[[VAL_4]] : i64
+// CHECK:             %[[VAL_35:.*]] = arith.addi %[[VAL_34]], %[[VAL_4]] : i64
 // CHECK:             memref.store %[[VAL_35]], %[[VAL_27]]{{\[}}%[[VAL_33]]] : memref<?xi64>
 // CHECK:           }
 // CHECK:           memref.store %[[VAL_3]], %[[VAL_27]]{{\[}}%[[VAL_9]]] : memref<?xi64>
@@ -78,26 +78,26 @@
 // CHECK:             %[[VAL_37:.*]] = memref.load %[[VAL_27]]{{\[}}%[[VAL_36]]] : memref<?xi64>
 // CHECK:             %[[VAL_38:.*]] = memref.load %[[VAL_27]]{{\[}}%[[VAL_9]]] : memref<?xi64>
 // CHECK:             memref.store %[[VAL_38]], %[[VAL_27]]{{\[}}%[[VAL_36]]] : memref<?xi64>
-// CHECK:             %[[VAL_39:.*]] = addi %[[VAL_38]], %[[VAL_37]] : i64
+// CHECK:             %[[VAL_39:.*]] = arith.addi %[[VAL_38]], %[[VAL_37]] : i64
 // CHECK:             memref.store %[[VAL_39]], %[[VAL_27]]{{\[}}%[[VAL_9]]] : memref<?xi64>
 // CHECK:           }
 // CHECK:           scf.for %[[VAL_40:.*]] = %[[VAL_1]] to %[[VAL_8]] step %[[VAL_2]] {
-// CHECK:             %[[VAL_41:.*]] = index_cast %[[VAL_40]] : index to i64
+// CHECK:             %[[VAL_41:.*]] = arith.index_cast %[[VAL_40]] : index to i64
 // CHECK:             %[[VAL_42:.*]] = memref.load %[[VAL_5]]{{\[}}%[[VAL_40]]] : memref<?xi64>
-// CHECK:             %[[VAL_43:.*]] = index_cast %[[VAL_42]] : i64 to index
-// CHECK:             %[[VAL_44:.*]] = addi %[[VAL_40]], %[[VAL_2]] : index
+// CHECK:             %[[VAL_43:.*]] = arith.index_cast %[[VAL_42]] : i64 to index
+// CHECK:             %[[VAL_44:.*]] = arith.addi %[[VAL_40]], %[[VAL_2]] : index
 // CHECK:             %[[VAL_45:.*]] = memref.load %[[VAL_5]]{{\[}}%[[VAL_44]]] : memref<?xi64>
-// CHECK:             %[[VAL_46:.*]] = index_cast %[[VAL_45]] : i64 to index
+// CHECK:             %[[VAL_46:.*]] = arith.index_cast %[[VAL_45]] : i64 to index
 // CHECK:             scf.for %[[VAL_47:.*]] = %[[VAL_43]] to %[[VAL_46]] step %[[VAL_2]] {
 // CHECK:               %[[VAL_48:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_47]]] : memref<?xi64>
-// CHECK:               %[[VAL_49:.*]] = index_cast %[[VAL_48]] : i64 to index
+// CHECK:               %[[VAL_49:.*]] = arith.index_cast %[[VAL_48]] : i64 to index
 // CHECK:               %[[VAL_50:.*]] = memref.load %[[VAL_27]]{{\[}}%[[VAL_49]]] : memref<?xi64>
-// CHECK:               %[[VAL_51:.*]] = index_cast %[[VAL_50]] : i64 to index
+// CHECK:               %[[VAL_51:.*]] = arith.index_cast %[[VAL_50]] : i64 to index
 // CHECK:               memref.store %[[VAL_41]], %[[VAL_28]]{{\[}}%[[VAL_51]]] : memref<?xi64>
 // CHECK:               %[[VAL_52:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_47]]] : memref<?xf64>
 // CHECK:               memref.store %[[VAL_52]], %[[VAL_29]]{{\[}}%[[VAL_51]]] : memref<?xf64>
 // CHECK:               %[[VAL_53:.*]] = memref.load %[[VAL_27]]{{\[}}%[[VAL_49]]] : memref<?xi64>
-// CHECK:               %[[VAL_54:.*]] = addi %[[VAL_53]], %[[VAL_4]] : i64
+// CHECK:               %[[VAL_54:.*]] = arith.addi %[[VAL_53]], %[[VAL_4]] : i64
 // CHECK:               memref.store %[[VAL_54]], %[[VAL_27]]{{\[}}%[[VAL_49]]] : memref<?xi64>
 // CHECK:             }
 // CHECK:           }

--- a/mlir_graphblas/src/test/GraphBLAS/lower_diag.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_diag.mlir
@@ -33,114 +33,118 @@ module {
 // CHECK:           func private @vector_i64_p64i64_to_ptr8(tensor<7xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           func private @new_vector_i64_p64i64(index) -> tensor<7xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           func @vec_to_mat_fixed_csr(%[[VAL_0:.*]]: tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:             %[[VAL_1:.*]] = constant 0 : i64
-// CHECK:             %[[VAL_2:.*]] = constant 1 : i64
-// CHECK:             %[[VAL_3:.*]] = constant 0 : index
-// CHECK:             %[[VAL_4:.*]] = constant 1 : index
-// CHECK:             %[[VAL_5:.*]] = constant 6 : index
-// CHECK:             %[[VAL_6:.*]] = constant 7 : index
+// CHECK:             %[[VAL_1:.*]] = arith.constant 0 : i64
+// CHECK:             %[[VAL_2:.*]] = arith.constant 1 : i64
+// CHECK:             %[[VAL_3:.*]] = arith.constant 0 : index
+// CHECK:             %[[VAL_4:.*]] = arith.constant 1 : index
+// CHECK:             %[[VAL_5:.*]] = arith.constant 6 : index
+// CHECK:             %[[VAL_6:.*]] = arith.constant 7 : index
 // CHECK:             %[[VAL_7:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_3]] : tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:             %[[VAL_8:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:             %[[VAL_9:.*]] = call @new_matrix_csr_f64_p64i64(%[[VAL_6]], %[[VAL_6]]) : (index, index) -> tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:             %[[VAL_12:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:             %[[VAL_13:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_4]]] : memref<?xi64>
-// CHECK:             %[[VAL_14:.*]] = index_cast %[[VAL_13]] : i64 to index
-// CHECK:             %[[VAL_15:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_9]]) : (tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
-// CHECK:             call @resize_index(%[[VAL_15]], %[[VAL_4]], %[[VAL_14]]) : (!llvm.ptr<i8>, index, index) -> ()
-// CHECK:             %[[VAL_16:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_9]]) : (tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
-// CHECK:             call @resize_values(%[[VAL_16]], %[[VAL_14]]) : (!llvm.ptr<i8>, index) -> ()
-// CHECK:             %[[VAL_17:.*]] = sparse_tensor.indices %[[VAL_9]], %[[VAL_4]] : tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:             %[[VAL_18:.*]] = sparse_tensor.values %[[VAL_9]] : tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:             scf.for %[[VAL_19:.*]] = %[[VAL_3]] to %[[VAL_14]] step %[[VAL_4]] {
-// CHECK:               %[[VAL_20:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_19]]] : memref<?xi64>
-// CHECK:               memref.store %[[VAL_20]], %[[VAL_17]]{{\[}}%[[VAL_19]]] : memref<?xi64>
-// CHECK:               %[[VAL_21:.*]] = memref.load %[[VAL_8]]{{\[}}%[[VAL_19]]] : memref<?xf64>
-// CHECK:               memref.store %[[VAL_21]], %[[VAL_18]]{{\[}}%[[VAL_19]]] : memref<?xf64>
+// CHECK:             %[[VAL_10:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:             %[[VAL_11:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_4]]] : memref<?xi64>
+// CHECK:             %[[VAL_12:.*]] = arith.index_cast %[[VAL_11]] : i64 to index
+// CHECK:             %[[VAL_13:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_9]]) : (tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:             call @resize_index(%[[VAL_13]], %[[VAL_4]], %[[VAL_12]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:             %[[VAL_14:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_9]]) : (tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:             call @resize_values(%[[VAL_14]], %[[VAL_12]]) : (!llvm.ptr<i8>, index) -> ()
+// CHECK:             %[[VAL_15:.*]] = sparse_tensor.indices %[[VAL_9]], %[[VAL_4]] : tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:             %[[VAL_16:.*]] = sparse_tensor.values %[[VAL_9]] : tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:             scf.for %[[VAL_17:.*]] = %[[VAL_3]] to %[[VAL_12]] step %[[VAL_4]] {
+// CHECK:               %[[VAL_18:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_17]]] : memref<?xi64>
+// CHECK:               memref.store %[[VAL_18]], %[[VAL_15]]{{\[}}%[[VAL_17]]] : memref<?xi64>
+// CHECK:               %[[VAL_19:.*]] = memref.load %[[VAL_8]]{{\[}}%[[VAL_17]]] : memref<?xf64>
+// CHECK:               memref.store %[[VAL_19]], %[[VAL_16]]{{\[}}%[[VAL_17]]] : memref<?xf64>
 // CHECK:             }
-// CHECK:             %[[VAL_22:.*]] = sparse_tensor.pointers %[[VAL_9]], %[[VAL_4]] : tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:             %[[VAL_23:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_3]]] : memref<?xi64>
-// CHECK:             %[[VAL_24:.*]]:3 = scf.for %[[VAL_25:.*]] = %[[VAL_3]] to %[[VAL_6]] step %[[VAL_4]] iter_args(%[[VAL_26:.*]] = %[[VAL_1]], %[[VAL_27:.*]] = %[[VAL_3]], %[[VAL_28:.*]] = %[[VAL_23]]) -> (i64, index, i64) {
-// CHECK:               memref.store %[[VAL_26]], %[[VAL_22]]{{\[}}%[[VAL_25]]] : memref<?xi64>
-// CHECK:               %[[VAL_29:.*]] = index_cast %[[VAL_25]] : index to i64
-// CHECK:               %[[VAL_30:.*]] = cmpi eq, %[[VAL_28]], %[[VAL_29]] : i64
-// CHECK:               %[[VAL_31:.*]] = cmpi ne, %[[VAL_25]], %[[VAL_5]] : index
-// CHECK:               %[[VAL_32:.*]] = and %[[VAL_31]], %[[VAL_30]] : i1
-// CHECK:               %[[VAL_33:.*]]:3 = scf.if %[[VAL_32]] -> (i64, index, i64) {
-// CHECK:                 %[[VAL_34:.*]] = addi %[[VAL_26]], %[[VAL_2]] : i64
-// CHECK:                 %[[VAL_35:.*]] = addi %[[VAL_27]], %[[VAL_4]] : index
-// CHECK:                 %[[VAL_36:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_35]]] : memref<?xi64>
-// CHECK:                 scf.yield %[[VAL_34]], %[[VAL_35]], %[[VAL_36]] : i64, index, i64
+// CHECK:             %[[VAL_20:.*]] = sparse_tensor.pointers %[[VAL_9]], %[[VAL_4]] : tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:             %[[VAL_21:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_3]]] : memref<?xi64>
+// CHECK:             %[[VAL_22:.*]]:3 = scf.for %[[VAL_23:.*]] = %[[VAL_3]] to %[[VAL_6]] step %[[VAL_4]] iter_args(%[[VAL_24:.*]] = %[[VAL_1]], %[[VAL_25:.*]] = %[[VAL_3]], %[[VAL_26:.*]] = %[[VAL_21]]) -> (i64, index, i64) {
+// CHECK:               memref.store %[[VAL_24]], %[[VAL_20]]{{\[}}%[[VAL_23]]] : memref<?xi64>
+// CHECK:               %[[VAL_27:.*]] = arith.index_cast %[[VAL_23]] : index to i64
+// CHECK:               %[[VAL_28:.*]] = arith.cmpi eq, %[[VAL_26]], %[[VAL_27]] : i64
+// CHECK:               %[[VAL_29:.*]] = arith.cmpi ne, %[[VAL_23]], %[[VAL_5]] : index
+// CHECK:               %[[VAL_30:.*]] = arith.andi %[[VAL_29]], %[[VAL_28]] : i1
+// CHECK:               %[[VAL_31:.*]]:3 = scf.if %[[VAL_30]] -> (i64, index, i64) {
+// CHECK:                 %[[VAL_32:.*]] = arith.addi %[[VAL_24]], %[[VAL_2]] : i64
+// CHECK:                 %[[VAL_33:.*]] = arith.addi %[[VAL_25]], %[[VAL_4]] : index
+// CHECK:                 %[[VAL_34:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_33]]] : memref<?xi64>
+// CHECK:                 scf.yield %[[VAL_32]], %[[VAL_33]], %[[VAL_34]] : i64, index, i64
 // CHECK:               } else {
-// CHECK:                 scf.yield %[[VAL_26]], %[[VAL_27]], %[[VAL_28]] : i64, index, i64
+// CHECK:                 scf.yield %[[VAL_24]], %[[VAL_25]], %[[VAL_26]] : i64, index, i64
 // CHECK:               }
-// CHECK:               scf.yield %[[VAL_37:.*]]#0, %[[VAL_37]]#1, %[[VAL_37]]#2 : i64, index, i64
+// CHECK:               scf.yield %[[VAL_35:.*]]#0, %[[VAL_35]]#1, %[[VAL_35]]#2 : i64, index, i64
 // CHECK:             }
-// CHECK:             memref.store %[[VAL_13]], %[[VAL_22]]{{\[}}%[[VAL_6]]] : memref<?xi64>
+// CHECK:             %[[VAL_36:.*]] = arith.index_cast %[[VAL_12]] : index to i64
+// CHECK:             memref.store %[[VAL_36]], %[[VAL_20]]{{\[}}%[[VAL_6]]] : memref<?xi64>
 // CHECK:             return %[[VAL_9]] : tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           }
+
    func @vec_to_mat_fixed_csr(%sparse_tensor: tensor<7xf64, #CV64>) -> tensor<7x7xf64, #CSR64> {
        %answer = graphblas.diag %sparse_tensor : tensor<7xf64, #CV64> to tensor<7x7xf64, #CSR64>
        return %answer : tensor<7x7xf64, #CSR64>
    }
 
-// CHECK:           func @vec_to_mat_fixed_csc(%[[VAL_38:.*]]: tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:             %[[VAL_39:.*]] = constant 0 : i64
-// CHECK:             %[[VAL_40:.*]] = constant 1 : i64
-// CHECK:             %[[VAL_41:.*]] = constant 0 : index
-// CHECK:             %[[VAL_42:.*]] = constant 1 : index
-// CHECK:             %[[VAL_43:.*]] = constant 6 : index
-// CHECK:             %[[VAL_44:.*]] = constant 7 : index
-// CHECK:             %[[VAL_45:.*]] = sparse_tensor.indices %[[VAL_38]], %[[VAL_41]] : tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:             %[[VAL_46:.*]] = sparse_tensor.values %[[VAL_38]] : tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:             %[[VAL_47:.*]] = call @new_matrix_csc_f64_p64i64(%[[VAL_44]], %[[VAL_44]]) : (index, index) -> tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:             %[[VAL_50:.*]] = sparse_tensor.pointers %[[VAL_38]], %[[VAL_41]] : tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:             %[[VAL_51:.*]] = memref.load %[[VAL_50]]{{\[}}%[[VAL_42]]] : memref<?xi64>
-// CHECK:             %[[VAL_52:.*]] = index_cast %[[VAL_51]] : i64 to index
-// CHECK:             %[[VAL_53:.*]] = call @matrix_csc_f64_p64i64_to_ptr8(%[[VAL_47]]) : (tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
-// CHECK:             call @resize_index(%[[VAL_53]], %[[VAL_42]], %[[VAL_52]]) : (!llvm.ptr<i8>, index, index) -> ()
-// CHECK:             %[[VAL_54:.*]] = call @matrix_csc_f64_p64i64_to_ptr8(%[[VAL_47]]) : (tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
-// CHECK:             call @resize_values(%[[VAL_54]], %[[VAL_52]]) : (!llvm.ptr<i8>, index) -> ()
-// CHECK:             %[[VAL_55:.*]] = sparse_tensor.indices %[[VAL_47]], %[[VAL_42]] : tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:             %[[VAL_56:.*]] = sparse_tensor.values %[[VAL_47]] : tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:             scf.for %[[VAL_57:.*]] = %[[VAL_41]] to %[[VAL_52]] step %[[VAL_42]] {
-// CHECK:               %[[VAL_58:.*]] = memref.load %[[VAL_45]]{{\[}}%[[VAL_57]]] : memref<?xi64>
-// CHECK:               memref.store %[[VAL_58]], %[[VAL_55]]{{\[}}%[[VAL_57]]] : memref<?xi64>
-// CHECK:               %[[VAL_59:.*]] = memref.load %[[VAL_46]]{{\[}}%[[VAL_57]]] : memref<?xf64>
-// CHECK:               memref.store %[[VAL_59]], %[[VAL_56]]{{\[}}%[[VAL_57]]] : memref<?xf64>
+// CHECK:           func @vec_to_mat_fixed_csc(%[[VAL_37:.*]]: tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK:             %[[VAL_38:.*]] = arith.constant 0 : i64
+// CHECK:             %[[VAL_39:.*]] = arith.constant 1 : i64
+// CHECK:             %[[VAL_40:.*]] = arith.constant 0 : index
+// CHECK:             %[[VAL_41:.*]] = arith.constant 1 : index
+// CHECK:             %[[VAL_42:.*]] = arith.constant 6 : index
+// CHECK:             %[[VAL_43:.*]] = arith.constant 7 : index
+// CHECK:             %[[VAL_44:.*]] = sparse_tensor.indices %[[VAL_37]], %[[VAL_40]] : tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:             %[[VAL_45:.*]] = sparse_tensor.values %[[VAL_37]] : tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:             %[[VAL_46:.*]] = call @new_matrix_csc_f64_p64i64(%[[VAL_43]], %[[VAL_43]]) : (index, index) -> tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:             %[[VAL_47:.*]] = sparse_tensor.pointers %[[VAL_37]], %[[VAL_40]] : tensor<7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:             %[[VAL_48:.*]] = memref.load %[[VAL_47]]{{\[}}%[[VAL_41]]] : memref<?xi64>
+// CHECK:             %[[VAL_49:.*]] = arith.index_cast %[[VAL_48]] : i64 to index
+// CHECK:             %[[VAL_50:.*]] = call @matrix_csc_f64_p64i64_to_ptr8(%[[VAL_46]]) : (tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:             call @resize_index(%[[VAL_50]], %[[VAL_41]], %[[VAL_49]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:             %[[VAL_51:.*]] = call @matrix_csc_f64_p64i64_to_ptr8(%[[VAL_46]]) : (tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:             call @resize_values(%[[VAL_51]], %[[VAL_49]]) : (!llvm.ptr<i8>, index) -> ()
+// CHECK:             %[[VAL_52:.*]] = sparse_tensor.indices %[[VAL_46]], %[[VAL_41]] : tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:             %[[VAL_53:.*]] = sparse_tensor.values %[[VAL_46]] : tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:             scf.for %[[VAL_54:.*]] = %[[VAL_40]] to %[[VAL_49]] step %[[VAL_41]] {
+// CHECK:               %[[VAL_55:.*]] = memref.load %[[VAL_44]]{{\[}}%[[VAL_54]]] : memref<?xi64>
+// CHECK:               memref.store %[[VAL_55]], %[[VAL_52]]{{\[}}%[[VAL_54]]] : memref<?xi64>
+// CHECK:               %[[VAL_56:.*]] = memref.load %[[VAL_45]]{{\[}}%[[VAL_54]]] : memref<?xf64>
+// CHECK:               memref.store %[[VAL_56]], %[[VAL_53]]{{\[}}%[[VAL_54]]] : memref<?xf64>
 // CHECK:             }
-// CHECK:             %[[VAL_60:.*]] = sparse_tensor.pointers %[[VAL_47]], %[[VAL_42]] : tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:             %[[VAL_61:.*]] = memref.load %[[VAL_45]]{{\[}}%[[VAL_41]]] : memref<?xi64>
-// CHECK:             %[[VAL_62:.*]]:3 = scf.for %[[VAL_63:.*]] = %[[VAL_41]] to %[[VAL_44]] step %[[VAL_42]] iter_args(%[[VAL_64:.*]] = %[[VAL_39]], %[[VAL_65:.*]] = %[[VAL_41]], %[[VAL_66:.*]] = %[[VAL_61]]) -> (i64, index, i64) {
-// CHECK:               memref.store %[[VAL_64]], %[[VAL_60]]{{\[}}%[[VAL_63]]] : memref<?xi64>
-// CHECK:               %[[VAL_67:.*]] = index_cast %[[VAL_63]] : index to i64
-// CHECK:               %[[VAL_68:.*]] = cmpi eq, %[[VAL_66]], %[[VAL_67]] : i64
-// CHECK:               %[[VAL_69:.*]] = cmpi ne, %[[VAL_63]], %[[VAL_43]] : index
-// CHECK:               %[[VAL_70:.*]] = and %[[VAL_69]], %[[VAL_68]] : i1
-// CHECK:               %[[VAL_71:.*]]:3 = scf.if %[[VAL_70]] -> (i64, index, i64) {
-// CHECK:                 %[[VAL_72:.*]] = addi %[[VAL_64]], %[[VAL_40]] : i64
-// CHECK:                 %[[VAL_73:.*]] = addi %[[VAL_65]], %[[VAL_42]] : index
-// CHECK:                 %[[VAL_74:.*]] = memref.load %[[VAL_45]]{{\[}}%[[VAL_73]]] : memref<?xi64>
-// CHECK:                 scf.yield %[[VAL_72]], %[[VAL_73]], %[[VAL_74]] : i64, index, i64
+// CHECK:             %[[VAL_57:.*]] = sparse_tensor.pointers %[[VAL_46]], %[[VAL_41]] : tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:             %[[VAL_58:.*]] = memref.load %[[VAL_44]]{{\[}}%[[VAL_40]]] : memref<?xi64>
+// CHECK:             %[[VAL_59:.*]]:3 = scf.for %[[VAL_60:.*]] = %[[VAL_40]] to %[[VAL_43]] step %[[VAL_41]] iter_args(%[[VAL_61:.*]] = %[[VAL_38]], %[[VAL_62:.*]] = %[[VAL_40]], %[[VAL_63:.*]] = %[[VAL_58]]) -> (i64, index, i64) {
+// CHECK:               memref.store %[[VAL_61]], %[[VAL_57]]{{\[}}%[[VAL_60]]] : memref<?xi64>
+// CHECK:               %[[VAL_64:.*]] = arith.index_cast %[[VAL_60]] : index to i64
+// CHECK:               %[[VAL_65:.*]] = arith.cmpi eq, %[[VAL_63]], %[[VAL_64]] : i64
+// CHECK:               %[[VAL_66:.*]] = arith.cmpi ne, %[[VAL_60]], %[[VAL_42]] : index
+// CHECK:               %[[VAL_67:.*]] = arith.andi %[[VAL_66]], %[[VAL_65]] : i1
+// CHECK:               %[[VAL_68:.*]]:3 = scf.if %[[VAL_67]] -> (i64, index, i64) {
+// CHECK:                 %[[VAL_69:.*]] = arith.addi %[[VAL_61]], %[[VAL_39]] : i64
+// CHECK:                 %[[VAL_70:.*]] = arith.addi %[[VAL_62]], %[[VAL_41]] : index
+// CHECK:                 %[[VAL_71:.*]] = memref.load %[[VAL_44]]{{\[}}%[[VAL_70]]] : memref<?xi64>
+// CHECK:                 scf.yield %[[VAL_69]], %[[VAL_70]], %[[VAL_71]] : i64, index, i64
 // CHECK:               } else {
-// CHECK:                 scf.yield %[[VAL_64]], %[[VAL_65]], %[[VAL_66]] : i64, index, i64
+// CHECK:                 scf.yield %[[VAL_61]], %[[VAL_62]], %[[VAL_63]] : i64, index, i64
 // CHECK:               }
-// CHECK:               scf.yield %[[VAL_75:.*]]#0, %[[VAL_75]]#1, %[[VAL_75]]#2 : i64, index, i64
+// CHECK:               scf.yield %[[VAL_72:.*]]#0, %[[VAL_72]]#1, %[[VAL_72]]#2 : i64, index, i64
 // CHECK:             }
-// CHECK:             memref.store %[[VAL_51]], %[[VAL_60]]{{\[}}%[[VAL_44]]] : memref<?xi64>
-// CHECK:             return %[[VAL_47]] : tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:             %[[VAL_73:.*]] = arith.index_cast %[[VAL_49]] : index to i64
+// CHECK:             memref.store %[[VAL_73]], %[[VAL_57]]{{\[}}%[[VAL_43]]] : memref<?xi64>
+// CHECK:             return %[[VAL_46]] : tensor<7x7xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           }
+
    func @vec_to_mat_fixed_csc(%sparse_tensor: tensor<7xf64, #CV64>) -> tensor<7x7xf64, #CSC64> {
        %answer = graphblas.diag %sparse_tensor : tensor<7xf64, #CV64> to tensor<7x7xf64, #CSC64>
        return %answer : tensor<7x7xf64, #CSC64>
    }
    
 // CHECK:           func @mat_to_vec_fixed_csr(%[[VAL_76:.*]]: tensor<7x7xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<7xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:             %[[VAL_77:.*]] = constant true
-// CHECK:             %[[VAL_78:.*]] = constant 1 : i64
-// CHECK:             %[[VAL_79:.*]] = constant 0 : index
-// CHECK:             %[[VAL_80:.*]] = constant 1 : index
-// CHECK:             %[[VAL_81:.*]] = constant 2 : index
-// CHECK:             %[[VAL_82:.*]] = constant 7 : index
+// CHECK:             %[[VAL_77:.*]] = arith.constant true
+// CHECK:             %[[VAL_78:.*]] = arith.constant 1 : i64
+// CHECK:             %[[VAL_79:.*]] = arith.constant 0 : index
+// CHECK:             %[[VAL_80:.*]] = arith.constant 1 : index
+// CHECK:             %[[VAL_81:.*]] = arith.constant 2 : index
+// CHECK:             %[[VAL_82:.*]] = arith.constant 7 : index
 // CHECK:             %[[VAL_83:.*]] = sparse_tensor.pointers %[[VAL_76]], %[[VAL_80]] : tensor<7x7xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:             %[[VAL_84:.*]] = sparse_tensor.indices %[[VAL_76]], %[[VAL_80]] : tensor<7x7xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:             %[[VAL_85:.*]] = sparse_tensor.values %[[VAL_76]] : tensor<7x7xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
@@ -148,27 +152,27 @@ module {
 // CHECK:             %[[VAL_88:.*]] = call @vector_i64_p64i64_to_ptr8(%[[VAL_86]]) : (tensor<7xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:             call @resize_dim(%[[VAL_88]], %[[VAL_79]], %[[VAL_82]]) : (!llvm.ptr<i8>, index, index) -> ()
 // CHECK:             %[[VAL_89:.*]] = scf.for %[[VAL_90:.*]] = %[[VAL_79]] to %[[VAL_82]] step %[[VAL_80]] iter_args(%[[VAL_91:.*]] = %[[VAL_79]]) -> (index) {
-// CHECK:               %[[VAL_92:.*]] = addi %[[VAL_90]], %[[VAL_80]] : index
+// CHECK:               %[[VAL_92:.*]] = arith.addi %[[VAL_90]], %[[VAL_80]] : index
 // CHECK:               %[[VAL_93:.*]] = memref.load %[[VAL_83]]{{\[}}%[[VAL_90]]] : memref<?xi64>
 // CHECK:               %[[VAL_94:.*]] = memref.load %[[VAL_83]]{{\[}}%[[VAL_92]]] : memref<?xi64>
-// CHECK:               %[[VAL_95:.*]] = index_cast %[[VAL_93]] : i64 to index
-// CHECK:               %[[VAL_96:.*]] = index_cast %[[VAL_94]] : i64 to index
-// CHECK:               %[[VAL_97:.*]] = index_cast %[[VAL_90]] : index to i64
+// CHECK:               %[[VAL_95:.*]] = arith.index_cast %[[VAL_93]] : i64 to index
+// CHECK:               %[[VAL_96:.*]] = arith.index_cast %[[VAL_94]] : i64 to index
+// CHECK:               %[[VAL_97:.*]] = arith.index_cast %[[VAL_90]] : index to i64
 // CHECK:               %[[VAL_98:.*]]:2 = scf.while (%[[VAL_99:.*]] = %[[VAL_95]], %[[VAL_100:.*]] = %[[VAL_77]]) : (index, i1) -> (index, i1) {
-// CHECK:                 %[[VAL_101:.*]] = cmpi ult, %[[VAL_99]], %[[VAL_96]] : index
-// CHECK:                 %[[VAL_102:.*]] = and %[[VAL_100]], %[[VAL_101]] : i1
+// CHECK:                 %[[VAL_101:.*]] = arith.cmpi ult, %[[VAL_99]], %[[VAL_96]] : index
+// CHECK:                 %[[VAL_102:.*]] = arith.andi %[[VAL_100]], %[[VAL_101]] : i1
 // CHECK:                 scf.condition(%[[VAL_102]]) %[[VAL_99]], %[[VAL_100]] : index, i1
 // CHECK:               } do {
 // CHECK:               ^bb0(%[[VAL_103:.*]]: index, %[[VAL_104:.*]]: i1):
 // CHECK:                 %[[VAL_105:.*]] = memref.load %[[VAL_84]]{{\[}}%[[VAL_103]]] : memref<?xi64>
-// CHECK:                 %[[VAL_106:.*]] = cmpi ne, %[[VAL_105]], %[[VAL_97]] : i64
-// CHECK:                 %[[VAL_107:.*]] = addi %[[VAL_103]], %[[VAL_80]] : index
+// CHECK:                 %[[VAL_106:.*]] = arith.cmpi ne, %[[VAL_105]], %[[VAL_97]] : i64
+// CHECK:                 %[[VAL_107:.*]] = arith.addi %[[VAL_103]], %[[VAL_80]] : index
 // CHECK:                 scf.yield %[[VAL_107]], %[[VAL_106]] : index, i1
 // CHECK:               }
 // CHECK:               %[[VAL_108:.*]] = scf.if %[[VAL_109:.*]]#1 -> (index) {
 // CHECK:                 scf.yield %[[VAL_91]] : index
 // CHECK:               } else {
-// CHECK:                 %[[VAL_110:.*]] = addi %[[VAL_91]], %[[VAL_80]] : index
+// CHECK:                 %[[VAL_110:.*]] = arith.addi %[[VAL_91]], %[[VAL_80]] : index
 // CHECK:                 scf.yield %[[VAL_110]] : index
 // CHECK:               }
 // CHECK:               scf.yield %[[VAL_111:.*]] : index
@@ -180,32 +184,32 @@ module {
 // CHECK:             %[[VAL_115:.*]] = call @vector_i64_p64i64_to_ptr8(%[[VAL_86]]) : (tensor<7xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:             call @resize_values(%[[VAL_115]], %[[VAL_114]]) : (!llvm.ptr<i8>, index) -> ()
 // CHECK:             %[[VAL_116:.*]] = sparse_tensor.pointers %[[VAL_86]], %[[VAL_79]] : tensor<7xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:             %[[VAL_117:.*]] = index_cast %[[VAL_114]] : index to i64
+// CHECK:             %[[VAL_117:.*]] = arith.index_cast %[[VAL_114]] : index to i64
 // CHECK:             memref.store %[[VAL_117]], %[[VAL_116]]{{\[}}%[[VAL_80]]] : memref<?xi64>
 // CHECK:             %[[VAL_118:.*]] = sparse_tensor.indices %[[VAL_86]], %[[VAL_79]] : tensor<7xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:             %[[VAL_119:.*]] = sparse_tensor.values %[[VAL_86]] : tensor<7xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:             %[[VAL_120:.*]] = scf.for %[[VAL_121:.*]] = %[[VAL_79]] to %[[VAL_82]] step %[[VAL_80]] iter_args(%[[VAL_122:.*]] = %[[VAL_79]]) -> (index) {
-// CHECK:               %[[VAL_123:.*]] = addi %[[VAL_121]], %[[VAL_80]] : index
+// CHECK:               %[[VAL_123:.*]] = arith.addi %[[VAL_121]], %[[VAL_80]] : index
 // CHECK:               %[[VAL_124:.*]] = memref.load %[[VAL_83]]{{\[}}%[[VAL_121]]] : memref<?xi64>
 // CHECK:               %[[VAL_125:.*]] = memref.load %[[VAL_83]]{{\[}}%[[VAL_123]]] : memref<?xi64>
-// CHECK:               %[[VAL_126:.*]] = index_cast %[[VAL_124]] : i64 to index
-// CHECK:               %[[VAL_127:.*]] = index_cast %[[VAL_125]] : i64 to index
-// CHECK:               %[[VAL_128:.*]] = index_cast %[[VAL_121]] : index to i64
+// CHECK:               %[[VAL_126:.*]] = arith.index_cast %[[VAL_124]] : i64 to index
+// CHECK:               %[[VAL_127:.*]] = arith.index_cast %[[VAL_125]] : i64 to index
+// CHECK:               %[[VAL_128:.*]] = arith.index_cast %[[VAL_121]] : index to i64
 // CHECK:               %[[VAL_129:.*]]:3 = scf.while (%[[VAL_130:.*]] = %[[VAL_126]], %[[VAL_131:.*]] = %[[VAL_77]], %[[VAL_132:.*]] = %[[VAL_78]]) : (index, i1, i64) -> (index, i1, i64) {
-// CHECK:                 %[[VAL_133:.*]] = cmpi ult, %[[VAL_130]], %[[VAL_127]] : index
-// CHECK:                 %[[VAL_134:.*]] = and %[[VAL_131]], %[[VAL_133]] : i1
+// CHECK:                 %[[VAL_133:.*]] = arith.cmpi ult, %[[VAL_130]], %[[VAL_127]] : index
+// CHECK:                 %[[VAL_134:.*]] = arith.andi %[[VAL_131]], %[[VAL_133]] : i1
 // CHECK:                 scf.condition(%[[VAL_134]]) %[[VAL_130]], %[[VAL_131]], %[[VAL_132]] : index, i1, i64
 // CHECK:               } do {
 // CHECK:               ^bb0(%[[VAL_135:.*]]: index, %[[VAL_136:.*]]: i1, %[[VAL_137:.*]]: i64):
 // CHECK:                 %[[VAL_138:.*]] = memref.load %[[VAL_84]]{{\[}}%[[VAL_135]]] : memref<?xi64>
-// CHECK:                 %[[VAL_139:.*]] = cmpi ne, %[[VAL_138]], %[[VAL_128]] : i64
+// CHECK:                 %[[VAL_139:.*]] = arith.cmpi ne, %[[VAL_138]], %[[VAL_128]] : i64
 // CHECK:                 %[[VAL_140:.*]] = scf.if %[[VAL_139]] -> (i64) {
 // CHECK:                   scf.yield %[[VAL_137]] : i64
 // CHECK:                 } else {
 // CHECK:                   %[[VAL_141:.*]] = memref.load %[[VAL_85]]{{\[}}%[[VAL_135]]] : memref<?xi64>
 // CHECK:                   scf.yield %[[VAL_141]] : i64
 // CHECK:                 }
-// CHECK:                 %[[VAL_142:.*]] = addi %[[VAL_135]], %[[VAL_80]] : index
+// CHECK:                 %[[VAL_142:.*]] = arith.addi %[[VAL_135]], %[[VAL_80]] : index
 // CHECK:                 scf.yield %[[VAL_142]], %[[VAL_139]], %[[VAL_143:.*]] : index, i1, i64
 // CHECK:               }
 // CHECK:               %[[VAL_144:.*]] = scf.if %[[VAL_145:.*]]#1 -> (index) {
@@ -213,7 +217,7 @@ module {
 // CHECK:               } else {
 // CHECK:                 memref.store %[[VAL_146:.*]]#2, %[[VAL_119]]{{\[}}%[[VAL_122]]] : memref<?xi64>
 // CHECK:                 memref.store %[[VAL_128]], %[[VAL_118]]{{\[}}%[[VAL_122]]] : memref<?xi64>
-// CHECK:                 %[[VAL_147:.*]] = addi %[[VAL_122]], %[[VAL_80]] : index
+// CHECK:                 %[[VAL_147:.*]] = arith.addi %[[VAL_122]], %[[VAL_80]] : index
 // CHECK:                 scf.yield %[[VAL_147]] : index
 // CHECK:               }
 // CHECK:               scf.yield %[[VAL_148:.*]] : index
@@ -226,12 +230,12 @@ module {
     }
 
 // CHECK:           func @mat_to_vec_fixed_csc(%[[VAL_149:.*]]: tensor<7x7xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<7xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:             %[[VAL_150:.*]] = constant true
-// CHECK:             %[[VAL_151:.*]] = constant 1 : i64
-// CHECK:             %[[VAL_152:.*]] = constant 0 : index
-// CHECK:             %[[VAL_153:.*]] = constant 1 : index
-// CHECK:             %[[VAL_154:.*]] = constant 2 : index
-// CHECK:             %[[VAL_155:.*]] = constant 7 : index
+// CHECK:             %[[VAL_150:.*]] = arith.constant true
+// CHECK:             %[[VAL_151:.*]] = arith.constant 1 : i64
+// CHECK:             %[[VAL_152:.*]] = arith.constant 0 : index
+// CHECK:             %[[VAL_153:.*]] = arith.constant 1 : index
+// CHECK:             %[[VAL_154:.*]] = arith.constant 2 : index
+// CHECK:             %[[VAL_155:.*]] = arith.constant 7 : index
 // CHECK:             %[[VAL_156:.*]] = sparse_tensor.pointers %[[VAL_149]], %[[VAL_153]] : tensor<7x7xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:             %[[VAL_157:.*]] = sparse_tensor.indices %[[VAL_149]], %[[VAL_153]] : tensor<7x7xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:             %[[VAL_158:.*]] = sparse_tensor.values %[[VAL_149]] : tensor<7x7xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
@@ -239,27 +243,27 @@ module {
 // CHECK:             %[[VAL_161:.*]] = call @vector_i64_p64i64_to_ptr8(%[[VAL_159]]) : (tensor<7xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:             call @resize_dim(%[[VAL_161]], %[[VAL_152]], %[[VAL_155]]) : (!llvm.ptr<i8>, index, index) -> ()
 // CHECK:             %[[VAL_162:.*]] = scf.for %[[VAL_163:.*]] = %[[VAL_152]] to %[[VAL_155]] step %[[VAL_153]] iter_args(%[[VAL_164:.*]] = %[[VAL_152]]) -> (index) {
-// CHECK:               %[[VAL_165:.*]] = addi %[[VAL_163]], %[[VAL_153]] : index
+// CHECK:               %[[VAL_165:.*]] = arith.addi %[[VAL_163]], %[[VAL_153]] : index
 // CHECK:               %[[VAL_166:.*]] = memref.load %[[VAL_156]]{{\[}}%[[VAL_163]]] : memref<?xi64>
 // CHECK:               %[[VAL_167:.*]] = memref.load %[[VAL_156]]{{\[}}%[[VAL_165]]] : memref<?xi64>
-// CHECK:               %[[VAL_168:.*]] = index_cast %[[VAL_166]] : i64 to index
-// CHECK:               %[[VAL_169:.*]] = index_cast %[[VAL_167]] : i64 to index
-// CHECK:               %[[VAL_170:.*]] = index_cast %[[VAL_163]] : index to i64
+// CHECK:               %[[VAL_168:.*]] = arith.index_cast %[[VAL_166]] : i64 to index
+// CHECK:               %[[VAL_169:.*]] = arith.index_cast %[[VAL_167]] : i64 to index
+// CHECK:               %[[VAL_170:.*]] = arith.index_cast %[[VAL_163]] : index to i64
 // CHECK:               %[[VAL_171:.*]]:2 = scf.while (%[[VAL_172:.*]] = %[[VAL_168]], %[[VAL_173:.*]] = %[[VAL_150]]) : (index, i1) -> (index, i1) {
-// CHECK:                 %[[VAL_174:.*]] = cmpi ult, %[[VAL_172]], %[[VAL_169]] : index
-// CHECK:                 %[[VAL_175:.*]] = and %[[VAL_173]], %[[VAL_174]] : i1
+// CHECK:                 %[[VAL_174:.*]] = arith.cmpi ult, %[[VAL_172]], %[[VAL_169]] : index
+// CHECK:                 %[[VAL_175:.*]] = arith.andi %[[VAL_173]], %[[VAL_174]] : i1
 // CHECK:                 scf.condition(%[[VAL_175]]) %[[VAL_172]], %[[VAL_173]] : index, i1
 // CHECK:               } do {
 // CHECK:               ^bb0(%[[VAL_176:.*]]: index, %[[VAL_177:.*]]: i1):
 // CHECK:                 %[[VAL_178:.*]] = memref.load %[[VAL_157]]{{\[}}%[[VAL_176]]] : memref<?xi64>
-// CHECK:                 %[[VAL_179:.*]] = cmpi ne, %[[VAL_178]], %[[VAL_170]] : i64
-// CHECK:                 %[[VAL_180:.*]] = addi %[[VAL_176]], %[[VAL_153]] : index
+// CHECK:                 %[[VAL_179:.*]] = arith.cmpi ne, %[[VAL_178]], %[[VAL_170]] : i64
+// CHECK:                 %[[VAL_180:.*]] = arith.addi %[[VAL_176]], %[[VAL_153]] : index
 // CHECK:                 scf.yield %[[VAL_180]], %[[VAL_179]] : index, i1
 // CHECK:               }
 // CHECK:               %[[VAL_181:.*]] = scf.if %[[VAL_182:.*]]#1 -> (index) {
 // CHECK:                 scf.yield %[[VAL_164]] : index
 // CHECK:               } else {
-// CHECK:                 %[[VAL_183:.*]] = addi %[[VAL_164]], %[[VAL_153]] : index
+// CHECK:                 %[[VAL_183:.*]] = arith.addi %[[VAL_164]], %[[VAL_153]] : index
 // CHECK:                 scf.yield %[[VAL_183]] : index
 // CHECK:               }
 // CHECK:               scf.yield %[[VAL_184:.*]] : index
@@ -271,32 +275,32 @@ module {
 // CHECK:             %[[VAL_188:.*]] = call @vector_i64_p64i64_to_ptr8(%[[VAL_159]]) : (tensor<7xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:             call @resize_values(%[[VAL_188]], %[[VAL_187]]) : (!llvm.ptr<i8>, index) -> ()
 // CHECK:             %[[VAL_189:.*]] = sparse_tensor.pointers %[[VAL_159]], %[[VAL_152]] : tensor<7xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:             %[[VAL_190:.*]] = index_cast %[[VAL_187]] : index to i64
+// CHECK:             %[[VAL_190:.*]] = arith.index_cast %[[VAL_187]] : index to i64
 // CHECK:             memref.store %[[VAL_190]], %[[VAL_189]]{{\[}}%[[VAL_153]]] : memref<?xi64>
 // CHECK:             %[[VAL_191:.*]] = sparse_tensor.indices %[[VAL_159]], %[[VAL_152]] : tensor<7xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:             %[[VAL_192:.*]] = sparse_tensor.values %[[VAL_159]] : tensor<7xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:             %[[VAL_193:.*]] = scf.for %[[VAL_194:.*]] = %[[VAL_152]] to %[[VAL_155]] step %[[VAL_153]] iter_args(%[[VAL_195:.*]] = %[[VAL_152]]) -> (index) {
-// CHECK:               %[[VAL_196:.*]] = addi %[[VAL_194]], %[[VAL_153]] : index
+// CHECK:               %[[VAL_196:.*]] = arith.addi %[[VAL_194]], %[[VAL_153]] : index
 // CHECK:               %[[VAL_197:.*]] = memref.load %[[VAL_156]]{{\[}}%[[VAL_194]]] : memref<?xi64>
 // CHECK:               %[[VAL_198:.*]] = memref.load %[[VAL_156]]{{\[}}%[[VAL_196]]] : memref<?xi64>
-// CHECK:               %[[VAL_199:.*]] = index_cast %[[VAL_197]] : i64 to index
-// CHECK:               %[[VAL_200:.*]] = index_cast %[[VAL_198]] : i64 to index
-// CHECK:               %[[VAL_201:.*]] = index_cast %[[VAL_194]] : index to i64
+// CHECK:               %[[VAL_199:.*]] = arith.index_cast %[[VAL_197]] : i64 to index
+// CHECK:               %[[VAL_200:.*]] = arith.index_cast %[[VAL_198]] : i64 to index
+// CHECK:               %[[VAL_201:.*]] = arith.index_cast %[[VAL_194]] : index to i64
 // CHECK:               %[[VAL_202:.*]]:3 = scf.while (%[[VAL_203:.*]] = %[[VAL_199]], %[[VAL_204:.*]] = %[[VAL_150]], %[[VAL_205:.*]] = %[[VAL_151]]) : (index, i1, i64) -> (index, i1, i64) {
-// CHECK:                 %[[VAL_206:.*]] = cmpi ult, %[[VAL_203]], %[[VAL_200]] : index
-// CHECK:                 %[[VAL_207:.*]] = and %[[VAL_204]], %[[VAL_206]] : i1
+// CHECK:                 %[[VAL_206:.*]] = arith.cmpi ult, %[[VAL_203]], %[[VAL_200]] : index
+// CHECK:                 %[[VAL_207:.*]] = arith.andi %[[VAL_204]], %[[VAL_206]] : i1
 // CHECK:                 scf.condition(%[[VAL_207]]) %[[VAL_203]], %[[VAL_204]], %[[VAL_205]] : index, i1, i64
 // CHECK:               } do {
 // CHECK:               ^bb0(%[[VAL_208:.*]]: index, %[[VAL_209:.*]]: i1, %[[VAL_210:.*]]: i64):
 // CHECK:                 %[[VAL_211:.*]] = memref.load %[[VAL_157]]{{\[}}%[[VAL_208]]] : memref<?xi64>
-// CHECK:                 %[[VAL_212:.*]] = cmpi ne, %[[VAL_211]], %[[VAL_201]] : i64
+// CHECK:                 %[[VAL_212:.*]] = arith.cmpi ne, %[[VAL_211]], %[[VAL_201]] : i64
 // CHECK:                 %[[VAL_213:.*]] = scf.if %[[VAL_212]] -> (i64) {
 // CHECK:                   scf.yield %[[VAL_210]] : i64
 // CHECK:                 } else {
 // CHECK:                   %[[VAL_214:.*]] = memref.load %[[VAL_158]]{{\[}}%[[VAL_208]]] : memref<?xi64>
 // CHECK:                   scf.yield %[[VAL_214]] : i64
 // CHECK:                 }
-// CHECK:                 %[[VAL_215:.*]] = addi %[[VAL_208]], %[[VAL_153]] : index
+// CHECK:                 %[[VAL_215:.*]] = arith.addi %[[VAL_208]], %[[VAL_153]] : index
 // CHECK:                 scf.yield %[[VAL_215]], %[[VAL_212]], %[[VAL_216:.*]] : index, i1, i64
 // CHECK:               }
 // CHECK:               %[[VAL_217:.*]] = scf.if %[[VAL_218:.*]]#1 -> (index) {
@@ -304,7 +308,7 @@ module {
 // CHECK:               } else {
 // CHECK:                 memref.store %[[VAL_219:.*]]#2, %[[VAL_192]]{{\[}}%[[VAL_195]]] : memref<?xi64>
 // CHECK:                 memref.store %[[VAL_201]], %[[VAL_191]]{{\[}}%[[VAL_195]]] : memref<?xi64>
-// CHECK:                 %[[VAL_220:.*]] = addi %[[VAL_195]], %[[VAL_153]] : index
+// CHECK:                 %[[VAL_220:.*]] = arith.addi %[[VAL_195]], %[[VAL_153]] : index
 // CHECK:                 scf.yield %[[VAL_220]] : index
 // CHECK:               }
 // CHECK:               scf.yield %[[VAL_221:.*]] : index
@@ -331,49 +335,50 @@ module {
 // CHECK:           func private @vector_i64_p64i64_to_ptr8(tensor<?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           func private @new_vector_i64_p64i64(index) -> tensor<?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           func @vec_to_mat_arbitrary_csr(%[[VAL_0:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:             %[[VAL_1:.*]] = constant 0 : i64
-// CHECK:             %[[VAL_2:.*]] = constant 1 : i64
-// CHECK:             %[[VAL_3:.*]] = constant 0 : index
-// CHECK:             %[[VAL_4:.*]] = constant 1 : index
+// CHECK:             %[[VAL_1:.*]] = arith.constant 0 : i64
+// CHECK:             %[[VAL_2:.*]] = arith.constant 1 : i64
+// CHECK:             %[[VAL_3:.*]] = arith.constant 0 : index
+// CHECK:             %[[VAL_4:.*]] = arith.constant 1 : index
 // CHECK:             %[[VAL_5:.*]] = tensor.dim %[[VAL_0]], %[[VAL_3]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:             %[[VAL_6:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_3]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:             %[[VAL_7:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:             %[[VAL_8:.*]] = call @new_matrix_csr_f64_p64i64(%[[VAL_5]], %[[VAL_5]]) : (index, index) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:             %[[VAL_11:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:             %[[VAL_12:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_4]]] : memref<?xi64>
-// CHECK:             %[[VAL_13:.*]] = index_cast %[[VAL_12]] : i64 to index
-// CHECK:             %[[VAL_14:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_8]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
-// CHECK:             call @resize_index(%[[VAL_14]], %[[VAL_4]], %[[VAL_13]]) : (!llvm.ptr<i8>, index, index) -> ()
-// CHECK:             %[[VAL_15:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_8]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
-// CHECK:             call @resize_values(%[[VAL_15]], %[[VAL_13]]) : (!llvm.ptr<i8>, index) -> ()
-// CHECK:             %[[VAL_16:.*]] = sparse_tensor.indices %[[VAL_8]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:             %[[VAL_17:.*]] = sparse_tensor.values %[[VAL_8]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:             scf.for %[[VAL_18:.*]] = %[[VAL_3]] to %[[VAL_13]] step %[[VAL_4]] {
-// CHECK:               %[[VAL_19:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_18]]] : memref<?xi64>
-// CHECK:               memref.store %[[VAL_19]], %[[VAL_16]]{{\[}}%[[VAL_18]]] : memref<?xi64>
-// CHECK:               %[[VAL_20:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_18]]] : memref<?xf64>
-// CHECK:               memref.store %[[VAL_20]], %[[VAL_17]]{{\[}}%[[VAL_18]]] : memref<?xf64>
+// CHECK:             %[[VAL_9:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:             %[[VAL_10:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_4]]] : memref<?xi64>
+// CHECK:             %[[VAL_11:.*]] = arith.index_cast %[[VAL_10]] : i64 to index
+// CHECK:             %[[VAL_12:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_8]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:             call @resize_index(%[[VAL_12]], %[[VAL_4]], %[[VAL_11]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:             %[[VAL_13:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_8]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:             call @resize_values(%[[VAL_13]], %[[VAL_11]]) : (!llvm.ptr<i8>, index) -> ()
+// CHECK:             %[[VAL_14:.*]] = sparse_tensor.indices %[[VAL_8]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:             %[[VAL_15:.*]] = sparse_tensor.values %[[VAL_8]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:             scf.for %[[VAL_16:.*]] = %[[VAL_3]] to %[[VAL_11]] step %[[VAL_4]] {
+// CHECK:               %[[VAL_17:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_16]]] : memref<?xi64>
+// CHECK:               memref.store %[[VAL_17]], %[[VAL_14]]{{\[}}%[[VAL_16]]] : memref<?xi64>
+// CHECK:               %[[VAL_18:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_16]]] : memref<?xf64>
+// CHECK:               memref.store %[[VAL_18]], %[[VAL_15]]{{\[}}%[[VAL_16]]] : memref<?xf64>
 // CHECK:             }
-// CHECK:             %[[VAL_21:.*]] = sparse_tensor.pointers %[[VAL_8]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:             %[[VAL_22:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_3]]] : memref<?xi64>
-// CHECK:             %[[VAL_23:.*]] = subi %[[VAL_5]], %[[VAL_4]] : index
-// CHECK:             %[[VAL_24:.*]]:3 = scf.for %[[VAL_25:.*]] = %[[VAL_3]] to %[[VAL_5]] step %[[VAL_4]] iter_args(%[[VAL_26:.*]] = %[[VAL_1]], %[[VAL_27:.*]] = %[[VAL_3]], %[[VAL_28:.*]] = %[[VAL_22]]) -> (i64, index, i64) {
-// CHECK:               memref.store %[[VAL_26]], %[[VAL_21]]{{\[}}%[[VAL_25]]] : memref<?xi64>
-// CHECK:               %[[VAL_29:.*]] = index_cast %[[VAL_25]] : index to i64
-// CHECK:               %[[VAL_30:.*]] = cmpi eq, %[[VAL_28]], %[[VAL_29]] : i64
-// CHECK:               %[[VAL_31:.*]] = cmpi ne, %[[VAL_25]], %[[VAL_23]] : index
-// CHECK:               %[[VAL_32:.*]] = and %[[VAL_31]], %[[VAL_30]] : i1
-// CHECK:               %[[VAL_33:.*]]:3 = scf.if %[[VAL_32]] -> (i64, index, i64) {
-// CHECK:                 %[[VAL_34:.*]] = addi %[[VAL_26]], %[[VAL_2]] : i64
-// CHECK:                 %[[VAL_35:.*]] = addi %[[VAL_27]], %[[VAL_4]] : index
-// CHECK:                 %[[VAL_36:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_35]]] : memref<?xi64>
-// CHECK:                 scf.yield %[[VAL_34]], %[[VAL_35]], %[[VAL_36]] : i64, index, i64
+// CHECK:             %[[VAL_19:.*]] = sparse_tensor.pointers %[[VAL_8]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:             %[[VAL_20:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_3]]] : memref<?xi64>
+// CHECK:             %[[VAL_21:.*]] = arith.subi %[[VAL_5]], %[[VAL_4]] : index
+// CHECK:             %[[VAL_22:.*]]:3 = scf.for %[[VAL_23:.*]] = %[[VAL_3]] to %[[VAL_5]] step %[[VAL_4]] iter_args(%[[VAL_24:.*]] = %[[VAL_1]], %[[VAL_25:.*]] = %[[VAL_3]], %[[VAL_26:.*]] = %[[VAL_20]]) -> (i64, index, i64) {
+// CHECK:               memref.store %[[VAL_24]], %[[VAL_19]]{{\[}}%[[VAL_23]]] : memref<?xi64>
+// CHECK:               %[[VAL_27:.*]] = arith.index_cast %[[VAL_23]] : index to i64
+// CHECK:               %[[VAL_28:.*]] = arith.cmpi eq, %[[VAL_26]], %[[VAL_27]] : i64
+// CHECK:               %[[VAL_29:.*]] = arith.cmpi ne, %[[VAL_23]], %[[VAL_21]] : index
+// CHECK:               %[[VAL_30:.*]] = arith.andi %[[VAL_29]], %[[VAL_28]] : i1
+// CHECK:               %[[VAL_31:.*]]:3 = scf.if %[[VAL_30]] -> (i64, index, i64) {
+// CHECK:                 %[[VAL_32:.*]] = arith.addi %[[VAL_24]], %[[VAL_2]] : i64
+// CHECK:                 %[[VAL_33:.*]] = arith.addi %[[VAL_25]], %[[VAL_4]] : index
+// CHECK:                 %[[VAL_34:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_33]]] : memref<?xi64>
+// CHECK:                 scf.yield %[[VAL_32]], %[[VAL_33]], %[[VAL_34]] : i64, index, i64
 // CHECK:               } else {
-// CHECK:                 scf.yield %[[VAL_26]], %[[VAL_27]], %[[VAL_28]] : i64, index, i64
+// CHECK:                 scf.yield %[[VAL_24]], %[[VAL_25]], %[[VAL_26]] : i64, index, i64
 // CHECK:               }
-// CHECK:               scf.yield %[[VAL_37:.*]]#0, %[[VAL_37]]#1, %[[VAL_37]]#2 : i64, index, i64
+// CHECK:               scf.yield %[[VAL_35:.*]]#0, %[[VAL_35]]#1, %[[VAL_35]]#2 : i64, index, i64
 // CHECK:             }
-// CHECK:             memref.store %[[VAL_12]], %[[VAL_21]]{{\[}}%[[VAL_5]]] : memref<?xi64>
+// CHECK:             %[[VAL_36:.*]] = arith.index_cast %[[VAL_11]] : index to i64
+// CHECK:             memref.store %[[VAL_36]], %[[VAL_19]]{{\[}}%[[VAL_5]]] : memref<?xi64>
 // CHECK:             return %[[VAL_8]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           }
    func @vec_to_mat_arbitrary_csr(%sparse_tensor: tensor<?xf64, #CV64>) -> tensor<?x?xf64, #CSR64> {
@@ -381,51 +386,52 @@ module {
        return %answer : tensor<?x?xf64, #CSR64>
    }
 
-// CHECK:           func @vec_to_mat_arbitrary_csc(%[[VAL_38:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:             %[[VAL_39:.*]] = constant 0 : i64
-// CHECK:             %[[VAL_40:.*]] = constant 1 : i64
-// CHECK:             %[[VAL_41:.*]] = constant 0 : index
-// CHECK:             %[[VAL_42:.*]] = constant 1 : index
-// CHECK:             %[[VAL_43:.*]] = tensor.dim %[[VAL_38]], %[[VAL_41]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:             %[[VAL_44:.*]] = sparse_tensor.indices %[[VAL_38]], %[[VAL_41]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:             %[[VAL_45:.*]] = sparse_tensor.values %[[VAL_38]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:             %[[VAL_46:.*]] = call @new_matrix_csc_f64_p64i64(%[[VAL_43]], %[[VAL_43]]) : (index, index) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:             %[[VAL_49:.*]] = sparse_tensor.pointers %[[VAL_38]], %[[VAL_41]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:             %[[VAL_50:.*]] = memref.load %[[VAL_49]]{{\[}}%[[VAL_42]]] : memref<?xi64>
-// CHECK:             %[[VAL_51:.*]] = index_cast %[[VAL_50]] : i64 to index
-// CHECK:             %[[VAL_52:.*]] = call @matrix_csc_f64_p64i64_to_ptr8(%[[VAL_46]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
-// CHECK:             call @resize_index(%[[VAL_52]], %[[VAL_42]], %[[VAL_51]]) : (!llvm.ptr<i8>, index, index) -> ()
-// CHECK:             %[[VAL_53:.*]] = call @matrix_csc_f64_p64i64_to_ptr8(%[[VAL_46]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
-// CHECK:             call @resize_values(%[[VAL_53]], %[[VAL_51]]) : (!llvm.ptr<i8>, index) -> ()
-// CHECK:             %[[VAL_54:.*]] = sparse_tensor.indices %[[VAL_46]], %[[VAL_42]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:             %[[VAL_55:.*]] = sparse_tensor.values %[[VAL_46]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:             scf.for %[[VAL_56:.*]] = %[[VAL_41]] to %[[VAL_51]] step %[[VAL_42]] {
-// CHECK:               %[[VAL_57:.*]] = memref.load %[[VAL_44]]{{\[}}%[[VAL_56]]] : memref<?xi64>
-// CHECK:               memref.store %[[VAL_57]], %[[VAL_54]]{{\[}}%[[VAL_56]]] : memref<?xi64>
-// CHECK:               %[[VAL_58:.*]] = memref.load %[[VAL_45]]{{\[}}%[[VAL_56]]] : memref<?xf64>
-// CHECK:               memref.store %[[VAL_58]], %[[VAL_55]]{{\[}}%[[VAL_56]]] : memref<?xf64>
+// CHECK:           func @vec_to_mat_arbitrary_csc(%[[VAL_37:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
+// CHECK:             %[[VAL_38:.*]] = arith.constant 0 : i64
+// CHECK:             %[[VAL_39:.*]] = arith.constant 1 : i64
+// CHECK:             %[[VAL_40:.*]] = arith.constant 0 : index
+// CHECK:             %[[VAL_41:.*]] = arith.constant 1 : index
+// CHECK:             %[[VAL_42:.*]] = tensor.dim %[[VAL_37]], %[[VAL_40]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:             %[[VAL_43:.*]] = sparse_tensor.indices %[[VAL_37]], %[[VAL_40]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:             %[[VAL_44:.*]] = sparse_tensor.values %[[VAL_37]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:             %[[VAL_45:.*]] = call @new_matrix_csc_f64_p64i64(%[[VAL_42]], %[[VAL_42]]) : (index, index) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:             %[[VAL_46:.*]] = sparse_tensor.pointers %[[VAL_37]], %[[VAL_40]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:             %[[VAL_47:.*]] = memref.load %[[VAL_46]]{{\[}}%[[VAL_41]]] : memref<?xi64>
+// CHECK:             %[[VAL_48:.*]] = arith.index_cast %[[VAL_47]] : i64 to index
+// CHECK:             %[[VAL_49:.*]] = call @matrix_csc_f64_p64i64_to_ptr8(%[[VAL_45]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:             call @resize_index(%[[VAL_49]], %[[VAL_41]], %[[VAL_48]]) : (!llvm.ptr<i8>, index, index) -> ()
+// CHECK:             %[[VAL_50:.*]] = call @matrix_csc_f64_p64i64_to_ptr8(%[[VAL_45]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
+// CHECK:             call @resize_values(%[[VAL_50]], %[[VAL_48]]) : (!llvm.ptr<i8>, index) -> ()
+// CHECK:             %[[VAL_51:.*]] = sparse_tensor.indices %[[VAL_45]], %[[VAL_41]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:             %[[VAL_52:.*]] = sparse_tensor.values %[[VAL_45]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
+// CHECK:             scf.for %[[VAL_53:.*]] = %[[VAL_40]] to %[[VAL_48]] step %[[VAL_41]] {
+// CHECK:               %[[VAL_54:.*]] = memref.load %[[VAL_43]]{{\[}}%[[VAL_53]]] : memref<?xi64>
+// CHECK:               memref.store %[[VAL_54]], %[[VAL_51]]{{\[}}%[[VAL_53]]] : memref<?xi64>
+// CHECK:               %[[VAL_55:.*]] = memref.load %[[VAL_44]]{{\[}}%[[VAL_53]]] : memref<?xf64>
+// CHECK:               memref.store %[[VAL_55]], %[[VAL_52]]{{\[}}%[[VAL_53]]] : memref<?xf64>
 // CHECK:             }
-// CHECK:             %[[VAL_59:.*]] = sparse_tensor.pointers %[[VAL_46]], %[[VAL_42]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:             %[[VAL_60:.*]] = memref.load %[[VAL_44]]{{\[}}%[[VAL_41]]] : memref<?xi64>
-// CHECK:             %[[VAL_61:.*]] = subi %[[VAL_43]], %[[VAL_42]] : index
-// CHECK:             %[[VAL_62:.*]]:3 = scf.for %[[VAL_63:.*]] = %[[VAL_41]] to %[[VAL_43]] step %[[VAL_42]] iter_args(%[[VAL_64:.*]] = %[[VAL_39]], %[[VAL_65:.*]] = %[[VAL_41]], %[[VAL_66:.*]] = %[[VAL_60]]) -> (i64, index, i64) {
-// CHECK:               memref.store %[[VAL_64]], %[[VAL_59]]{{\[}}%[[VAL_63]]] : memref<?xi64>
-// CHECK:               %[[VAL_67:.*]] = index_cast %[[VAL_63]] : index to i64
-// CHECK:               %[[VAL_68:.*]] = cmpi eq, %[[VAL_66]], %[[VAL_67]] : i64
-// CHECK:               %[[VAL_69:.*]] = cmpi ne, %[[VAL_63]], %[[VAL_61]] : index
-// CHECK:               %[[VAL_70:.*]] = and %[[VAL_69]], %[[VAL_68]] : i1
-// CHECK:               %[[VAL_71:.*]]:3 = scf.if %[[VAL_70]] -> (i64, index, i64) {
-// CHECK:                 %[[VAL_72:.*]] = addi %[[VAL_64]], %[[VAL_40]] : i64
-// CHECK:                 %[[VAL_73:.*]] = addi %[[VAL_65]], %[[VAL_42]] : index
-// CHECK:                 %[[VAL_74:.*]] = memref.load %[[VAL_44]]{{\[}}%[[VAL_73]]] : memref<?xi64>
-// CHECK:                 scf.yield %[[VAL_72]], %[[VAL_73]], %[[VAL_74]] : i64, index, i64
+// CHECK:             %[[VAL_56:.*]] = sparse_tensor.pointers %[[VAL_45]], %[[VAL_41]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
+// CHECK:             %[[VAL_57:.*]] = memref.load %[[VAL_43]]{{\[}}%[[VAL_40]]] : memref<?xi64>
+// CHECK:             %[[VAL_58:.*]] = arith.subi %[[VAL_42]], %[[VAL_41]] : index
+// CHECK:             %[[VAL_59:.*]]:3 = scf.for %[[VAL_60:.*]] = %[[VAL_40]] to %[[VAL_42]] step %[[VAL_41]] iter_args(%[[VAL_61:.*]] = %[[VAL_38]], %[[VAL_62:.*]] = %[[VAL_40]], %[[VAL_63:.*]] = %[[VAL_57]]) -> (i64, index, i64) {
+// CHECK:               memref.store %[[VAL_61]], %[[VAL_56]]{{\[}}%[[VAL_60]]] : memref<?xi64>
+// CHECK:               %[[VAL_64:.*]] = arith.index_cast %[[VAL_60]] : index to i64
+// CHECK:               %[[VAL_65:.*]] = arith.cmpi eq, %[[VAL_63]], %[[VAL_64]] : i64
+// CHECK:               %[[VAL_66:.*]] = arith.cmpi ne, %[[VAL_60]], %[[VAL_58]] : index
+// CHECK:               %[[VAL_67:.*]] = arith.andi %[[VAL_66]], %[[VAL_65]] : i1
+// CHECK:               %[[VAL_68:.*]]:3 = scf.if %[[VAL_67]] -> (i64, index, i64) {
+// CHECK:                 %[[VAL_69:.*]] = arith.addi %[[VAL_61]], %[[VAL_39]] : i64
+// CHECK:                 %[[VAL_70:.*]] = arith.addi %[[VAL_62]], %[[VAL_41]] : index
+// CHECK:                 %[[VAL_71:.*]] = memref.load %[[VAL_43]]{{\[}}%[[VAL_70]]] : memref<?xi64>
+// CHECK:                 scf.yield %[[VAL_69]], %[[VAL_70]], %[[VAL_71]] : i64, index, i64
 // CHECK:               } else {
-// CHECK:                 scf.yield %[[VAL_64]], %[[VAL_65]], %[[VAL_66]] : i64, index, i64
+// CHECK:                 scf.yield %[[VAL_61]], %[[VAL_62]], %[[VAL_63]] : i64, index, i64
 // CHECK:               }
-// CHECK:               scf.yield %[[VAL_75:.*]]#0, %[[VAL_75]]#1, %[[VAL_75]]#2 : i64, index, i64
+// CHECK:               scf.yield %[[VAL_72:.*]]#0, %[[VAL_72]]#1, %[[VAL_72]]#2 : i64, index, i64
 // CHECK:             }
-// CHECK:             memref.store %[[VAL_50]], %[[VAL_59]]{{\[}}%[[VAL_43]]] : memref<?xi64>
-// CHECK:             return %[[VAL_46]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
+// CHECK:             %[[VAL_73:.*]] = arith.index_cast %[[VAL_48]] : index to i64
+// CHECK:             memref.store %[[VAL_73]], %[[VAL_56]]{{\[}}%[[VAL_42]]] : memref<?xi64>
+// CHECK:             return %[[VAL_45]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           }
    func @vec_to_mat_arbitrary_csc(%sparse_tensor: tensor<?xf64, #CV64>) -> tensor<?x?xf64, #CSC64> {
        %answer = graphblas.diag %sparse_tensor : tensor<?xf64, #CV64> to tensor<?x?xf64, #CSC64>
@@ -433,11 +439,11 @@ module {
    }
 
 // CHECK:           func @mat_to_vec_arbitrary_csr(%[[VAL_76:.*]]: tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:             %[[VAL_77:.*]] = constant true
-// CHECK:             %[[VAL_78:.*]] = constant 1 : i64
-// CHECK:             %[[VAL_79:.*]] = constant 0 : index
-// CHECK:             %[[VAL_80:.*]] = constant 1 : index
-// CHECK:             %[[VAL_81:.*]] = constant 2 : index
+// CHECK:             %[[VAL_77:.*]] = arith.constant true
+// CHECK:             %[[VAL_78:.*]] = arith.constant 1 : i64
+// CHECK:             %[[VAL_79:.*]] = arith.constant 0 : index
+// CHECK:             %[[VAL_80:.*]] = arith.constant 1 : index
+// CHECK:             %[[VAL_81:.*]] = arith.constant 2 : index
 // CHECK:             %[[VAL_82:.*]] = tensor.dim %[[VAL_76]], %[[VAL_79]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:             %[[VAL_83:.*]] = sparse_tensor.pointers %[[VAL_76]], %[[VAL_80]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:             %[[VAL_84:.*]] = sparse_tensor.indices %[[VAL_76]], %[[VAL_80]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
@@ -446,27 +452,27 @@ module {
 // CHECK:             %[[VAL_88:.*]] = call @vector_i64_p64i64_to_ptr8(%[[VAL_86]]) : (tensor<?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:             call @resize_dim(%[[VAL_88]], %[[VAL_79]], %[[VAL_82]]) : (!llvm.ptr<i8>, index, index) -> ()
 // CHECK:             %[[VAL_89:.*]] = scf.for %[[VAL_90:.*]] = %[[VAL_79]] to %[[VAL_82]] step %[[VAL_80]] iter_args(%[[VAL_91:.*]] = %[[VAL_79]]) -> (index) {
-// CHECK:               %[[VAL_92:.*]] = addi %[[VAL_90]], %[[VAL_80]] : index
+// CHECK:               %[[VAL_92:.*]] = arith.addi %[[VAL_90]], %[[VAL_80]] : index
 // CHECK:               %[[VAL_93:.*]] = memref.load %[[VAL_83]]{{\[}}%[[VAL_90]]] : memref<?xi64>
 // CHECK:               %[[VAL_94:.*]] = memref.load %[[VAL_83]]{{\[}}%[[VAL_92]]] : memref<?xi64>
-// CHECK:               %[[VAL_95:.*]] = index_cast %[[VAL_93]] : i64 to index
-// CHECK:               %[[VAL_96:.*]] = index_cast %[[VAL_94]] : i64 to index
-// CHECK:               %[[VAL_97:.*]] = index_cast %[[VAL_90]] : index to i64
+// CHECK:               %[[VAL_95:.*]] = arith.index_cast %[[VAL_93]] : i64 to index
+// CHECK:               %[[VAL_96:.*]] = arith.index_cast %[[VAL_94]] : i64 to index
+// CHECK:               %[[VAL_97:.*]] = arith.index_cast %[[VAL_90]] : index to i64
 // CHECK:               %[[VAL_98:.*]]:2 = scf.while (%[[VAL_99:.*]] = %[[VAL_95]], %[[VAL_100:.*]] = %[[VAL_77]]) : (index, i1) -> (index, i1) {
-// CHECK:                 %[[VAL_101:.*]] = cmpi ult, %[[VAL_99]], %[[VAL_96]] : index
-// CHECK:                 %[[VAL_102:.*]] = and %[[VAL_100]], %[[VAL_101]] : i1
+// CHECK:                 %[[VAL_101:.*]] = arith.cmpi ult, %[[VAL_99]], %[[VAL_96]] : index
+// CHECK:                 %[[VAL_102:.*]] = arith.andi %[[VAL_100]], %[[VAL_101]] : i1
 // CHECK:                 scf.condition(%[[VAL_102]]) %[[VAL_99]], %[[VAL_100]] : index, i1
 // CHECK:               } do {
 // CHECK:               ^bb0(%[[VAL_103:.*]]: index, %[[VAL_104:.*]]: i1):
 // CHECK:                 %[[VAL_105:.*]] = memref.load %[[VAL_84]]{{\[}}%[[VAL_103]]] : memref<?xi64>
-// CHECK:                 %[[VAL_106:.*]] = cmpi ne, %[[VAL_105]], %[[VAL_97]] : i64
-// CHECK:                 %[[VAL_107:.*]] = addi %[[VAL_103]], %[[VAL_80]] : index
+// CHECK:                 %[[VAL_106:.*]] = arith.cmpi ne, %[[VAL_105]], %[[VAL_97]] : i64
+// CHECK:                 %[[VAL_107:.*]] = arith.addi %[[VAL_103]], %[[VAL_80]] : index
 // CHECK:                 scf.yield %[[VAL_107]], %[[VAL_106]] : index, i1
 // CHECK:               }
 // CHECK:               %[[VAL_108:.*]] = scf.if %[[VAL_109:.*]]#1 -> (index) {
 // CHECK:                 scf.yield %[[VAL_91]] : index
 // CHECK:               } else {
-// CHECK:                 %[[VAL_110:.*]] = addi %[[VAL_91]], %[[VAL_80]] : index
+// CHECK:                 %[[VAL_110:.*]] = arith.addi %[[VAL_91]], %[[VAL_80]] : index
 // CHECK:                 scf.yield %[[VAL_110]] : index
 // CHECK:               }
 // CHECK:               scf.yield %[[VAL_111:.*]] : index
@@ -478,32 +484,32 @@ module {
 // CHECK:             %[[VAL_115:.*]] = call @vector_i64_p64i64_to_ptr8(%[[VAL_86]]) : (tensor<?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:             call @resize_values(%[[VAL_115]], %[[VAL_114]]) : (!llvm.ptr<i8>, index) -> ()
 // CHECK:             %[[VAL_116:.*]] = sparse_tensor.pointers %[[VAL_86]], %[[VAL_79]] : tensor<?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:             %[[VAL_117:.*]] = index_cast %[[VAL_114]] : index to i64
+// CHECK:             %[[VAL_117:.*]] = arith.index_cast %[[VAL_114]] : index to i64
 // CHECK:             memref.store %[[VAL_117]], %[[VAL_116]]{{\[}}%[[VAL_80]]] : memref<?xi64>
 // CHECK:             %[[VAL_118:.*]] = sparse_tensor.indices %[[VAL_86]], %[[VAL_79]] : tensor<?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:             %[[VAL_119:.*]] = sparse_tensor.values %[[VAL_86]] : tensor<?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:             %[[VAL_120:.*]] = scf.for %[[VAL_121:.*]] = %[[VAL_79]] to %[[VAL_82]] step %[[VAL_80]] iter_args(%[[VAL_122:.*]] = %[[VAL_79]]) -> (index) {
-// CHECK:               %[[VAL_123:.*]] = addi %[[VAL_121]], %[[VAL_80]] : index
+// CHECK:               %[[VAL_123:.*]] = arith.addi %[[VAL_121]], %[[VAL_80]] : index
 // CHECK:               %[[VAL_124:.*]] = memref.load %[[VAL_83]]{{\[}}%[[VAL_121]]] : memref<?xi64>
 // CHECK:               %[[VAL_125:.*]] = memref.load %[[VAL_83]]{{\[}}%[[VAL_123]]] : memref<?xi64>
-// CHECK:               %[[VAL_126:.*]] = index_cast %[[VAL_124]] : i64 to index
-// CHECK:               %[[VAL_127:.*]] = index_cast %[[VAL_125]] : i64 to index
-// CHECK:               %[[VAL_128:.*]] = index_cast %[[VAL_121]] : index to i64
+// CHECK:               %[[VAL_126:.*]] = arith.index_cast %[[VAL_124]] : i64 to index
+// CHECK:               %[[VAL_127:.*]] = arith.index_cast %[[VAL_125]] : i64 to index
+// CHECK:               %[[VAL_128:.*]] = arith.index_cast %[[VAL_121]] : index to i64
 // CHECK:               %[[VAL_129:.*]]:3 = scf.while (%[[VAL_130:.*]] = %[[VAL_126]], %[[VAL_131:.*]] = %[[VAL_77]], %[[VAL_132:.*]] = %[[VAL_78]]) : (index, i1, i64) -> (index, i1, i64) {
-// CHECK:                 %[[VAL_133:.*]] = cmpi ult, %[[VAL_130]], %[[VAL_127]] : index
-// CHECK:                 %[[VAL_134:.*]] = and %[[VAL_131]], %[[VAL_133]] : i1
+// CHECK:                 %[[VAL_133:.*]] = arith.cmpi ult, %[[VAL_130]], %[[VAL_127]] : index
+// CHECK:                 %[[VAL_134:.*]] = arith.andi %[[VAL_131]], %[[VAL_133]] : i1
 // CHECK:                 scf.condition(%[[VAL_134]]) %[[VAL_130]], %[[VAL_131]], %[[VAL_132]] : index, i1, i64
 // CHECK:               } do {
 // CHECK:               ^bb0(%[[VAL_135:.*]]: index, %[[VAL_136:.*]]: i1, %[[VAL_137:.*]]: i64):
 // CHECK:                 %[[VAL_138:.*]] = memref.load %[[VAL_84]]{{\[}}%[[VAL_135]]] : memref<?xi64>
-// CHECK:                 %[[VAL_139:.*]] = cmpi ne, %[[VAL_138]], %[[VAL_128]] : i64
+// CHECK:                 %[[VAL_139:.*]] = arith.cmpi ne, %[[VAL_138]], %[[VAL_128]] : i64
 // CHECK:                 %[[VAL_140:.*]] = scf.if %[[VAL_139]] -> (i64) {
 // CHECK:                   scf.yield %[[VAL_137]] : i64
 // CHECK:                 } else {
 // CHECK:                   %[[VAL_141:.*]] = memref.load %[[VAL_85]]{{\[}}%[[VAL_135]]] : memref<?xi64>
 // CHECK:                   scf.yield %[[VAL_141]] : i64
 // CHECK:                 }
-// CHECK:                 %[[VAL_142:.*]] = addi %[[VAL_135]], %[[VAL_80]] : index
+// CHECK:                 %[[VAL_142:.*]] = arith.addi %[[VAL_135]], %[[VAL_80]] : index
 // CHECK:                 scf.yield %[[VAL_142]], %[[VAL_139]], %[[VAL_143:.*]] : index, i1, i64
 // CHECK:               }
 // CHECK:               %[[VAL_144:.*]] = scf.if %[[VAL_145:.*]]#1 -> (index) {
@@ -511,7 +517,7 @@ module {
 // CHECK:               } else {
 // CHECK:                 memref.store %[[VAL_146:.*]]#2, %[[VAL_119]]{{\[}}%[[VAL_122]]] : memref<?xi64>
 // CHECK:                 memref.store %[[VAL_128]], %[[VAL_118]]{{\[}}%[[VAL_122]]] : memref<?xi64>
-// CHECK:                 %[[VAL_147:.*]] = addi %[[VAL_122]], %[[VAL_80]] : index
+// CHECK:                 %[[VAL_147:.*]] = arith.addi %[[VAL_122]], %[[VAL_80]] : index
 // CHECK:                 scf.yield %[[VAL_147]] : index
 // CHECK:               }
 // CHECK:               scf.yield %[[VAL_148:.*]] : index
@@ -524,11 +530,11 @@ module {
     }
 
 // CHECK:           func @mat_to_vec_arbitrary_csc(%[[VAL_149:.*]]: tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:             %[[VAL_150:.*]] = constant true
-// CHECK:             %[[VAL_151:.*]] = constant 1 : i64
-// CHECK:             %[[VAL_152:.*]] = constant 0 : index
-// CHECK:             %[[VAL_153:.*]] = constant 1 : index
-// CHECK:             %[[VAL_154:.*]] = constant 2 : index
+// CHECK:             %[[VAL_150:.*]] = arith.constant true
+// CHECK:             %[[VAL_151:.*]] = arith.constant 1 : i64
+// CHECK:             %[[VAL_152:.*]] = arith.constant 0 : index
+// CHECK:             %[[VAL_153:.*]] = arith.constant 1 : index
+// CHECK:             %[[VAL_154:.*]] = arith.constant 2 : index
 // CHECK:             %[[VAL_155:.*]] = tensor.dim %[[VAL_149]], %[[VAL_152]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:             %[[VAL_156:.*]] = sparse_tensor.pointers %[[VAL_149]], %[[VAL_153]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:             %[[VAL_157:.*]] = sparse_tensor.indices %[[VAL_149]], %[[VAL_153]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
@@ -537,27 +543,27 @@ module {
 // CHECK:             %[[VAL_161:.*]] = call @vector_i64_p64i64_to_ptr8(%[[VAL_159]]) : (tensor<?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:             call @resize_dim(%[[VAL_161]], %[[VAL_152]], %[[VAL_155]]) : (!llvm.ptr<i8>, index, index) -> ()
 // CHECK:             %[[VAL_162:.*]] = scf.for %[[VAL_163:.*]] = %[[VAL_152]] to %[[VAL_155]] step %[[VAL_153]] iter_args(%[[VAL_164:.*]] = %[[VAL_152]]) -> (index) {
-// CHECK:               %[[VAL_165:.*]] = addi %[[VAL_163]], %[[VAL_153]] : index
+// CHECK:               %[[VAL_165:.*]] = arith.addi %[[VAL_163]], %[[VAL_153]] : index
 // CHECK:               %[[VAL_166:.*]] = memref.load %[[VAL_156]]{{\[}}%[[VAL_163]]] : memref<?xi64>
 // CHECK:               %[[VAL_167:.*]] = memref.load %[[VAL_156]]{{\[}}%[[VAL_165]]] : memref<?xi64>
-// CHECK:               %[[VAL_168:.*]] = index_cast %[[VAL_166]] : i64 to index
-// CHECK:               %[[VAL_169:.*]] = index_cast %[[VAL_167]] : i64 to index
-// CHECK:               %[[VAL_170:.*]] = index_cast %[[VAL_163]] : index to i64
+// CHECK:               %[[VAL_168:.*]] = arith.index_cast %[[VAL_166]] : i64 to index
+// CHECK:               %[[VAL_169:.*]] = arith.index_cast %[[VAL_167]] : i64 to index
+// CHECK:               %[[VAL_170:.*]] = arith.index_cast %[[VAL_163]] : index to i64
 // CHECK:               %[[VAL_171:.*]]:2 = scf.while (%[[VAL_172:.*]] = %[[VAL_168]], %[[VAL_173:.*]] = %[[VAL_150]]) : (index, i1) -> (index, i1) {
-// CHECK:                 %[[VAL_174:.*]] = cmpi ult, %[[VAL_172]], %[[VAL_169]] : index
-// CHECK:                 %[[VAL_175:.*]] = and %[[VAL_173]], %[[VAL_174]] : i1
+// CHECK:                 %[[VAL_174:.*]] = arith.cmpi ult, %[[VAL_172]], %[[VAL_169]] : index
+// CHECK:                 %[[VAL_175:.*]] = arith.andi %[[VAL_173]], %[[VAL_174]] : i1
 // CHECK:                 scf.condition(%[[VAL_175]]) %[[VAL_172]], %[[VAL_173]] : index, i1
 // CHECK:               } do {
 // CHECK:               ^bb0(%[[VAL_176:.*]]: index, %[[VAL_177:.*]]: i1):
 // CHECK:                 %[[VAL_178:.*]] = memref.load %[[VAL_157]]{{\[}}%[[VAL_176]]] : memref<?xi64>
-// CHECK:                 %[[VAL_179:.*]] = cmpi ne, %[[VAL_178]], %[[VAL_170]] : i64
-// CHECK:                 %[[VAL_180:.*]] = addi %[[VAL_176]], %[[VAL_153]] : index
+// CHECK:                 %[[VAL_179:.*]] = arith.cmpi ne, %[[VAL_178]], %[[VAL_170]] : i64
+// CHECK:                 %[[VAL_180:.*]] = arith.addi %[[VAL_176]], %[[VAL_153]] : index
 // CHECK:                 scf.yield %[[VAL_180]], %[[VAL_179]] : index, i1
 // CHECK:               }
 // CHECK:               %[[VAL_181:.*]] = scf.if %[[VAL_182:.*]]#1 -> (index) {
 // CHECK:                 scf.yield %[[VAL_164]] : index
 // CHECK:               } else {
-// CHECK:                 %[[VAL_183:.*]] = addi %[[VAL_164]], %[[VAL_153]] : index
+// CHECK:                 %[[VAL_183:.*]] = arith.addi %[[VAL_164]], %[[VAL_153]] : index
 // CHECK:                 scf.yield %[[VAL_183]] : index
 // CHECK:               }
 // CHECK:               scf.yield %[[VAL_184:.*]] : index
@@ -569,32 +575,32 @@ module {
 // CHECK:             %[[VAL_188:.*]] = call @vector_i64_p64i64_to_ptr8(%[[VAL_159]]) : (tensor<?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:             call @resize_values(%[[VAL_188]], %[[VAL_187]]) : (!llvm.ptr<i8>, index) -> ()
 // CHECK:             %[[VAL_189:.*]] = sparse_tensor.pointers %[[VAL_159]], %[[VAL_152]] : tensor<?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
-// CHECK:             %[[VAL_190:.*]] = index_cast %[[VAL_187]] : index to i64
+// CHECK:             %[[VAL_190:.*]] = arith.index_cast %[[VAL_187]] : index to i64
 // CHECK:             memref.store %[[VAL_190]], %[[VAL_189]]{{\[}}%[[VAL_153]]] : memref<?xi64>
 // CHECK:             %[[VAL_191:.*]] = sparse_tensor.indices %[[VAL_159]], %[[VAL_152]] : tensor<?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:             %[[VAL_192:.*]] = sparse_tensor.values %[[VAL_159]] : tensor<?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:             %[[VAL_193:.*]] = scf.for %[[VAL_194:.*]] = %[[VAL_152]] to %[[VAL_155]] step %[[VAL_153]] iter_args(%[[VAL_195:.*]] = %[[VAL_152]]) -> (index) {
-// CHECK:               %[[VAL_196:.*]] = addi %[[VAL_194]], %[[VAL_153]] : index
+// CHECK:               %[[VAL_196:.*]] = arith.addi %[[VAL_194]], %[[VAL_153]] : index
 // CHECK:               %[[VAL_197:.*]] = memref.load %[[VAL_156]]{{\[}}%[[VAL_194]]] : memref<?xi64>
 // CHECK:               %[[VAL_198:.*]] = memref.load %[[VAL_156]]{{\[}}%[[VAL_196]]] : memref<?xi64>
-// CHECK:               %[[VAL_199:.*]] = index_cast %[[VAL_197]] : i64 to index
-// CHECK:               %[[VAL_200:.*]] = index_cast %[[VAL_198]] : i64 to index
-// CHECK:               %[[VAL_201:.*]] = index_cast %[[VAL_194]] : index to i64
+// CHECK:               %[[VAL_199:.*]] = arith.index_cast %[[VAL_197]] : i64 to index
+// CHECK:               %[[VAL_200:.*]] = arith.index_cast %[[VAL_198]] : i64 to index
+// CHECK:               %[[VAL_201:.*]] = arith.index_cast %[[VAL_194]] : index to i64
 // CHECK:               %[[VAL_202:.*]]:3 = scf.while (%[[VAL_203:.*]] = %[[VAL_199]], %[[VAL_204:.*]] = %[[VAL_150]], %[[VAL_205:.*]] = %[[VAL_151]]) : (index, i1, i64) -> (index, i1, i64) {
-// CHECK:                 %[[VAL_206:.*]] = cmpi ult, %[[VAL_203]], %[[VAL_200]] : index
-// CHECK:                 %[[VAL_207:.*]] = and %[[VAL_204]], %[[VAL_206]] : i1
+// CHECK:                 %[[VAL_206:.*]] = arith.cmpi ult, %[[VAL_203]], %[[VAL_200]] : index
+// CHECK:                 %[[VAL_207:.*]] = arith.andi %[[VAL_204]], %[[VAL_206]] : i1
 // CHECK:                 scf.condition(%[[VAL_207]]) %[[VAL_203]], %[[VAL_204]], %[[VAL_205]] : index, i1, i64
 // CHECK:               } do {
 // CHECK:               ^bb0(%[[VAL_208:.*]]: index, %[[VAL_209:.*]]: i1, %[[VAL_210:.*]]: i64):
 // CHECK:                 %[[VAL_211:.*]] = memref.load %[[VAL_157]]{{\[}}%[[VAL_208]]] : memref<?xi64>
-// CHECK:                 %[[VAL_212:.*]] = cmpi ne, %[[VAL_211]], %[[VAL_201]] : i64
+// CHECK:                 %[[VAL_212:.*]] = arith.cmpi ne, %[[VAL_211]], %[[VAL_201]] : i64
 // CHECK:                 %[[VAL_213:.*]] = scf.if %[[VAL_212]] -> (i64) {
 // CHECK:                   scf.yield %[[VAL_210]] : i64
 // CHECK:                 } else {
 // CHECK:                   %[[VAL_214:.*]] = memref.load %[[VAL_158]]{{\[}}%[[VAL_208]]] : memref<?xi64>
 // CHECK:                   scf.yield %[[VAL_214]] : i64
 // CHECK:                 }
-// CHECK:                 %[[VAL_215:.*]] = addi %[[VAL_208]], %[[VAL_153]] : index
+// CHECK:                 %[[VAL_215:.*]] = arith.addi %[[VAL_208]], %[[VAL_153]] : index
 // CHECK:                 scf.yield %[[VAL_215]], %[[VAL_212]], %[[VAL_216:.*]] : index, i1, i64
 // CHECK:               }
 // CHECK:               %[[VAL_217:.*]] = scf.if %[[VAL_218:.*]]#1 -> (index) {
@@ -602,7 +608,7 @@ module {
 // CHECK:               } else {
 // CHECK:                 memref.store %[[VAL_219:.*]]#2, %[[VAL_192]]{{\[}}%[[VAL_195]]] : memref<?xi64>
 // CHECK:                 memref.store %[[VAL_201]], %[[VAL_191]]{{\[}}%[[VAL_195]]] : memref<?xi64>
-// CHECK:                 %[[VAL_220:.*]] = addi %[[VAL_195]], %[[VAL_153]] : index
+// CHECK:                 %[[VAL_220:.*]] = arith.addi %[[VAL_195]], %[[VAL_153]] : index
 // CHECK:                 scf.yield %[[VAL_220]] : index
 // CHECK:               }
 // CHECK:               scf.yield %[[VAL_221:.*]] : index

--- a/mlir_graphblas/src/test/GraphBLAS/lower_equal.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_equal.mlir
@@ -9,21 +9,21 @@
 // CHECK-LABEL:   func @vector_equal(
 // CHECK-SAME:                       %[[VAL_0:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                       %[[VAL_1:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> i1 {
-// CHECK:           %[[VAL_2:.*]] = constant 0 : index
-// CHECK:           %[[VAL_3:.*]] = constant 1 : index
-// CHECK:           %[[VAL_4:.*]] = constant false
-// CHECK:           %[[VAL_5:.*]] = constant 1 : i32
+// CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK:           %[[VAL_3:.*]] = arith.constant 1 : index
+// CHECK:           %[[VAL_4:.*]] = arith.constant false
+// CHECK:           %[[VAL_5:.*]] = arith.constant 1 : i32
 // CHECK:           %[[VAL_6:.*]] = tensor.dim %[[VAL_0]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_7:.*]] = tensor.dim %[[VAL_1]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_8:.*]] = cmpi eq, %[[VAL_6]], %[[VAL_7]] : index
+// CHECK:           %[[VAL_8:.*]] = arith.cmpi eq, %[[VAL_6]], %[[VAL_7]] : index
 // CHECK:           %[[VAL_9:.*]] = scf.if %[[VAL_8]] -> (i1) {
 // CHECK:             %[[VAL_10:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:             %[[VAL_11:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_3]]] : memref<?xi64>
-// CHECK:             %[[VAL_12:.*]] = index_cast %[[VAL_11]] : i64 to index
+// CHECK:             %[[VAL_12:.*]] = arith.index_cast %[[VAL_11]] : i64 to index
 // CHECK:             %[[VAL_13:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:             %[[VAL_14:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_3]]] : memref<?xi64>
-// CHECK:             %[[VAL_15:.*]] = index_cast %[[VAL_14]] : i64 to index
-// CHECK:             %[[VAL_16:.*]] = cmpi eq, %[[VAL_12]], %[[VAL_15]] : index
+// CHECK:             %[[VAL_15:.*]] = arith.index_cast %[[VAL_14]] : i64 to index
+// CHECK:             %[[VAL_16:.*]] = arith.cmpi eq, %[[VAL_12]], %[[VAL_15]] : index
 // CHECK:             %[[VAL_17:.*]] = scf.if %[[VAL_16]] -> (i1) {
 // CHECK:               %[[VAL_18:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:               %[[VAL_19:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
@@ -34,18 +34,18 @@
 // CHECK:                 %[[VAL_25:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_23]]] : memref<?xi64>
 // CHECK:                 %[[VAL_26:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_23]]] : memref<?xf64>
 // CHECK:                 %[[VAL_27:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_23]]] : memref<?xf64>
-// CHECK:                 %[[VAL_28:.*]] = cmpi eq, %[[VAL_24]], %[[VAL_25]] : i64
-// CHECK:                 %[[VAL_29:.*]] = cmpf oeq, %[[VAL_26]], %[[VAL_27]] : f64
-// CHECK:                 %[[VAL_30:.*]] = and %[[VAL_28]], %[[VAL_29]] : i1
-// CHECK:                 %[[VAL_31:.*]] = sexti %[[VAL_30]] : i1 to i32
+// CHECK:                 %[[VAL_28:.*]] = arith.cmpi eq, %[[VAL_24]], %[[VAL_25]] : i64
+// CHECK:                 %[[VAL_29:.*]] = arith.cmpf oeq, %[[VAL_26]], %[[VAL_27]] : f64
+// CHECK:                 %[[VAL_30:.*]] = arith.andi %[[VAL_28]], %[[VAL_29]] : i1
+// CHECK:                 %[[VAL_31:.*]] = arith.extsi %[[VAL_30]] : i1 to i32
 // CHECK:                 scf.reduce(%[[VAL_31]])  : i32 {
 // CHECK:                 ^bb0(%[[VAL_32:.*]]: i32, %[[VAL_33:.*]]: i32):
-// CHECK:                   %[[VAL_34:.*]] = and %[[VAL_32]], %[[VAL_33]] : i32
+// CHECK:                   %[[VAL_34:.*]] = arith.andi %[[VAL_32]], %[[VAL_33]] : i32
 // CHECK:                   scf.reduce.return %[[VAL_34]] : i32
 // CHECK:                 }
 // CHECK:                 scf.yield
 // CHECK:               }
-// CHECK:               %[[VAL_35:.*]] = trunci %[[VAL_36:.*]] : i32 to i1
+// CHECK:               %[[VAL_35:.*]] = arith.trunci %[[VAL_36:.*]] : i32 to i1
 // CHECK:               scf.yield %[[VAL_35]] : i1
 // CHECK:             } else {
 // CHECK:               scf.yield %[[VAL_4]] : i1

--- a/mlir_graphblas/src/test/GraphBLAS/lower_intersect.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_intersect.mlir
@@ -17,51 +17,51 @@
 // CHECK-LABEL:   func @vector_intersect(
 // CHECK-SAME:                            %[[VAL_0:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                            %[[VAL_1:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK-DAG:       %[[VAL_2:.*]] = constant 0 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_4:.*]] = constant 0 : i64
-// CHECK-DAG:       %[[VAL_5:.*]] = constant false
-// CHECK-DAG:       %[[VAL_6:.*]] = constant true
-// CHECK-DAG:       %[[VAL_7:.*]] = constant 0.000000e+00 : f64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : i64
+// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant false
+// CHECK-DAG:       %[[VAL_6:.*]] = arith.constant true
+// CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK:           %[[VAL_8:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_9:.*]] = call @empty_like(%[[VAL_8]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_10:.*]] = call @ptr8_to_vector_f64_p64i64(%[[VAL_9]]) : (!llvm.ptr<i8>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_11:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_12:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_3]]] : memref<?xi64>
-// CHECK:           %[[VAL_13:.*]] = index_cast %[[VAL_12]] : i64 to index
+// CHECK:           %[[VAL_13:.*]] = arith.index_cast %[[VAL_12]] : i64 to index
 // CHECK:           %[[VAL_14:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_15:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_3]]] : memref<?xi64>
-// CHECK:           %[[VAL_16:.*]] = index_cast %[[VAL_15]] : i64 to index
+// CHECK:           %[[VAL_16:.*]] = arith.index_cast %[[VAL_15]] : i64 to index
 // CHECK:           %[[VAL_17:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_18:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           %[[VAL_19:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_20:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           %[[VAL_21:.*]]:7 = scf.while (%[[VAL_22:.*]] = %[[VAL_2]], %[[VAL_23:.*]] = %[[VAL_2]], %[[VAL_24:.*]] = %[[VAL_2]], %[[VAL_25:.*]] = %[[VAL_2]], %[[VAL_26:.*]] = %[[VAL_6]], %[[VAL_27:.*]] = %[[VAL_6]], %[[VAL_28:.*]] = %[[VAL_2]]) : (index, index, index, index, i1, i1, index) -> (index, index, index, index, i1, i1, index) {
-// CHECK:             %[[VAL_29:.*]] = cmpi ult, %[[VAL_22]], %[[VAL_13]] : index
-// CHECK:             %[[VAL_30:.*]] = cmpi ult, %[[VAL_23]], %[[VAL_16]] : index
-// CHECK:             %[[VAL_31:.*]] = and %[[VAL_29]], %[[VAL_30]] : i1
+// CHECK:             %[[VAL_29:.*]] = arith.cmpi ult, %[[VAL_22]], %[[VAL_13]] : index
+// CHECK:             %[[VAL_30:.*]] = arith.cmpi ult, %[[VAL_23]], %[[VAL_16]] : index
+// CHECK:             %[[VAL_31:.*]] = arith.andi %[[VAL_29]], %[[VAL_30]] : i1
 // CHECK:             scf.condition(%[[VAL_31]]) %[[VAL_22]], %[[VAL_23]], %[[VAL_24]], %[[VAL_25]], %[[VAL_26]], %[[VAL_27]], %[[VAL_28]] : index, index, index, index, i1, i1, index
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_32:.*]]: index, %[[VAL_33:.*]]: index, %[[VAL_34:.*]]: index, %[[VAL_35:.*]]: index, %[[VAL_36:.*]]: i1, %[[VAL_37:.*]]: i1, %[[VAL_38:.*]]: index):
 // CHECK:             %[[VAL_39:.*]] = scf.if %[[VAL_36]] -> (index) {
 // CHECK:               %[[VAL_40:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_32]]] : memref<?xi64>
-// CHECK:               %[[VAL_41:.*]] = index_cast %[[VAL_40]] : i64 to index
+// CHECK:               %[[VAL_41:.*]] = arith.index_cast %[[VAL_40]] : i64 to index
 // CHECK:               scf.yield %[[VAL_41]] : index
 // CHECK:             } else {
 // CHECK:               scf.yield %[[VAL_34]] : index
 // CHECK:             }
 // CHECK:             %[[VAL_42:.*]] = scf.if %[[VAL_37]] -> (index) {
 // CHECK:               %[[VAL_43:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_33]]] : memref<?xi64>
-// CHECK:               %[[VAL_44:.*]] = index_cast %[[VAL_43]] : i64 to index
+// CHECK:               %[[VAL_44:.*]] = arith.index_cast %[[VAL_43]] : i64 to index
 // CHECK:               scf.yield %[[VAL_44]] : index
 // CHECK:             } else {
 // CHECK:               scf.yield %[[VAL_35]] : index
 // CHECK:             }
-// CHECK:             %[[VAL_45:.*]] = cmpi ult, %[[VAL_46:.*]], %[[VAL_47:.*]] : index
-// CHECK:             %[[VAL_48:.*]] = cmpi ugt, %[[VAL_46]], %[[VAL_47]] : index
-// CHECK:             %[[VAL_49:.*]] = addi %[[VAL_32]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_50:.*]] = addi %[[VAL_33]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_51:.*]] = addi %[[VAL_38]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_45:.*]] = arith.cmpi ult, %[[VAL_46:.*]], %[[VAL_47:.*]] : index
+// CHECK:             %[[VAL_48:.*]] = arith.cmpi ugt, %[[VAL_46]], %[[VAL_47]] : index
+// CHECK:             %[[VAL_49:.*]] = arith.addi %[[VAL_32]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_50:.*]] = arith.addi %[[VAL_33]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_51:.*]] = arith.addi %[[VAL_38]], %[[VAL_3]] : index
 // CHECK:             %[[VAL_52:.*]]:5 = scf.if %[[VAL_45]] -> (index, index, i1, i1, index) {
 // CHECK:               scf.yield %[[VAL_49]], %[[VAL_33]], %[[VAL_6]], %[[VAL_5]], %[[VAL_38]] : index, index, i1, i1, index
 // CHECK:             } else {
@@ -74,7 +74,7 @@
 // CHECK:             }
 // CHECK:             scf.yield %[[VAL_55:.*]]#0, %[[VAL_55]]#1, %[[VAL_46]], %[[VAL_47]], %[[VAL_55]]#2, %[[VAL_55]]#3, %[[VAL_55]]#4 : index, index, index, index, i1, i1, index
 // CHECK:           }
-// CHECK:           %[[VAL_56:.*]] = index_cast %[[VAL_57:.*]]#6 : index to i64
+// CHECK:           %[[VAL_56:.*]] = arith.index_cast %[[VAL_57:.*]]#6 : index to i64
 // CHECK:           %[[VAL_58:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_10]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           call @resize_index(%[[VAL_58]], %[[VAL_2]], %[[VAL_57]]#6) : (!llvm.ptr<i8>, index, index) -> ()
 // CHECK:           %[[VAL_59:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_10]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
@@ -84,9 +84,9 @@
 // CHECK:           %[[VAL_61:.*]] = sparse_tensor.indices %[[VAL_10]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_62:.*]] = sparse_tensor.values %[[VAL_10]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           %[[VAL_63:.*]]:9 = scf.while (%[[VAL_64:.*]] = %[[VAL_2]], %[[VAL_65:.*]] = %[[VAL_2]], %[[VAL_66:.*]] = %[[VAL_2]], %[[VAL_67:.*]] = %[[VAL_4]], %[[VAL_68:.*]] = %[[VAL_4]], %[[VAL_69:.*]] = %[[VAL_7]], %[[VAL_70:.*]] = %[[VAL_7]], %[[VAL_71:.*]] = %[[VAL_6]], %[[VAL_72:.*]] = %[[VAL_6]]) : (index, index, index, i64, i64, f64, f64, i1, i1) -> (index, index, index, i64, i64, f64, f64, i1, i1) {
-// CHECK:             %[[VAL_73:.*]] = cmpi ult, %[[VAL_64]], %[[VAL_13]] : index
-// CHECK:             %[[VAL_74:.*]] = cmpi ult, %[[VAL_65]], %[[VAL_16]] : index
-// CHECK:             %[[VAL_75:.*]] = and %[[VAL_73]], %[[VAL_74]] : i1
+// CHECK:             %[[VAL_73:.*]] = arith.cmpi ult, %[[VAL_64]], %[[VAL_13]] : index
+// CHECK:             %[[VAL_74:.*]] = arith.cmpi ult, %[[VAL_65]], %[[VAL_16]] : index
+// CHECK:             %[[VAL_75:.*]] = arith.andi %[[VAL_73]], %[[VAL_74]] : i1
 // CHECK:             scf.condition(%[[VAL_75]]) %[[VAL_64]], %[[VAL_65]], %[[VAL_66]], %[[VAL_67]], %[[VAL_68]], %[[VAL_69]], %[[VAL_70]], %[[VAL_71]], %[[VAL_72]] : index, index, index, i64, i64, f64, f64, i1, i1
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_76:.*]]: index, %[[VAL_77:.*]]: index, %[[VAL_78:.*]]: index, %[[VAL_79:.*]]: i64, %[[VAL_80:.*]]: i64, %[[VAL_81:.*]]: f64, %[[VAL_82:.*]]: f64, %[[VAL_83:.*]]: i1, %[[VAL_84:.*]]: i1):
@@ -104,11 +104,11 @@
 // CHECK:             } else {
 // CHECK:               scf.yield %[[VAL_80]], %[[VAL_82]] : i64, f64
 // CHECK:             }
-// CHECK:             %[[VAL_91:.*]] = cmpi ult, %[[VAL_92:.*]]#0, %[[VAL_93:.*]]#0 : i64
-// CHECK:             %[[VAL_94:.*]] = cmpi ugt, %[[VAL_92]]#0, %[[VAL_93]]#0 : i64
-// CHECK:             %[[VAL_95:.*]] = addi %[[VAL_76]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_96:.*]] = addi %[[VAL_77]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_97:.*]] = addi %[[VAL_78]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_91:.*]] = arith.cmpi ult, %[[VAL_92:.*]]#0, %[[VAL_93:.*]]#0 : i64
+// CHECK:             %[[VAL_94:.*]] = arith.cmpi ugt, %[[VAL_92]]#0, %[[VAL_93]]#0 : i64
+// CHECK:             %[[VAL_95:.*]] = arith.addi %[[VAL_76]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_96:.*]] = arith.addi %[[VAL_77]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_97:.*]] = arith.addi %[[VAL_78]], %[[VAL_3]] : index
 // CHECK:             %[[VAL_98:.*]]:5 = scf.if %[[VAL_91]] -> (index, index, index, i1, i1) {
 // CHECK:               scf.yield %[[VAL_95]], %[[VAL_77]], %[[VAL_78]], %[[VAL_6]], %[[VAL_5]] : index, index, index, i1, i1
 // CHECK:             } else {
@@ -116,7 +116,7 @@
 // CHECK:                 scf.yield %[[VAL_76]], %[[VAL_96]], %[[VAL_78]], %[[VAL_5]], %[[VAL_6]] : index, index, index, i1, i1
 // CHECK:               } else {
 // CHECK:                 memref.store %[[VAL_92]]#0, %[[VAL_61]]{{\[}}%[[VAL_78]]] : memref<?xi64>
-// CHECK:                 %[[VAL_100:.*]] = mulf %[[VAL_92]]#1, %[[VAL_93]]#1 : f64
+// CHECK:                 %[[VAL_100:.*]] = arith.mulf %[[VAL_92]]#1, %[[VAL_93]]#1 : f64
 // CHECK:                 memref.store %[[VAL_100]], %[[VAL_62]]{{\[}}%[[VAL_78]]] : memref<?xf64>
 // CHECK:                 scf.yield %[[VAL_95]], %[[VAL_96]], %[[VAL_97]], %[[VAL_6]], %[[VAL_6]] : index, index, index, i1, i1
 // CHECK:               }
@@ -136,12 +136,12 @@ func @vector_intersect(%a: tensor<?xf64, #CV64>, %b: tensor<?xf64, #CV64>) -> te
 // CHECK-LABEL:   func @matrix_intersect(
 // CHECK-SAME:                           %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                           %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK-DAG:       %[[VAL_2:.*]] = constant 0 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_4:.*]] = constant 0 : i64
-// CHECK-DAG:       %[[VAL_5:.*]] = constant false
-// CHECK-DAG:       %[[VAL_6:.*]] = constant true
-// CHECK-DAG:       %[[VAL_7:.*]] = constant 0.000000e+00 : f64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : i64
+// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant false
+// CHECK-DAG:       %[[VAL_6:.*]] = arith.constant true
+// CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK:           %[[VAL_8:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_9:.*]] = call @empty_like(%[[VAL_8]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_10:.*]] = call @ptr8_to_matrix_csr_f64_p64i64(%[[VAL_9]]) : (!llvm.ptr<i8>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -154,47 +154,47 @@ func @vector_intersect(%a: tensor<?xf64, #CV64>, %b: tensor<?xf64, #CV64>) -> te
 // CHECK:           %[[VAL_17:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           %[[VAL_18:.*]] = sparse_tensor.pointers %[[VAL_10]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           scf.parallel (%[[VAL_19:.*]]) = (%[[VAL_2]]) to (%[[VAL_11]]) step (%[[VAL_3]]) {
-// CHECK:             %[[VAL_20:.*]] = addi %[[VAL_19]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_20:.*]] = arith.addi %[[VAL_19]], %[[VAL_3]] : index
 // CHECK:             %[[VAL_21:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_19]]] : memref<?xi64>
 // CHECK:             %[[VAL_22:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_20]]] : memref<?xi64>
 // CHECK:             %[[VAL_23:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_19]]] : memref<?xi64>
 // CHECK:             %[[VAL_24:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_20]]] : memref<?xi64>
-// CHECK:             %[[VAL_25:.*]] = cmpi eq, %[[VAL_21]], %[[VAL_22]] : i64
-// CHECK:             %[[VAL_26:.*]] = cmpi eq, %[[VAL_23]], %[[VAL_24]] : i64
-// CHECK:             %[[VAL_27:.*]] = or %[[VAL_25]], %[[VAL_26]] : i1
+// CHECK:             %[[VAL_25:.*]] = arith.cmpi eq, %[[VAL_21]], %[[VAL_22]] : i64
+// CHECK:             %[[VAL_26:.*]] = arith.cmpi eq, %[[VAL_23]], %[[VAL_24]] : i64
+// CHECK:             %[[VAL_27:.*]] = arith.ori %[[VAL_25]], %[[VAL_26]] : i1
 // CHECK:             %[[VAL_28:.*]] = scf.if %[[VAL_27]] -> (i64) {
 // CHECK:               scf.yield %[[VAL_4]] : i64
 // CHECK:             } else {
-// CHECK:               %[[VAL_29:.*]] = index_cast %[[VAL_21]] : i64 to index
-// CHECK:               %[[VAL_30:.*]] = index_cast %[[VAL_22]] : i64 to index
-// CHECK:               %[[VAL_31:.*]] = index_cast %[[VAL_23]] : i64 to index
-// CHECK:               %[[VAL_32:.*]] = index_cast %[[VAL_24]] : i64 to index
+// CHECK:               %[[VAL_29:.*]] = arith.index_cast %[[VAL_21]] : i64 to index
+// CHECK:               %[[VAL_30:.*]] = arith.index_cast %[[VAL_22]] : i64 to index
+// CHECK:               %[[VAL_31:.*]] = arith.index_cast %[[VAL_23]] : i64 to index
+// CHECK:               %[[VAL_32:.*]] = arith.index_cast %[[VAL_24]] : i64 to index
 // CHECK:               %[[VAL_33:.*]]:7 = scf.while (%[[VAL_34:.*]] = %[[VAL_29]], %[[VAL_35:.*]] = %[[VAL_31]], %[[VAL_36:.*]] = %[[VAL_2]], %[[VAL_37:.*]] = %[[VAL_2]], %[[VAL_38:.*]] = %[[VAL_6]], %[[VAL_39:.*]] = %[[VAL_6]], %[[VAL_40:.*]] = %[[VAL_2]]) : (index, index, index, index, i1, i1, index) -> (index, index, index, index, i1, i1, index) {
-// CHECK:                 %[[VAL_41:.*]] = cmpi ult, %[[VAL_34]], %[[VAL_30]] : index
-// CHECK:                 %[[VAL_42:.*]] = cmpi ult, %[[VAL_35]], %[[VAL_32]] : index
-// CHECK:                 %[[VAL_43:.*]] = and %[[VAL_41]], %[[VAL_42]] : i1
+// CHECK:                 %[[VAL_41:.*]] = arith.cmpi ult, %[[VAL_34]], %[[VAL_30]] : index
+// CHECK:                 %[[VAL_42:.*]] = arith.cmpi ult, %[[VAL_35]], %[[VAL_32]] : index
+// CHECK:                 %[[VAL_43:.*]] = arith.andi %[[VAL_41]], %[[VAL_42]] : i1
 // CHECK:                 scf.condition(%[[VAL_43]]) %[[VAL_34]], %[[VAL_35]], %[[VAL_36]], %[[VAL_37]], %[[VAL_38]], %[[VAL_39]], %[[VAL_40]] : index, index, index, index, i1, i1, index
 // CHECK:               } do {
 // CHECK:               ^bb0(%[[VAL_44:.*]]: index, %[[VAL_45:.*]]: index, %[[VAL_46:.*]]: index, %[[VAL_47:.*]]: index, %[[VAL_48:.*]]: i1, %[[VAL_49:.*]]: i1, %[[VAL_50:.*]]: index):
 // CHECK:                 %[[VAL_51:.*]] = scf.if %[[VAL_48]] -> (index) {
 // CHECK:                   %[[VAL_52:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_44]]] : memref<?xi64>
-// CHECK:                   %[[VAL_53:.*]] = index_cast %[[VAL_52]] : i64 to index
+// CHECK:                   %[[VAL_53:.*]] = arith.index_cast %[[VAL_52]] : i64 to index
 // CHECK:                   scf.yield %[[VAL_53]] : index
 // CHECK:                 } else {
 // CHECK:                   scf.yield %[[VAL_46]] : index
 // CHECK:                 }
 // CHECK:                 %[[VAL_54:.*]] = scf.if %[[VAL_49]] -> (index) {
 // CHECK:                   %[[VAL_55:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_45]]] : memref<?xi64>
-// CHECK:                   %[[VAL_56:.*]] = index_cast %[[VAL_55]] : i64 to index
+// CHECK:                   %[[VAL_56:.*]] = arith.index_cast %[[VAL_55]] : i64 to index
 // CHECK:                   scf.yield %[[VAL_56]] : index
 // CHECK:                 } else {
 // CHECK:                   scf.yield %[[VAL_47]] : index
 // CHECK:                 }
-// CHECK:                 %[[VAL_57:.*]] = cmpi ult, %[[VAL_58:.*]], %[[VAL_59:.*]] : index
-// CHECK:                 %[[VAL_60:.*]] = cmpi ugt, %[[VAL_58]], %[[VAL_59]] : index
-// CHECK:                 %[[VAL_61:.*]] = addi %[[VAL_44]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_62:.*]] = addi %[[VAL_45]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_63:.*]] = addi %[[VAL_50]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_57:.*]] = arith.cmpi ult, %[[VAL_58:.*]], %[[VAL_59:.*]] : index
+// CHECK:                 %[[VAL_60:.*]] = arith.cmpi ugt, %[[VAL_58]], %[[VAL_59]] : index
+// CHECK:                 %[[VAL_61:.*]] = arith.addi %[[VAL_44]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_62:.*]] = arith.addi %[[VAL_45]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_63:.*]] = arith.addi %[[VAL_50]], %[[VAL_3]] : index
 // CHECK:                 %[[VAL_64:.*]]:5 = scf.if %[[VAL_57]] -> (index, index, i1, i1, index) {
 // CHECK:                   scf.yield %[[VAL_61]], %[[VAL_45]], %[[VAL_6]], %[[VAL_5]], %[[VAL_50]] : index, index, i1, i1, index
 // CHECK:                 } else {
@@ -207,7 +207,7 @@ func @vector_intersect(%a: tensor<?xf64, #CV64>, %b: tensor<?xf64, #CV64>) -> te
 // CHECK:                 }
 // CHECK:                 scf.yield %[[VAL_67:.*]]#0, %[[VAL_67]]#1, %[[VAL_58]], %[[VAL_59]], %[[VAL_67]]#2, %[[VAL_67]]#3, %[[VAL_67]]#4 : index, index, index, index, i1, i1, index
 // CHECK:               }
-// CHECK:               %[[VAL_68:.*]] = index_cast %[[VAL_69:.*]]#6 : index to i64
+// CHECK:               %[[VAL_68:.*]] = arith.index_cast %[[VAL_69:.*]]#6 : index to i64
 // CHECK:               scf.yield %[[VAL_68]] : i64
 // CHECK:             }
 // CHECK:             memref.store %[[VAL_70:.*]], %[[VAL_18]]{{\[}}%[[VAL_19]]] : memref<?xi64>
@@ -218,13 +218,13 @@ func @vector_intersect(%a: tensor<?xf64, #CV64>, %b: tensor<?xf64, #CV64>) -> te
 // CHECK:             %[[VAL_72:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_71]]] : memref<?xi64>
 // CHECK:             %[[VAL_73:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_11]]] : memref<?xi64>
 // CHECK:             memref.store %[[VAL_73]], %[[VAL_18]]{{\[}}%[[VAL_71]]] : memref<?xi64>
-// CHECK:             %[[VAL_74:.*]] = addi %[[VAL_73]], %[[VAL_72]] : i64
+// CHECK:             %[[VAL_74:.*]] = arith.addi %[[VAL_73]], %[[VAL_72]] : i64
 // CHECK:             memref.store %[[VAL_74]], %[[VAL_18]]{{\[}}%[[VAL_11]]] : memref<?xi64>
 // CHECK:           }
 // CHECK:           %[[VAL_75:.*]] = sparse_tensor.pointers %[[VAL_10]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_76:.*]] = tensor.dim %[[VAL_10]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_77:.*]] = memref.load %[[VAL_75]]{{\[}}%[[VAL_76]]] : memref<?xi64>
-// CHECK:           %[[VAL_78:.*]] = index_cast %[[VAL_77]] : i64 to index
+// CHECK:           %[[VAL_78:.*]] = arith.index_cast %[[VAL_77]] : i64 to index
 // CHECK:           %[[VAL_79:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_10]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           call @resize_index(%[[VAL_79]], %[[VAL_3]], %[[VAL_78]]) : (!llvm.ptr<i8>, index, index) -> ()
 // CHECK:           %[[VAL_80:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_10]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
@@ -232,25 +232,25 @@ func @vector_intersect(%a: tensor<?xf64, #CV64>, %b: tensor<?xf64, #CV64>) -> te
 // CHECK:           %[[VAL_81:.*]] = sparse_tensor.indices %[[VAL_10]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_82:.*]] = sparse_tensor.values %[[VAL_10]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           scf.parallel (%[[VAL_83:.*]]) = (%[[VAL_2]]) to (%[[VAL_11]]) step (%[[VAL_3]]) {
-// CHECK:             %[[VAL_84:.*]] = addi %[[VAL_83]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_84:.*]] = arith.addi %[[VAL_83]], %[[VAL_3]] : index
 // CHECK:             %[[VAL_85:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_83]]] : memref<?xi64>
 // CHECK:             %[[VAL_86:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_84]]] : memref<?xi64>
-// CHECK:             %[[VAL_87:.*]] = cmpi ne, %[[VAL_85]], %[[VAL_86]] : i64
+// CHECK:             %[[VAL_87:.*]] = arith.cmpi ne, %[[VAL_85]], %[[VAL_86]] : i64
 // CHECK:             scf.if %[[VAL_87]] {
 // CHECK:               %[[VAL_88:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_83]]] : memref<?xi64>
-// CHECK:               %[[VAL_89:.*]] = index_cast %[[VAL_88]] : i64 to index
+// CHECK:               %[[VAL_89:.*]] = arith.index_cast %[[VAL_88]] : i64 to index
 // CHECK:               %[[VAL_90:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_83]]] : memref<?xi64>
 // CHECK:               %[[VAL_91:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_84]]] : memref<?xi64>
-// CHECK:               %[[VAL_92:.*]] = index_cast %[[VAL_90]] : i64 to index
-// CHECK:               %[[VAL_93:.*]] = index_cast %[[VAL_91]] : i64 to index
+// CHECK:               %[[VAL_92:.*]] = arith.index_cast %[[VAL_90]] : i64 to index
+// CHECK:               %[[VAL_93:.*]] = arith.index_cast %[[VAL_91]] : i64 to index
 // CHECK:               %[[VAL_94:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_83]]] : memref<?xi64>
 // CHECK:               %[[VAL_95:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_84]]] : memref<?xi64>
-// CHECK:               %[[VAL_96:.*]] = index_cast %[[VAL_94]] : i64 to index
-// CHECK:               %[[VAL_97:.*]] = index_cast %[[VAL_95]] : i64 to index
+// CHECK:               %[[VAL_96:.*]] = arith.index_cast %[[VAL_94]] : i64 to index
+// CHECK:               %[[VAL_97:.*]] = arith.index_cast %[[VAL_95]] : i64 to index
 // CHECK:               %[[VAL_98:.*]]:9 = scf.while (%[[VAL_99:.*]] = %[[VAL_92]], %[[VAL_100:.*]] = %[[VAL_96]], %[[VAL_101:.*]] = %[[VAL_89]], %[[VAL_102:.*]] = %[[VAL_4]], %[[VAL_103:.*]] = %[[VAL_4]], %[[VAL_104:.*]] = %[[VAL_7]], %[[VAL_105:.*]] = %[[VAL_7]], %[[VAL_106:.*]] = %[[VAL_6]], %[[VAL_107:.*]] = %[[VAL_6]]) : (index, index, index, i64, i64, f64, f64, i1, i1) -> (index, index, index, i64, i64, f64, f64, i1, i1) {
-// CHECK:                 %[[VAL_108:.*]] = cmpi ult, %[[VAL_99]], %[[VAL_93]] : index
-// CHECK:                 %[[VAL_109:.*]] = cmpi ult, %[[VAL_100]], %[[VAL_97]] : index
-// CHECK:                 %[[VAL_110:.*]] = and %[[VAL_108]], %[[VAL_109]] : i1
+// CHECK:                 %[[VAL_108:.*]] = arith.cmpi ult, %[[VAL_99]], %[[VAL_93]] : index
+// CHECK:                 %[[VAL_109:.*]] = arith.cmpi ult, %[[VAL_100]], %[[VAL_97]] : index
+// CHECK:                 %[[VAL_110:.*]] = arith.andi %[[VAL_108]], %[[VAL_109]] : i1
 // CHECK:                 scf.condition(%[[VAL_110]]) %[[VAL_99]], %[[VAL_100]], %[[VAL_101]], %[[VAL_102]], %[[VAL_103]], %[[VAL_104]], %[[VAL_105]], %[[VAL_106]], %[[VAL_107]] : index, index, index, i64, i64, f64, f64, i1, i1
 // CHECK:               } do {
 // CHECK:               ^bb0(%[[VAL_111:.*]]: index, %[[VAL_112:.*]]: index, %[[VAL_113:.*]]: index, %[[VAL_114:.*]]: i64, %[[VAL_115:.*]]: i64, %[[VAL_116:.*]]: f64, %[[VAL_117:.*]]: f64, %[[VAL_118:.*]]: i1, %[[VAL_119:.*]]: i1):
@@ -268,11 +268,11 @@ func @vector_intersect(%a: tensor<?xf64, #CV64>, %b: tensor<?xf64, #CV64>) -> te
 // CHECK:                 } else {
 // CHECK:                   scf.yield %[[VAL_115]], %[[VAL_117]] : i64, f64
 // CHECK:                 }
-// CHECK:                 %[[VAL_126:.*]] = cmpi ult, %[[VAL_127:.*]]#0, %[[VAL_128:.*]]#0 : i64
-// CHECK:                 %[[VAL_129:.*]] = cmpi ugt, %[[VAL_127]]#0, %[[VAL_128]]#0 : i64
-// CHECK:                 %[[VAL_130:.*]] = addi %[[VAL_111]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_131:.*]] = addi %[[VAL_112]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_132:.*]] = addi %[[VAL_113]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_126:.*]] = arith.cmpi ult, %[[VAL_127:.*]]#0, %[[VAL_128:.*]]#0 : i64
+// CHECK:                 %[[VAL_129:.*]] = arith.cmpi ugt, %[[VAL_127]]#0, %[[VAL_128]]#0 : i64
+// CHECK:                 %[[VAL_130:.*]] = arith.addi %[[VAL_111]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_131:.*]] = arith.addi %[[VAL_112]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_132:.*]] = arith.addi %[[VAL_113]], %[[VAL_3]] : index
 // CHECK:                 %[[VAL_133:.*]]:5 = scf.if %[[VAL_126]] -> (index, index, index, i1, i1) {
 // CHECK:                   scf.yield %[[VAL_130]], %[[VAL_112]], %[[VAL_113]], %[[VAL_6]], %[[VAL_5]] : index, index, index, i1, i1
 // CHECK:                 } else {
@@ -280,7 +280,7 @@ func @vector_intersect(%a: tensor<?xf64, #CV64>, %b: tensor<?xf64, #CV64>) -> te
 // CHECK:                     scf.yield %[[VAL_111]], %[[VAL_131]], %[[VAL_113]], %[[VAL_5]], %[[VAL_6]] : index, index, index, i1, i1
 // CHECK:                   } else {
 // CHECK:                     memref.store %[[VAL_127]]#0, %[[VAL_81]]{{\[}}%[[VAL_113]]] : memref<?xi64>
-// CHECK:                     %[[VAL_135:.*]] = mulf %[[VAL_127]]#1, %[[VAL_128]]#1 : f64
+// CHECK:                     %[[VAL_135:.*]] = arith.mulf %[[VAL_127]]#1, %[[VAL_128]]#1 : f64
 // CHECK:                     memref.store %[[VAL_135]], %[[VAL_82]]{{\[}}%[[VAL_113]]] : memref<?xf64>
 // CHECK:                     scf.yield %[[VAL_130]], %[[VAL_131]], %[[VAL_132]], %[[VAL_6]], %[[VAL_6]] : index, index, index, i1, i1
 // CHECK:                   }

--- a/mlir_graphblas/src/test/GraphBLAS/lower_matrix_multiply_full.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_matrix_multiply_full.mlir
@@ -17,17 +17,17 @@
 // CHECK-LABEL:   func @matrix_multiply_plus_times(
 // CHECK-SAME:                                     %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                                     %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK-DAG:       %[[VAL_2:.*]] = constant 0 : i64
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 1 : i64
-// CHECK-DAG:       %[[VAL_4:.*]] = constant 0 : index
-// CHECK-DAG:       %[[VAL_5:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_6:.*]] = constant true
-// CHECK-DAG:       %[[VAL_7:.*]] = constant false
-// CHECK-DAG:       %[[VAL_8:.*]] = constant 0.000000e+00 : f64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i64
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : i64
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_6:.*]] = arith.constant true
+// CHECK-DAG:       %[[VAL_7:.*]] = arith.constant false
+// CHECK-DAG:       %[[VAL_8:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK:           %[[VAL_9:.*]] = tensor.dim %[[VAL_0]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_10:.*]] = tensor.dim %[[VAL_1]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_11:.*]] = tensor.dim %[[VAL_0]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_12:.*]] = addi %[[VAL_9]], %[[VAL_5]] : index
+// CHECK:           %[[VAL_12:.*]] = arith.addi %[[VAL_9]], %[[VAL_5]] : index
 // CHECK:           %[[VAL_13:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_14:.*]] = call @empty_like(%[[VAL_13]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_15:.*]] = call @ptr8_to_matrix_csr_f64_p64i64(%[[VAL_14]]) : (!llvm.ptr<i8>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -46,38 +46,38 @@
 // CHECK:           %[[VAL_25:.*]] = sparse_tensor.pointers %[[VAL_15]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           scf.parallel (%[[VAL_26:.*]]) = (%[[VAL_4]]) to (%[[VAL_9]]) step (%[[VAL_5]]) {
 // CHECK:             %[[VAL_27:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_26]]] : memref<?xi64>
-// CHECK:             %[[VAL_28:.*]] = addi %[[VAL_26]], %[[VAL_5]] : index
+// CHECK:             %[[VAL_28:.*]] = arith.addi %[[VAL_26]], %[[VAL_5]] : index
 // CHECK:             %[[VAL_29:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_28]]] : memref<?xi64>
-// CHECK:             %[[VAL_30:.*]] = cmpi eq, %[[VAL_27]], %[[VAL_29]] : i64
+// CHECK:             %[[VAL_30:.*]] = arith.cmpi eq, %[[VAL_27]], %[[VAL_29]] : i64
 // CHECK:             %[[VAL_31:.*]] = scf.if %[[VAL_30]] -> (i64) {
 // CHECK:               scf.yield %[[VAL_2]] : i64
 // CHECK:             } else {
-// CHECK:               %[[VAL_32:.*]] = index_cast %[[VAL_27]] : i64 to index
-// CHECK:               %[[VAL_33:.*]] = index_cast %[[VAL_29]] : i64 to index
+// CHECK:               %[[VAL_32:.*]] = arith.index_cast %[[VAL_27]] : i64 to index
+// CHECK:               %[[VAL_33:.*]] = arith.index_cast %[[VAL_29]] : i64 to index
 // CHECK:               %[[VAL_34:.*]] = memref.alloc(%[[VAL_11]]) : memref<?xi1>
 // CHECK:               linalg.fill(%[[VAL_7]], %[[VAL_34]]) : i1, memref<?xi1>
 // CHECK:               scf.parallel (%[[VAL_35:.*]]) = (%[[VAL_32]]) to (%[[VAL_33]]) step (%[[VAL_5]]) {
 // CHECK:                 %[[VAL_36:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_35]]] : memref<?xi64>
-// CHECK:                 %[[VAL_37:.*]] = index_cast %[[VAL_36]] : i64 to index
+// CHECK:                 %[[VAL_37:.*]] = arith.index_cast %[[VAL_36]] : i64 to index
 // CHECK:                 memref.store %[[VAL_6]], %[[VAL_34]]{{\[}}%[[VAL_37]]] : memref<?xi1>
 // CHECK:                 scf.yield
 // CHECK:               }
 // CHECK:               %[[VAL_38:.*]] = scf.parallel (%[[VAL_39:.*]]) = (%[[VAL_4]]) to (%[[VAL_10]]) step (%[[VAL_5]]) init (%[[VAL_2]]) -> i64 {
-// CHECK:                 %[[VAL_40:.*]] = addi %[[VAL_39]], %[[VAL_5]] : index
+// CHECK:                 %[[VAL_40:.*]] = arith.addi %[[VAL_39]], %[[VAL_5]] : index
 // CHECK:                 %[[VAL_41:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_39]]] : memref<?xi64>
 // CHECK:                 %[[VAL_42:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_40]]] : memref<?xi64>
-// CHECK:                 %[[VAL_43:.*]] = cmpi eq, %[[VAL_41]], %[[VAL_42]] : i64
+// CHECK:                 %[[VAL_43:.*]] = arith.cmpi eq, %[[VAL_41]], %[[VAL_42]] : i64
 // CHECK:                 %[[VAL_44:.*]] = scf.if %[[VAL_43]] -> (i64) {
 // CHECK:                   scf.yield %[[VAL_2]] : i64
 // CHECK:                 } else {
 // CHECK:                   %[[VAL_45:.*]] = scf.while (%[[VAL_46:.*]] = %[[VAL_41]]) : (i64) -> i64 {
-// CHECK:                     %[[VAL_47:.*]] = cmpi uge, %[[VAL_46]], %[[VAL_42]] : i64
+// CHECK:                     %[[VAL_47:.*]] = arith.cmpi uge, %[[VAL_46]], %[[VAL_42]] : i64
 // CHECK:                     %[[VAL_48:.*]]:2 = scf.if %[[VAL_47]] -> (i1, i64) {
 // CHECK:                       scf.yield %[[VAL_7]], %[[VAL_2]] : i1, i64
 // CHECK:                     } else {
-// CHECK:                       %[[VAL_49:.*]] = index_cast %[[VAL_46]] : i64 to index
+// CHECK:                       %[[VAL_49:.*]] = arith.index_cast %[[VAL_46]] : i64 to index
 // CHECK:                       %[[VAL_50:.*]] = memref.load %[[VAL_23]]{{\[}}%[[VAL_49]]] : memref<?xi64>
-// CHECK:                       %[[VAL_51:.*]] = index_cast %[[VAL_50]] : i64 to index
+// CHECK:                       %[[VAL_51:.*]] = arith.index_cast %[[VAL_50]] : i64 to index
 // CHECK:                       %[[VAL_52:.*]] = memref.load %[[VAL_34]]{{\[}}%[[VAL_51]]] : memref<?xi1>
 // CHECK:                       %[[VAL_53:.*]] = select %[[VAL_52]], %[[VAL_7]], %[[VAL_6]] : i1
 // CHECK:                       %[[VAL_54:.*]] = select %[[VAL_52]], %[[VAL_3]], %[[VAL_46]] : i64
@@ -86,14 +86,14 @@
 // CHECK:                     scf.condition(%[[VAL_55:.*]]#0) %[[VAL_55]]#1 : i64
 // CHECK:                   } do {
 // CHECK:                   ^bb0(%[[VAL_56:.*]]: i64):
-// CHECK:                     %[[VAL_57:.*]] = addi %[[VAL_56]], %[[VAL_3]] : i64
+// CHECK:                     %[[VAL_57:.*]] = arith.addi %[[VAL_56]], %[[VAL_3]] : i64
 // CHECK:                     scf.yield %[[VAL_57]] : i64
 // CHECK:                   }
 // CHECK:                   scf.yield %[[VAL_58:.*]] : i64
 // CHECK:                 }
 // CHECK:                 scf.reduce(%[[VAL_59:.*]])  : i64 {
 // CHECK:                 ^bb0(%[[VAL_60:.*]]: i64, %[[VAL_61:.*]]: i64):
-// CHECK:                   %[[VAL_62:.*]] = addi %[[VAL_60]], %[[VAL_61]] : i64
+// CHECK:                   %[[VAL_62:.*]] = arith.addi %[[VAL_60]], %[[VAL_61]] : i64
 // CHECK:                   scf.reduce.return %[[VAL_62]] : i64
 // CHECK:                 }
 // CHECK:                 scf.yield
@@ -108,13 +108,13 @@
 // CHECK:             %[[VAL_66:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_65]]] : memref<?xi64>
 // CHECK:             %[[VAL_67:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_9]]] : memref<?xi64>
 // CHECK:             memref.store %[[VAL_67]], %[[VAL_25]]{{\[}}%[[VAL_65]]] : memref<?xi64>
-// CHECK:             %[[VAL_68:.*]] = addi %[[VAL_67]], %[[VAL_66]] : i64
+// CHECK:             %[[VAL_68:.*]] = arith.addi %[[VAL_67]], %[[VAL_66]] : i64
 // CHECK:             memref.store %[[VAL_68]], %[[VAL_25]]{{\[}}%[[VAL_9]]] : memref<?xi64>
 // CHECK:           }
 // CHECK:           %[[VAL_69:.*]] = sparse_tensor.pointers %[[VAL_15]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_70:.*]] = tensor.dim %[[VAL_15]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_71:.*]] = memref.load %[[VAL_69]]{{\[}}%[[VAL_70]]] : memref<?xi64>
-// CHECK:           %[[VAL_72:.*]] = index_cast %[[VAL_71]] : i64 to index
+// CHECK:           %[[VAL_72:.*]] = arith.index_cast %[[VAL_71]] : i64 to index
 // CHECK:           %[[VAL_73:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_15]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           call @resize_index(%[[VAL_73]], %[[VAL_5]], %[[VAL_72]]) : (!llvm.ptr<i8>, index, index) -> ()
 // CHECK:           %[[VAL_74:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_15]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
@@ -122,44 +122,44 @@
 // CHECK:           %[[VAL_75:.*]] = sparse_tensor.indices %[[VAL_15]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_76:.*]] = sparse_tensor.values %[[VAL_15]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           scf.parallel (%[[VAL_77:.*]]) = (%[[VAL_4]]) to (%[[VAL_9]]) step (%[[VAL_5]]) {
-// CHECK:             %[[VAL_78:.*]] = addi %[[VAL_77]], %[[VAL_5]] : index
+// CHECK:             %[[VAL_78:.*]] = arith.addi %[[VAL_77]], %[[VAL_5]] : index
 // CHECK:             %[[VAL_79:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_77]]] : memref<?xi64>
 // CHECK:             %[[VAL_80:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_78]]] : memref<?xi64>
-// CHECK:             %[[VAL_81:.*]] = cmpi ne, %[[VAL_79]], %[[VAL_80]] : i64
+// CHECK:             %[[VAL_81:.*]] = arith.cmpi ne, %[[VAL_79]], %[[VAL_80]] : i64
 // CHECK:             scf.if %[[VAL_81]] {
 // CHECK:               %[[VAL_82:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_77]]] : memref<?xi64>
-// CHECK:               %[[VAL_83:.*]] = index_cast %[[VAL_82]] : i64 to index
+// CHECK:               %[[VAL_83:.*]] = arith.index_cast %[[VAL_82]] : i64 to index
 // CHECK:               %[[VAL_84:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_77]]] : memref<?xi64>
 // CHECK:               %[[VAL_85:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_78]]] : memref<?xi64>
-// CHECK:               %[[VAL_86:.*]] = index_cast %[[VAL_84]] : i64 to index
-// CHECK:               %[[VAL_87:.*]] = index_cast %[[VAL_85]] : i64 to index
+// CHECK:               %[[VAL_86:.*]] = arith.index_cast %[[VAL_84]] : i64 to index
+// CHECK:               %[[VAL_87:.*]] = arith.index_cast %[[VAL_85]] : i64 to index
 // CHECK:               %[[VAL_88:.*]] = memref.alloc(%[[VAL_11]]) : memref<?xf64>
 // CHECK:               %[[VAL_89:.*]] = memref.alloc(%[[VAL_11]]) : memref<?xi1>
 // CHECK:               linalg.fill(%[[VAL_7]], %[[VAL_89]]) : i1, memref<?xi1>
 // CHECK:               scf.parallel (%[[VAL_90:.*]]) = (%[[VAL_86]]) to (%[[VAL_87]]) step (%[[VAL_5]]) {
 // CHECK:                 %[[VAL_91:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_90]]] : memref<?xi64>
-// CHECK:                 %[[VAL_92:.*]] = index_cast %[[VAL_91]] : i64 to index
+// CHECK:                 %[[VAL_92:.*]] = arith.index_cast %[[VAL_91]] : i64 to index
 // CHECK:                 memref.store %[[VAL_6]], %[[VAL_89]]{{\[}}%[[VAL_92]]] : memref<?xi1>
 // CHECK:                 %[[VAL_93:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_90]]] : memref<?xf64>
 // CHECK:                 memref.store %[[VAL_93]], %[[VAL_88]]{{\[}}%[[VAL_92]]] : memref<?xf64>
 // CHECK:                 scf.yield
 // CHECK:               }
 // CHECK:               %[[VAL_94:.*]] = scf.for %[[VAL_95:.*]] = %[[VAL_4]] to %[[VAL_10]] step %[[VAL_5]] iter_args(%[[VAL_96:.*]] = %[[VAL_4]]) -> (index) {
-// CHECK:                 %[[VAL_97:.*]] = index_cast %[[VAL_95]] : index to i64
-// CHECK:                 %[[VAL_98:.*]] = addi %[[VAL_95]], %[[VAL_5]] : index
+// CHECK:                 %[[VAL_97:.*]] = arith.index_cast %[[VAL_95]] : index to i64
+// CHECK:                 %[[VAL_98:.*]] = arith.addi %[[VAL_95]], %[[VAL_5]] : index
 // CHECK:                 %[[VAL_99:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_95]]] : memref<?xi64>
 // CHECK:                 %[[VAL_100:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_98]]] : memref<?xi64>
-// CHECK:                 %[[VAL_101:.*]] = index_cast %[[VAL_99]] : i64 to index
-// CHECK:                 %[[VAL_102:.*]] = index_cast %[[VAL_100]] : i64 to index
+// CHECK:                 %[[VAL_101:.*]] = arith.index_cast %[[VAL_99]] : i64 to index
+// CHECK:                 %[[VAL_102:.*]] = arith.index_cast %[[VAL_100]] : i64 to index
 // CHECK:                 %[[VAL_103:.*]]:2 = scf.for %[[VAL_104:.*]] = %[[VAL_101]] to %[[VAL_102]] step %[[VAL_5]] iter_args(%[[VAL_105:.*]] = %[[VAL_8]], %[[VAL_106:.*]] = %[[VAL_7]]) -> (f64, i1) {
 // CHECK:                   %[[VAL_107:.*]] = memref.load %[[VAL_23]]{{\[}}%[[VAL_104]]] : memref<?xi64>
-// CHECK:                   %[[VAL_108:.*]] = index_cast %[[VAL_107]] : i64 to index
+// CHECK:                   %[[VAL_108:.*]] = arith.index_cast %[[VAL_107]] : i64 to index
 // CHECK:                   %[[VAL_109:.*]] = memref.load %[[VAL_89]]{{\[}}%[[VAL_108]]] : memref<?xi1>
 // CHECK:                   %[[VAL_110:.*]]:2 = scf.if %[[VAL_109]] -> (f64, i1) {
 // CHECK:                     %[[VAL_111:.*]] = memref.load %[[VAL_88]]{{\[}}%[[VAL_108]]] : memref<?xf64>
 // CHECK:                     %[[VAL_112:.*]] = memref.load %[[VAL_24]]{{\[}}%[[VAL_104]]] : memref<?xf64>
-// CHECK:                     %[[VAL_113:.*]] = mulf %[[VAL_111]], %[[VAL_112]] : f64
-// CHECK:                     %[[VAL_114:.*]] = addf %[[VAL_105]], %[[VAL_113]] : f64
+// CHECK:                     %[[VAL_113:.*]] = arith.mulf %[[VAL_111]], %[[VAL_112]] : f64
+// CHECK:                     %[[VAL_114:.*]] = arith.addf %[[VAL_105]], %[[VAL_113]] : f64
 // CHECK:                     scf.yield %[[VAL_114]], %[[VAL_6]] : f64, i1
 // CHECK:                   } else {
 // CHECK:                     scf.yield %[[VAL_105]], %[[VAL_106]] : f64, i1
@@ -167,10 +167,10 @@
 // CHECK:                   scf.yield %[[VAL_115:.*]]#0, %[[VAL_115]]#1 : f64, i1
 // CHECK:                 }
 // CHECK:                 %[[VAL_116:.*]] = scf.if %[[VAL_117:.*]]#1 -> (index) {
-// CHECK:                   %[[VAL_118:.*]] = addi %[[VAL_83]], %[[VAL_96]] : index
+// CHECK:                   %[[VAL_118:.*]] = arith.addi %[[VAL_83]], %[[VAL_96]] : index
 // CHECK:                   memref.store %[[VAL_97]], %[[VAL_75]]{{\[}}%[[VAL_118]]] : memref<?xi64>
 // CHECK:                   memref.store %[[VAL_117]]#0, %[[VAL_76]]{{\[}}%[[VAL_118]]] : memref<?xf64>
-// CHECK:                   %[[VAL_119:.*]] = addi %[[VAL_96]], %[[VAL_5]] : index
+// CHECK:                   %[[VAL_119:.*]] = arith.addi %[[VAL_96]], %[[VAL_5]] : index
 // CHECK:                   scf.yield %[[VAL_119]] : index
 // CHECK:                 } else {
 // CHECK:                   scf.yield %[[VAL_96]] : index

--- a/mlir_graphblas/src/test/GraphBLAS/lower_matrix_multiply_generic.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_matrix_multiply_generic.mlir
@@ -15,33 +15,33 @@
 }>
 
 
-// look for inlined addition of 4.0 to total
+// look for inlined arith.addition of 4.0 to total
 
-// CHECK:           %[[VAL_6:.*]] = constant 4.000000e+00 : f64
+// CHECK:           %[[VAL_6:.*]] = arith.constant 4.000000e+00 : f64
 // CHECK:                 %[[VAL_107:.*]] = scf.if %[[VAL_108:.*]]#1 -> (index) {
-// CHECK:                   %[[VAL_109:.*]] = addi %[[VAL_74:.*]], %[[VAL_87:.*]] : index
+// CHECK:                   %[[VAL_109:.*]] = arith.addi %[[VAL_74:.*]], %[[VAL_87:.*]] : index
 // CHECK:                   memref.store %[[VAL_88:.*]], %[[VAL_66:.*]]{{\[}}%[[VAL_109]]] : memref<?xi64>
-// CHECK:                   %[[VAL_2000:.*]] = addf %[[VAL_108]]#0, %[[VAL_6]] : f64
+// CHECK:                   %[[VAL_2000:.*]] = arith.addf %[[VAL_108]]#0, %[[VAL_6]] : f64
 // CHECK:                   memref.store %[[VAL_2000]], %[[VAL_67:.*]]{{\[}}%[[VAL_109]]] : memref<?xf64>
 
 func @matrix_multiply_plus_times(%a: tensor<?x?xf64, #CSR64>, %b: tensor<?x?xf64, #CSC64>) -> tensor<?x?xf64, #CSR64> {
-    %cf4 = constant 4.0 : f64
+    %cf4 = arith.constant 4.0 : f64
 
     %answer = graphblas.matrix_multiply_generic %a, %b {mask_complement = false} : (tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSC64>) to tensor<?x?xf64, #CSR64> {
         ^bb0:
-            %identity = constant 0.0 : f64
+            %identity = arith.constant 0.0 : f64
             graphblas.yield add_identity %identity : f64
     },{
         ^bb0(%add_a: f64, %add_b: f64):
-            %add_result = std.addf %add_a, %add_b : f64
+            %add_result = arith.addf %add_a, %add_b : f64
             graphblas.yield add %add_result : f64
     },{
         ^bb0(%mult_a: f64, %mult_b: f64):
-            %mult_result = std.mulf %mult_a, %mult_b : f64
+            %mult_result = arith.mulf %mult_a, %mult_b : f64
             graphblas.yield mult %mult_result : f64
     },{
         ^bb0(%value: f64):
-            %result = std.addf %value, %cf4: f64
+            %result = arith.addf %value, %cf4: f64
             graphblas.yield transform_out %result : f64
     }
     return %answer : tensor<?x?xf64, #CSR64>

--- a/mlir_graphblas/src/test/GraphBLAS/lower_matrix_multiply_mask.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_matrix_multiply_mask.mlir
@@ -18,18 +18,18 @@
 // CHECK-SAME:                                         %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                                         %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                                         %[[VAL_2:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 0 : i64
-// CHECK-DAG:       %[[VAL_4:.*]] = constant 1 : i64
-// CHECK-DAG:       %[[VAL_5:.*]] = constant 0 : index
-// CHECK-DAG:       %[[VAL_6:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_7:.*]] = constant true
-// CHECK-DAG:       %[[VAL_8:.*]] = constant false
-// CHECK-DAG:       %[[VAL_9:.*]] = constant 0.000000e+00 : f64
-// CHECK-DAG:       %[[VAL_10:.*]] = constant 1.000000e+00 : f64
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : i64
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 1 : i64
+// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_6:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_7:.*]] = arith.constant true
+// CHECK-DAG:       %[[VAL_8:.*]] = arith.constant false
+// CHECK-DAG:       %[[VAL_9:.*]] = arith.constant 0.000000e+00 : f64
+// CHECK-DAG:       %[[VAL_10:.*]] = arith.constant 1.000000e+00 : f64
 // CHECK:           %[[VAL_11:.*]] = tensor.dim %[[VAL_0]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_12:.*]] = tensor.dim %[[VAL_1]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_13:.*]] = tensor.dim %[[VAL_0]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
-// CHECK:           %[[VAL_14:.*]] = addi %[[VAL_11]], %[[VAL_6]] : index
+// CHECK:           %[[VAL_14:.*]] = arith.addi %[[VAL_11]], %[[VAL_6]] : index
 // CHECK:           %[[VAL_15:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_16:.*]] = call @empty_like(%[[VAL_15]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_17:.*]] = call @ptr8_to_matrix_csr_f64_p64i64(%[[VAL_16]]) : (!llvm.ptr<i8>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -49,44 +49,44 @@
 // CHECK:           %[[VAL_28:.*]] = sparse_tensor.indices %[[VAL_2]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           scf.parallel (%[[VAL_29:.*]]) = (%[[VAL_5]]) to (%[[VAL_11]]) step (%[[VAL_6]]) {
 // CHECK:             %[[VAL_30:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_29]]] : memref<?xi64>
-// CHECK:             %[[VAL_31:.*]] = addi %[[VAL_29]], %[[VAL_6]] : index
+// CHECK:             %[[VAL_31:.*]] = arith.addi %[[VAL_29]], %[[VAL_6]] : index
 // CHECK:             %[[VAL_32:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_31]]] : memref<?xi64>
-// CHECK:             %[[VAL_33:.*]] = cmpi eq, %[[VAL_30]], %[[VAL_32]] : i64
+// CHECK:             %[[VAL_33:.*]] = arith.cmpi eq, %[[VAL_30]], %[[VAL_32]] : i64
 // CHECK:             %[[VAL_34:.*]] = scf.if %[[VAL_33]] -> (i64) {
 // CHECK:               scf.yield %[[VAL_3]] : i64
 // CHECK:             } else {
-// CHECK:               %[[VAL_35:.*]] = index_cast %[[VAL_30]] : i64 to index
-// CHECK:               %[[VAL_36:.*]] = index_cast %[[VAL_32]] : i64 to index
+// CHECK:               %[[VAL_35:.*]] = arith.index_cast %[[VAL_30]] : i64 to index
+// CHECK:               %[[VAL_36:.*]] = arith.index_cast %[[VAL_32]] : i64 to index
 // CHECK:               %[[VAL_37:.*]] = memref.load %[[VAL_27]]{{\[}}%[[VAL_29]]] : memref<?xi64>
 // CHECK:               %[[VAL_38:.*]] = memref.load %[[VAL_27]]{{\[}}%[[VAL_31]]] : memref<?xi64>
-// CHECK:               %[[VAL_39:.*]] = index_cast %[[VAL_37]] : i64 to index
-// CHECK:               %[[VAL_40:.*]] = index_cast %[[VAL_38]] : i64 to index
+// CHECK:               %[[VAL_39:.*]] = arith.index_cast %[[VAL_37]] : i64 to index
+// CHECK:               %[[VAL_40:.*]] = arith.index_cast %[[VAL_38]] : i64 to index
 // CHECK:               %[[VAL_41:.*]] = memref.alloc(%[[VAL_13]]) : memref<?xi1>
 // CHECK:               linalg.fill(%[[VAL_8]], %[[VAL_41]]) : i1, memref<?xi1>
 // CHECK:               scf.parallel (%[[VAL_42:.*]]) = (%[[VAL_35]]) to (%[[VAL_36]]) step (%[[VAL_6]]) {
 // CHECK:                 %[[VAL_43:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_42]]] : memref<?xi64>
-// CHECK:                 %[[VAL_44:.*]] = index_cast %[[VAL_43]] : i64 to index
+// CHECK:                 %[[VAL_44:.*]] = arith.index_cast %[[VAL_43]] : i64 to index
 // CHECK:                 memref.store %[[VAL_7]], %[[VAL_41]]{{\[}}%[[VAL_44]]] : memref<?xi1>
 // CHECK:                 scf.yield
 // CHECK:               }
 // CHECK:               %[[VAL_45:.*]] = scf.parallel (%[[VAL_46:.*]]) = (%[[VAL_39]]) to (%[[VAL_40]]) step (%[[VAL_6]]) init (%[[VAL_3]]) -> i64 {
 // CHECK:                 %[[VAL_47:.*]] = memref.load %[[VAL_28]]{{\[}}%[[VAL_46]]] : memref<?xi64>
-// CHECK:                 %[[VAL_48:.*]] = index_cast %[[VAL_47]] : i64 to index
-// CHECK:                 %[[VAL_49:.*]] = addi %[[VAL_48]], %[[VAL_6]] : index
+// CHECK:                 %[[VAL_48:.*]] = arith.index_cast %[[VAL_47]] : i64 to index
+// CHECK:                 %[[VAL_49:.*]] = arith.addi %[[VAL_48]], %[[VAL_6]] : index
 // CHECK:                 %[[VAL_50:.*]] = memref.load %[[VAL_24]]{{\[}}%[[VAL_48]]] : memref<?xi64>
 // CHECK:                 %[[VAL_51:.*]] = memref.load %[[VAL_24]]{{\[}}%[[VAL_49]]] : memref<?xi64>
-// CHECK:                 %[[VAL_52:.*]] = cmpi eq, %[[VAL_50]], %[[VAL_51]] : i64
+// CHECK:                 %[[VAL_52:.*]] = arith.cmpi eq, %[[VAL_50]], %[[VAL_51]] : i64
 // CHECK:                 %[[VAL_53:.*]] = scf.if %[[VAL_52]] -> (i64) {
 // CHECK:                   scf.yield %[[VAL_3]] : i64
 // CHECK:                 } else {
 // CHECK:                   %[[VAL_54:.*]] = scf.while (%[[VAL_55:.*]] = %[[VAL_50]]) : (i64) -> i64 {
-// CHECK:                     %[[VAL_56:.*]] = cmpi uge, %[[VAL_55]], %[[VAL_51]] : i64
+// CHECK:                     %[[VAL_56:.*]] = arith.cmpi uge, %[[VAL_55]], %[[VAL_51]] : i64
 // CHECK:                     %[[VAL_57:.*]]:2 = scf.if %[[VAL_56]] -> (i1, i64) {
 // CHECK:                       scf.yield %[[VAL_8]], %[[VAL_3]] : i1, i64
 // CHECK:                     } else {
-// CHECK:                       %[[VAL_58:.*]] = index_cast %[[VAL_55]] : i64 to index
+// CHECK:                       %[[VAL_58:.*]] = arith.index_cast %[[VAL_55]] : i64 to index
 // CHECK:                       %[[VAL_59:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_58]]] : memref<?xi64>
-// CHECK:                       %[[VAL_60:.*]] = index_cast %[[VAL_59]] : i64 to index
+// CHECK:                       %[[VAL_60:.*]] = arith.index_cast %[[VAL_59]] : i64 to index
 // CHECK:                       %[[VAL_61:.*]] = memref.load %[[VAL_41]]{{\[}}%[[VAL_60]]] : memref<?xi1>
 // CHECK:                       %[[VAL_62:.*]] = select %[[VAL_61]], %[[VAL_8]], %[[VAL_7]] : i1
 // CHECK:                       %[[VAL_63:.*]] = select %[[VAL_61]], %[[VAL_4]], %[[VAL_55]] : i64
@@ -95,14 +95,14 @@
 // CHECK:                     scf.condition(%[[VAL_64:.*]]#0) %[[VAL_64]]#1 : i64
 // CHECK:                   } do {
 // CHECK:                   ^bb0(%[[VAL_65:.*]]: i64):
-// CHECK:                     %[[VAL_66:.*]] = addi %[[VAL_65]], %[[VAL_4]] : i64
+// CHECK:                     %[[VAL_66:.*]] = arith.addi %[[VAL_65]], %[[VAL_4]] : i64
 // CHECK:                     scf.yield %[[VAL_66]] : i64
 // CHECK:                   }
 // CHECK:                   scf.yield %[[VAL_67:.*]] : i64
 // CHECK:                 }
 // CHECK:                 scf.reduce(%[[VAL_68:.*]])  : i64 {
 // CHECK:                 ^bb0(%[[VAL_69:.*]]: i64, %[[VAL_70:.*]]: i64):
-// CHECK:                   %[[VAL_71:.*]] = addi %[[VAL_69]], %[[VAL_70]] : i64
+// CHECK:                   %[[VAL_71:.*]] = arith.addi %[[VAL_69]], %[[VAL_70]] : i64
 // CHECK:                   scf.reduce.return %[[VAL_71]] : i64
 // CHECK:                 }
 // CHECK:                 scf.yield
@@ -117,13 +117,13 @@
 // CHECK:             %[[VAL_75:.*]] = memref.load %[[VAL_26]]{{\[}}%[[VAL_74]]] : memref<?xi64>
 // CHECK:             %[[VAL_76:.*]] = memref.load %[[VAL_26]]{{\[}}%[[VAL_11]]] : memref<?xi64>
 // CHECK:             memref.store %[[VAL_76]], %[[VAL_26]]{{\[}}%[[VAL_74]]] : memref<?xi64>
-// CHECK:             %[[VAL_77:.*]] = addi %[[VAL_76]], %[[VAL_75]] : i64
+// CHECK:             %[[VAL_77:.*]] = arith.addi %[[VAL_76]], %[[VAL_75]] : i64
 // CHECK:             memref.store %[[VAL_77]], %[[VAL_26]]{{\[}}%[[VAL_11]]] : memref<?xi64>
 // CHECK:           }
 // CHECK:           %[[VAL_78:.*]] = sparse_tensor.pointers %[[VAL_17]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_79:.*]] = tensor.dim %[[VAL_17]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_80:.*]] = memref.load %[[VAL_78]]{{\[}}%[[VAL_79]]] : memref<?xi64>
-// CHECK:           %[[VAL_81:.*]] = index_cast %[[VAL_80]] : i64 to index
+// CHECK:           %[[VAL_81:.*]] = arith.index_cast %[[VAL_80]] : i64 to index
 // CHECK:           %[[VAL_82:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_17]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           call @resize_index(%[[VAL_82]], %[[VAL_6]], %[[VAL_81]]) : (!llvm.ptr<i8>, index, index) -> ()
 // CHECK:           %[[VAL_83:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_17]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
@@ -131,27 +131,27 @@
 // CHECK:           %[[VAL_84:.*]] = sparse_tensor.indices %[[VAL_17]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_85:.*]] = sparse_tensor.values %[[VAL_17]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           scf.parallel (%[[VAL_86:.*]]) = (%[[VAL_5]]) to (%[[VAL_11]]) step (%[[VAL_6]]) {
-// CHECK:             %[[VAL_87:.*]] = addi %[[VAL_86]], %[[VAL_6]] : index
+// CHECK:             %[[VAL_87:.*]] = arith.addi %[[VAL_86]], %[[VAL_6]] : index
 // CHECK:             %[[VAL_88:.*]] = memref.load %[[VAL_26]]{{\[}}%[[VAL_86]]] : memref<?xi64>
 // CHECK:             %[[VAL_89:.*]] = memref.load %[[VAL_26]]{{\[}}%[[VAL_87]]] : memref<?xi64>
-// CHECK:             %[[VAL_90:.*]] = cmpi ne, %[[VAL_88]], %[[VAL_89]] : i64
+// CHECK:             %[[VAL_90:.*]] = arith.cmpi ne, %[[VAL_88]], %[[VAL_89]] : i64
 // CHECK:             scf.if %[[VAL_90]] {
 // CHECK:               %[[VAL_91:.*]] = memref.load %[[VAL_26]]{{\[}}%[[VAL_86]]] : memref<?xi64>
-// CHECK:               %[[VAL_92:.*]] = index_cast %[[VAL_91]] : i64 to index
+// CHECK:               %[[VAL_92:.*]] = arith.index_cast %[[VAL_91]] : i64 to index
 // CHECK:               %[[VAL_93:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_86]]] : memref<?xi64>
 // CHECK:               %[[VAL_94:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_87]]] : memref<?xi64>
-// CHECK:               %[[VAL_95:.*]] = index_cast %[[VAL_93]] : i64 to index
-// CHECK:               %[[VAL_96:.*]] = index_cast %[[VAL_94]] : i64 to index
+// CHECK:               %[[VAL_95:.*]] = arith.index_cast %[[VAL_93]] : i64 to index
+// CHECK:               %[[VAL_96:.*]] = arith.index_cast %[[VAL_94]] : i64 to index
 // CHECK:               %[[VAL_97:.*]] = memref.load %[[VAL_27]]{{\[}}%[[VAL_86]]] : memref<?xi64>
 // CHECK:               %[[VAL_98:.*]] = memref.load %[[VAL_27]]{{\[}}%[[VAL_87]]] : memref<?xi64>
-// CHECK:               %[[VAL_99:.*]] = index_cast %[[VAL_97]] : i64 to index
-// CHECK:               %[[VAL_100:.*]] = index_cast %[[VAL_98]] : i64 to index
+// CHECK:               %[[VAL_99:.*]] = arith.index_cast %[[VAL_97]] : i64 to index
+// CHECK:               %[[VAL_100:.*]] = arith.index_cast %[[VAL_98]] : i64 to index
 // CHECK:               %[[VAL_101:.*]] = memref.alloc(%[[VAL_13]]) : memref<?xf64>
 // CHECK:               %[[VAL_102:.*]] = memref.alloc(%[[VAL_13]]) : memref<?xi1>
 // CHECK:               linalg.fill(%[[VAL_8]], %[[VAL_102]]) : i1, memref<?xi1>
 // CHECK:               scf.parallel (%[[VAL_103:.*]]) = (%[[VAL_95]]) to (%[[VAL_96]]) step (%[[VAL_6]]) {
 // CHECK:                 %[[VAL_104:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_103]]] : memref<?xi64>
-// CHECK:                 %[[VAL_105:.*]] = index_cast %[[VAL_104]] : i64 to index
+// CHECK:                 %[[VAL_105:.*]] = arith.index_cast %[[VAL_104]] : i64 to index
 // CHECK:                 memref.store %[[VAL_7]], %[[VAL_102]]{{\[}}%[[VAL_105]]] : memref<?xi1>
 // CHECK:                 %[[VAL_106:.*]] = memref.load %[[VAL_23]]{{\[}}%[[VAL_103]]] : memref<?xf64>
 // CHECK:                 memref.store %[[VAL_106]], %[[VAL_101]]{{\[}}%[[VAL_105]]] : memref<?xf64>
@@ -159,18 +159,18 @@
 // CHECK:               }
 // CHECK:               %[[VAL_107:.*]] = scf.for %[[VAL_108:.*]] = %[[VAL_99]] to %[[VAL_100]] step %[[VAL_6]] iter_args(%[[VAL_109:.*]] = %[[VAL_5]]) -> (index) {
 // CHECK:                 %[[VAL_110:.*]] = memref.load %[[VAL_28]]{{\[}}%[[VAL_108]]] : memref<?xi64>
-// CHECK:                 %[[VAL_111:.*]] = index_cast %[[VAL_110]] : i64 to index
-// CHECK:                 %[[VAL_112:.*]] = addi %[[VAL_111]], %[[VAL_6]] : index
+// CHECK:                 %[[VAL_111:.*]] = arith.index_cast %[[VAL_110]] : i64 to index
+// CHECK:                 %[[VAL_112:.*]] = arith.addi %[[VAL_111]], %[[VAL_6]] : index
 // CHECK:                 %[[VAL_113:.*]] = memref.load %[[VAL_24]]{{\[}}%[[VAL_111]]] : memref<?xi64>
 // CHECK:                 %[[VAL_114:.*]] = memref.load %[[VAL_24]]{{\[}}%[[VAL_112]]] : memref<?xi64>
-// CHECK:                 %[[VAL_115:.*]] = index_cast %[[VAL_113]] : i64 to index
-// CHECK:                 %[[VAL_116:.*]] = index_cast %[[VAL_114]] : i64 to index
+// CHECK:                 %[[VAL_115:.*]] = arith.index_cast %[[VAL_113]] : i64 to index
+// CHECK:                 %[[VAL_116:.*]] = arith.index_cast %[[VAL_114]] : i64 to index
 // CHECK:                 %[[VAL_117:.*]]:2 = scf.for %[[VAL_118:.*]] = %[[VAL_115]] to %[[VAL_116]] step %[[VAL_6]] iter_args(%[[VAL_119:.*]] = %[[VAL_9]], %[[VAL_120:.*]] = %[[VAL_8]]) -> (f64, i1) {
 // CHECK:                   %[[VAL_121:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_118]]] : memref<?xi64>
-// CHECK:                   %[[VAL_122:.*]] = index_cast %[[VAL_121]] : i64 to index
+// CHECK:                   %[[VAL_122:.*]] = arith.index_cast %[[VAL_121]] : i64 to index
 // CHECK:                   %[[VAL_123:.*]] = memref.load %[[VAL_102]]{{\[}}%[[VAL_122]]] : memref<?xi1>
 // CHECK:                   %[[VAL_124:.*]]:2 = scf.if %[[VAL_123]] -> (f64, i1) {
-// CHECK:                     %[[VAL_125:.*]] = addf %[[VAL_119]], %[[VAL_10]] : f64
+// CHECK:                     %[[VAL_125:.*]] = arith.addf %[[VAL_119]], %[[VAL_10]] : f64
 // CHECK:                     scf.yield %[[VAL_125]], %[[VAL_7]] : f64, i1
 // CHECK:                   } else {
 // CHECK:                     scf.yield %[[VAL_119]], %[[VAL_120]] : f64, i1
@@ -178,10 +178,10 @@
 // CHECK:                   scf.yield %[[VAL_126:.*]]#0, %[[VAL_126]]#1 : f64, i1
 // CHECK:                 }
 // CHECK:                 %[[VAL_127:.*]] = scf.if %[[VAL_128:.*]]#1 -> (index) {
-// CHECK:                   %[[VAL_129:.*]] = addi %[[VAL_92]], %[[VAL_109]] : index
+// CHECK:                   %[[VAL_129:.*]] = arith.addi %[[VAL_92]], %[[VAL_109]] : index
 // CHECK:                   memref.store %[[VAL_110]], %[[VAL_84]]{{\[}}%[[VAL_129]]] : memref<?xi64>
 // CHECK:                   memref.store %[[VAL_128]]#0, %[[VAL_85]]{{\[}}%[[VAL_129]]] : memref<?xf64>
-// CHECK:                   %[[VAL_130:.*]] = addi %[[VAL_109]], %[[VAL_6]] : index
+// CHECK:                   %[[VAL_130:.*]] = arith.addi %[[VAL_109]], %[[VAL_6]] : index
 // CHECK:                   scf.yield %[[VAL_130]] : index
 // CHECK:                 } else {
 // CHECK:                   scf.yield %[[VAL_109]] : index

--- a/mlir_graphblas/src/test/GraphBLAS/lower_matrix_multiply_reduce_to_scalar.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_matrix_multiply_reduce_to_scalar.mlir
@@ -18,11 +18,11 @@
 // CHECK-SAME:        %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:        %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK-SAME:    ) -> f64 {
-// CHECK-DAG:       %[[VAL_2:.*]] = constant 0 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_4:.*]] = constant 0.000000e+00 : f64
-// CHECK-DAG:       %[[VAL_5:.*]] = constant true
-// CHECK-DAG:       %[[VAL_6:.*]] = constant false
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0.000000e+00 : f64
+// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant true
+// CHECK-DAG:       %[[VAL_6:.*]] = arith.constant false
 // CHECK:           %[[VAL_7:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_8:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_9:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
@@ -33,41 +33,41 @@
 // CHECK:           %[[VAL_14:.*]] = tensor.dim %[[VAL_1]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_15:.*]] = tensor.dim %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_16:.*]] = scf.parallel (%[[VAL_17:.*]]) = (%[[VAL_2]]) to (%[[VAL_13]]) step (%[[VAL_3]]) init (%[[VAL_4]]) -> f64 {
-// CHECK:             %[[VAL_18:.*]] = addi %[[VAL_17]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_18:.*]] = arith.addi %[[VAL_17]], %[[VAL_3]] : index
 // CHECK:             %[[VAL_19:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_17]]] : memref<?xi64>
 // CHECK:             %[[VAL_20:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_18]]] : memref<?xi64>
-// CHECK:             %[[VAL_21:.*]] = cmpi eq, %[[VAL_19]], %[[VAL_20]] : i64
+// CHECK:             %[[VAL_21:.*]] = arith.cmpi eq, %[[VAL_19]], %[[VAL_20]] : i64
 // CHECK:             %[[VAL_22:.*]] = scf.if %[[VAL_21]] -> (f64) {
 // CHECK:               scf.yield %[[VAL_4]] : f64
 // CHECK:             } else {
-// CHECK:               %[[VAL_23:.*]] = index_cast %[[VAL_19]] : i64 to index
-// CHECK:               %[[VAL_24:.*]] = index_cast %[[VAL_20]] : i64 to index
+// CHECK:               %[[VAL_23:.*]] = arith.index_cast %[[VAL_19]] : i64 to index
+// CHECK:               %[[VAL_24:.*]] = arith.index_cast %[[VAL_20]] : i64 to index
 // CHECK:               %[[VAL_25:.*]] = memref.alloc(%[[VAL_15]]) : memref<?xf64>
 // CHECK:               %[[VAL_26:.*]] = memref.alloc(%[[VAL_15]]) : memref<?xi1>
 // CHECK:               linalg.fill(%[[VAL_6]], %[[VAL_26]]) : i1, memref<?xi1>
 // CHECK:               scf.parallel (%[[VAL_27:.*]]) = (%[[VAL_23]]) to (%[[VAL_24]]) step (%[[VAL_3]]) {
 // CHECK:                 %[[VAL_28:.*]] = memref.load %[[VAL_8]]{{\[}}%[[VAL_27]]] : memref<?xi64>
-// CHECK:                 %[[VAL_29:.*]] = index_cast %[[VAL_28]] : i64 to index
+// CHECK:                 %[[VAL_29:.*]] = arith.index_cast %[[VAL_28]] : i64 to index
 // CHECK:                 memref.store %[[VAL_5]], %[[VAL_26]]{{\[}}%[[VAL_29]]] : memref<?xi1>
 // CHECK:                 %[[VAL_30:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_27]]] : memref<?xf64>
 // CHECK:                 memref.store %[[VAL_30]], %[[VAL_25]]{{\[}}%[[VAL_29]]] : memref<?xf64>
 // CHECK:                 scf.yield
 // CHECK:               }
 // CHECK:               %[[VAL_31:.*]] = scf.parallel (%[[VAL_32:.*]]) = (%[[VAL_2]]) to (%[[VAL_14]]) step (%[[VAL_3]]) init (%[[VAL_4]]) -> f64 {
-// CHECK:                 %[[VAL_33:.*]] = addi %[[VAL_32]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_33:.*]] = arith.addi %[[VAL_32]], %[[VAL_3]] : index
 // CHECK:                 %[[VAL_34:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_32]]] : memref<?xi64>
 // CHECK:                 %[[VAL_35:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_33]]] : memref<?xi64>
-// CHECK:                 %[[VAL_36:.*]] = index_cast %[[VAL_34]] : i64 to index
-// CHECK:                 %[[VAL_37:.*]] = index_cast %[[VAL_35]] : i64 to index
+// CHECK:                 %[[VAL_36:.*]] = arith.index_cast %[[VAL_34]] : i64 to index
+// CHECK:                 %[[VAL_37:.*]] = arith.index_cast %[[VAL_35]] : i64 to index
 // CHECK:                 %[[VAL_38:.*]] = scf.for %[[VAL_39:.*]] = %[[VAL_36]] to %[[VAL_37]] step %[[VAL_3]] iter_args(%[[VAL_40:.*]] = %[[VAL_4]]) -> (f64) {
 // CHECK:                   %[[VAL_41:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_39]]] : memref<?xi64>
-// CHECK:                   %[[VAL_42:.*]] = index_cast %[[VAL_41]] : i64 to index
+// CHECK:                   %[[VAL_42:.*]] = arith.index_cast %[[VAL_41]] : i64 to index
 // CHECK:                   %[[VAL_43:.*]] = memref.load %[[VAL_26]]{{\[}}%[[VAL_42]]] : memref<?xi1>
 // CHECK:                   %[[VAL_44:.*]] = scf.if %[[VAL_43]] -> (f64) {
 // CHECK:                     %[[VAL_45:.*]] = memref.load %[[VAL_25]]{{\[}}%[[VAL_42]]] : memref<?xf64>
 // CHECK:                     %[[VAL_46:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_39]]] : memref<?xf64>
-// CHECK:                     %[[VAL_47:.*]] = mulf %[[VAL_45]], %[[VAL_46]] : f64
-// CHECK:                     %[[VAL_48:.*]] = addf %[[VAL_40]], %[[VAL_47]] : f64
+// CHECK:                     %[[VAL_47:.*]] = arith.mulf %[[VAL_45]], %[[VAL_46]] : f64
+// CHECK:                     %[[VAL_48:.*]] = arith.addf %[[VAL_40]], %[[VAL_47]] : f64
 // CHECK:                     scf.yield %[[VAL_48]] : f64
 // CHECK:                   } else {
 // CHECK:                     scf.yield %[[VAL_40]] : f64
@@ -76,7 +76,7 @@
 // CHECK:                 }
 // CHECK:                 scf.reduce(%[[VAL_38]])  : f64 {
 // CHECK:                 ^bb0(%[[VAL_51:.*]]: f64, %[[VAL_52:.*]]: f64):
-// CHECK:                   %[[VAL_53:.*]] = addf %[[VAL_51]], %[[VAL_52]] : f64
+// CHECK:                   %[[VAL_53:.*]] = arith.addf %[[VAL_51]], %[[VAL_52]] : f64
 // CHECK:                   scf.reduce.return %[[VAL_53]] : f64
 // CHECK:                 }
 // CHECK:                 scf.yield
@@ -85,7 +85,7 @@
 // CHECK:             }
 // CHECK:             scf.reduce(%[[VAL_22]])  : f64 {
 // CHECK:             ^bb0(%[[VAL_56:.*]]: f64, %[[VAL_57:.*]]: f64):
-// CHECK:               %[[VAL_58:.*]] = addf %[[VAL_56]], %[[VAL_57]] : f64
+// CHECK:               %[[VAL_58:.*]] = arith.addf %[[VAL_56]], %[[VAL_57]] : f64
 // CHECK:               scf.reduce.return %[[VAL_58]] : f64
 // CHECK:             }
 // CHECK:             scf.yield
@@ -97,22 +97,22 @@
 func @matrix_multiply_plus_times_sum(%a: tensor<?x?xf64, #CSR64>, %b: tensor<?x?xf64, #CSC64>) -> f64 {
     %answer = graphblas.matrix_multiply_reduce_to_scalar_generic %a, %b : (tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSC64>) to f64 {
         ^bb0:
-            %identity = constant 0.0 : f64
+            %identity = arith.constant 0.0 : f64
             graphblas.yield add_identity %identity : f64
     },{
         ^bb0(%add_a: f64, %add_b: f64):
-            %add_result = std.addf %add_a, %add_b : f64
+            %add_result = arith.addf %add_a, %add_b : f64
             graphblas.yield add %add_result : f64
     },{
         ^bb0(%mult_a: f64, %mult_b: f64):
-            %mult_result = std.mulf %mult_a, %mult_b : f64
+            %mult_result = arith.mulf %mult_a, %mult_b : f64
             graphblas.yield mult %mult_result : f64
     },{
-        %agg_identity = constant 0.0 : f64
+        %agg_identity = arith.constant 0.0 : f64
         graphblas.yield agg_identity %agg_identity : f64
     },{
         ^bb0(%lhs: f64, %rhs: f64):
-            %agg_result = std.addf %lhs, %rhs: f64
+            %agg_result = arith.addf %lhs, %rhs: f64
             graphblas.yield agg %agg_result : f64
     }
     return %answer : f64

--- a/mlir_graphblas/src/test/GraphBLAS/lower_matrix_update_accumulate.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_matrix_update_accumulate.mlir
@@ -10,12 +10,12 @@
 // CHECK-LABEL:   func @matrix_update_accumulate(
 // CHECK-SAME:                                    %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                                    %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> index {
-// CHECK-DAG:       %[[VAL_2:.*]] = constant 0 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_4:.*]] = constant 0 : i64
-// CHECK-DAG:       %[[VAL_5:.*]] = constant false
-// CHECK-DAG:       %[[VAL_6:.*]] = constant true
-// CHECK-DAG:       %[[VAL_7:.*]] = constant 0.000000e+00 : f64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : i64
+// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant false
+// CHECK-DAG:       %[[VAL_6:.*]] = arith.constant true
+// CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK:           %[[VAL_8:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_1]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_9:.*]] = call @dup_tensor(%[[VAL_8]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_10:.*]] = call @ptr8_to_matrix_csr_f64_p64i64(%[[VAL_9]]) : (!llvm.ptr<i8>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -28,47 +28,47 @@
 // CHECK:           %[[VAL_17:.*]] = sparse_tensor.values %[[VAL_10]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           %[[VAL_18:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           scf.parallel (%[[VAL_19:.*]]) = (%[[VAL_2]]) to (%[[VAL_11]]) step (%[[VAL_3]]) {
-// CHECK:             %[[VAL_20:.*]] = addi %[[VAL_19]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_20:.*]] = arith.addi %[[VAL_19]], %[[VAL_3]] : index
 // CHECK:             %[[VAL_21:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_19]]] : memref<?xi64>
 // CHECK:             %[[VAL_22:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_20]]] : memref<?xi64>
 // CHECK:             %[[VAL_23:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_19]]] : memref<?xi64>
 // CHECK:             %[[VAL_24:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_20]]] : memref<?xi64>
-// CHECK:             %[[VAL_25:.*]] = cmpi eq, %[[VAL_21]], %[[VAL_22]] : i64
-// CHECK:             %[[VAL_26:.*]] = cmpi eq, %[[VAL_23]], %[[VAL_24]] : i64
-// CHECK:             %[[VAL_27:.*]] = and %[[VAL_25]], %[[VAL_26]] : i1
+// CHECK:             %[[VAL_25:.*]] = arith.cmpi eq, %[[VAL_21]], %[[VAL_22]] : i64
+// CHECK:             %[[VAL_26:.*]] = arith.cmpi eq, %[[VAL_23]], %[[VAL_24]] : i64
+// CHECK:             %[[VAL_27:.*]] = arith.andi %[[VAL_25]], %[[VAL_26]] : i1
 // CHECK:             %[[VAL_28:.*]] = scf.if %[[VAL_27]] -> (i64) {
 // CHECK:               scf.yield %[[VAL_4]] : i64
 // CHECK:             } else {
-// CHECK:               %[[VAL_29:.*]] = index_cast %[[VAL_21]] : i64 to index
-// CHECK:               %[[VAL_30:.*]] = index_cast %[[VAL_22]] : i64 to index
-// CHECK:               %[[VAL_31:.*]] = index_cast %[[VAL_23]] : i64 to index
-// CHECK:               %[[VAL_32:.*]] = index_cast %[[VAL_24]] : i64 to index
+// CHECK:               %[[VAL_29:.*]] = arith.index_cast %[[VAL_21]] : i64 to index
+// CHECK:               %[[VAL_30:.*]] = arith.index_cast %[[VAL_22]] : i64 to index
+// CHECK:               %[[VAL_31:.*]] = arith.index_cast %[[VAL_23]] : i64 to index
+// CHECK:               %[[VAL_32:.*]] = arith.index_cast %[[VAL_24]] : i64 to index
 // CHECK:               %[[VAL_33:.*]]:7 = scf.while (%[[VAL_34:.*]] = %[[VAL_29]], %[[VAL_35:.*]] = %[[VAL_31]], %[[VAL_36:.*]] = %[[VAL_2]], %[[VAL_37:.*]] = %[[VAL_2]], %[[VAL_38:.*]] = %[[VAL_6]], %[[VAL_39:.*]] = %[[VAL_6]], %[[VAL_40:.*]] = %[[VAL_2]]) : (index, index, index, index, i1, i1, index) -> (index, index, index, index, i1, i1, index) {
-// CHECK:                 %[[VAL_41:.*]] = cmpi ult, %[[VAL_34]], %[[VAL_30]] : index
-// CHECK:                 %[[VAL_42:.*]] = cmpi ult, %[[VAL_35]], %[[VAL_32]] : index
-// CHECK:                 %[[VAL_43:.*]] = and %[[VAL_41]], %[[VAL_42]] : i1
+// CHECK:                 %[[VAL_41:.*]] = arith.cmpi ult, %[[VAL_34]], %[[VAL_30]] : index
+// CHECK:                 %[[VAL_42:.*]] = arith.cmpi ult, %[[VAL_35]], %[[VAL_32]] : index
+// CHECK:                 %[[VAL_43:.*]] = arith.andi %[[VAL_41]], %[[VAL_42]] : i1
 // CHECK:                 scf.condition(%[[VAL_43]]) %[[VAL_34]], %[[VAL_35]], %[[VAL_36]], %[[VAL_37]], %[[VAL_38]], %[[VAL_39]], %[[VAL_40]] : index, index, index, index, i1, i1, index
 // CHECK:               } do {
 // CHECK:               ^bb0(%[[VAL_44:.*]]: index, %[[VAL_45:.*]]: index, %[[VAL_46:.*]]: index, %[[VAL_47:.*]]: index, %[[VAL_48:.*]]: i1, %[[VAL_49:.*]]: i1, %[[VAL_50:.*]]: index):
 // CHECK:                 %[[VAL_51:.*]] = scf.if %[[VAL_48]] -> (index) {
 // CHECK:                   %[[VAL_52:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_44]]] : memref<?xi64>
-// CHECK:                   %[[VAL_53:.*]] = index_cast %[[VAL_52]] : i64 to index
+// CHECK:                   %[[VAL_53:.*]] = arith.index_cast %[[VAL_52]] : i64 to index
 // CHECK:                   scf.yield %[[VAL_53]] : index
 // CHECK:                 } else {
 // CHECK:                   scf.yield %[[VAL_46]] : index
 // CHECK:                 }
 // CHECK:                 %[[VAL_54:.*]] = scf.if %[[VAL_49]] -> (index) {
 // CHECK:                   %[[VAL_55:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_45]]] : memref<?xi64>
-// CHECK:                   %[[VAL_56:.*]] = index_cast %[[VAL_55]] : i64 to index
+// CHECK:                   %[[VAL_56:.*]] = arith.index_cast %[[VAL_55]] : i64 to index
 // CHECK:                   scf.yield %[[VAL_56]] : index
 // CHECK:                 } else {
 // CHECK:                   scf.yield %[[VAL_47]] : index
 // CHECK:                 }
-// CHECK:                 %[[VAL_57:.*]] = cmpi ult, %[[VAL_58:.*]], %[[VAL_59:.*]] : index
-// CHECK:                 %[[VAL_60:.*]] = cmpi ugt, %[[VAL_58]], %[[VAL_59]] : index
-// CHECK:                 %[[VAL_61:.*]] = addi %[[VAL_44]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_62:.*]] = addi %[[VAL_45]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_63:.*]] = addi %[[VAL_50]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_57:.*]] = arith.cmpi ult, %[[VAL_58:.*]], %[[VAL_59:.*]] : index
+// CHECK:                 %[[VAL_60:.*]] = arith.cmpi ugt, %[[VAL_58]], %[[VAL_59]] : index
+// CHECK:                 %[[VAL_61:.*]] = arith.addi %[[VAL_44]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_62:.*]] = arith.addi %[[VAL_45]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_63:.*]] = arith.addi %[[VAL_50]], %[[VAL_3]] : index
 // CHECK:                 %[[VAL_64:.*]]:5 = scf.if %[[VAL_57]] -> (index, index, i1, i1, index) {
 // CHECK:                   scf.yield %[[VAL_61]], %[[VAL_45]], %[[VAL_6]], %[[VAL_5]], %[[VAL_63]] : index, index, i1, i1, index
 // CHECK:                 } else {
@@ -81,23 +81,23 @@
 // CHECK:                 }
 // CHECK:                 scf.yield %[[VAL_67:.*]]#0, %[[VAL_67]]#1, %[[VAL_58]], %[[VAL_59]], %[[VAL_67]]#2, %[[VAL_67]]#3, %[[VAL_67]]#4 : index, index, index, index, i1, i1, index
 // CHECK:               }
-// CHECK:               %[[VAL_68:.*]] = cmpi ult, %[[VAL_69:.*]]#0, %[[VAL_30]] : index
+// CHECK:               %[[VAL_68:.*]] = arith.cmpi ult, %[[VAL_69:.*]]#0, %[[VAL_30]] : index
 // CHECK:               %[[VAL_70:.*]] = scf.if %[[VAL_68]] -> (index) {
-// CHECK:                 %[[VAL_71:.*]] = subi %[[VAL_30]], %[[VAL_69]]#0 : index
-// CHECK:                 %[[VAL_72:.*]] = addi %[[VAL_69]]#6, %[[VAL_71]] : index
+// CHECK:                 %[[VAL_71:.*]] = arith.subi %[[VAL_30]], %[[VAL_69]]#0 : index
+// CHECK:                 %[[VAL_72:.*]] = arith.addi %[[VAL_69]]#6, %[[VAL_71]] : index
 // CHECK:                 scf.yield %[[VAL_72]] : index
 // CHECK:               } else {
-// CHECK:                 %[[VAL_73:.*]] = cmpi ult, %[[VAL_69]]#1, %[[VAL_32]] : index
+// CHECK:                 %[[VAL_73:.*]] = arith.cmpi ult, %[[VAL_69]]#1, %[[VAL_32]] : index
 // CHECK:                 %[[VAL_74:.*]] = scf.if %[[VAL_73]] -> (index) {
-// CHECK:                   %[[VAL_75:.*]] = subi %[[VAL_32]], %[[VAL_69]]#1 : index
-// CHECK:                   %[[VAL_76:.*]] = addi %[[VAL_69]]#6, %[[VAL_75]] : index
+// CHECK:                   %[[VAL_75:.*]] = arith.subi %[[VAL_32]], %[[VAL_69]]#1 : index
+// CHECK:                   %[[VAL_76:.*]] = arith.addi %[[VAL_69]]#6, %[[VAL_75]] : index
 // CHECK:                   scf.yield %[[VAL_76]] : index
 // CHECK:                 } else {
 // CHECK:                   scf.yield %[[VAL_69]]#6 : index
 // CHECK:                 }
 // CHECK:                 scf.yield %[[VAL_77:.*]] : index
 // CHECK:               }
-// CHECK:               %[[VAL_78:.*]] = index_cast %[[VAL_79:.*]] : index to i64
+// CHECK:               %[[VAL_78:.*]] = arith.index_cast %[[VAL_79:.*]] : index to i64
 // CHECK:               scf.yield %[[VAL_78]] : i64
 // CHECK:             }
 // CHECK:             memref.store %[[VAL_80:.*]], %[[VAL_18]]{{\[}}%[[VAL_19]]] : memref<?xi64>
@@ -108,13 +108,13 @@
 // CHECK:             %[[VAL_82:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_81]]] : memref<?xi64>
 // CHECK:             %[[VAL_83:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_11]]] : memref<?xi64>
 // CHECK:             memref.store %[[VAL_83]], %[[VAL_18]]{{\[}}%[[VAL_81]]] : memref<?xi64>
-// CHECK:             %[[VAL_84:.*]] = addi %[[VAL_83]], %[[VAL_82]] : i64
+// CHECK:             %[[VAL_84:.*]] = arith.addi %[[VAL_83]], %[[VAL_82]] : i64
 // CHECK:             memref.store %[[VAL_84]], %[[VAL_18]]{{\[}}%[[VAL_11]]] : memref<?xi64>
 // CHECK:           }
 // CHECK:           %[[VAL_85:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_86:.*]] = tensor.dim %[[VAL_1]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_87:.*]] = memref.load %[[VAL_85]]{{\[}}%[[VAL_86]]] : memref<?xi64>
-// CHECK:           %[[VAL_88:.*]] = index_cast %[[VAL_87]] : i64 to index
+// CHECK:           %[[VAL_88:.*]] = arith.index_cast %[[VAL_87]] : i64 to index
 // CHECK:           %[[VAL_89:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_1]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           call @resize_index(%[[VAL_89]], %[[VAL_3]], %[[VAL_88]]) : (!llvm.ptr<i8>, index, index) -> ()
 // CHECK:           %[[VAL_90:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_1]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
@@ -122,25 +122,25 @@
 // CHECK:           %[[VAL_91:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_92:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           scf.parallel (%[[VAL_93:.*]]) = (%[[VAL_2]]) to (%[[VAL_11]]) step (%[[VAL_3]]) {
-// CHECK:             %[[VAL_94:.*]] = addi %[[VAL_93]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_94:.*]] = arith.addi %[[VAL_93]], %[[VAL_3]] : index
 // CHECK:             %[[VAL_95:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_93]]] : memref<?xi64>
 // CHECK:             %[[VAL_96:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_94]]] : memref<?xi64>
-// CHECK:             %[[VAL_97:.*]] = cmpi ne, %[[VAL_95]], %[[VAL_96]] : i64
+// CHECK:             %[[VAL_97:.*]] = arith.cmpi ne, %[[VAL_95]], %[[VAL_96]] : i64
 // CHECK:             scf.if %[[VAL_97]] {
 // CHECK:               %[[VAL_98:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_93]]] : memref<?xi64>
-// CHECK:               %[[VAL_99:.*]] = index_cast %[[VAL_98]] : i64 to index
+// CHECK:               %[[VAL_99:.*]] = arith.index_cast %[[VAL_98]] : i64 to index
 // CHECK:               %[[VAL_100:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_93]]] : memref<?xi64>
 // CHECK:               %[[VAL_101:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_94]]] : memref<?xi64>
-// CHECK:               %[[VAL_102:.*]] = index_cast %[[VAL_100]] : i64 to index
-// CHECK:               %[[VAL_103:.*]] = index_cast %[[VAL_101]] : i64 to index
+// CHECK:               %[[VAL_102:.*]] = arith.index_cast %[[VAL_100]] : i64 to index
+// CHECK:               %[[VAL_103:.*]] = arith.index_cast %[[VAL_101]] : i64 to index
 // CHECK:               %[[VAL_104:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_93]]] : memref<?xi64>
 // CHECK:               %[[VAL_105:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_94]]] : memref<?xi64>
-// CHECK:               %[[VAL_106:.*]] = index_cast %[[VAL_104]] : i64 to index
-// CHECK:               %[[VAL_107:.*]] = index_cast %[[VAL_105]] : i64 to index
+// CHECK:               %[[VAL_106:.*]] = arith.index_cast %[[VAL_104]] : i64 to index
+// CHECK:               %[[VAL_107:.*]] = arith.index_cast %[[VAL_105]] : i64 to index
 // CHECK:               %[[VAL_108:.*]]:9 = scf.while (%[[VAL_109:.*]] = %[[VAL_102]], %[[VAL_110:.*]] = %[[VAL_106]], %[[VAL_111:.*]] = %[[VAL_99]], %[[VAL_112:.*]] = %[[VAL_4]], %[[VAL_113:.*]] = %[[VAL_4]], %[[VAL_114:.*]] = %[[VAL_7]], %[[VAL_115:.*]] = %[[VAL_7]], %[[VAL_116:.*]] = %[[VAL_6]], %[[VAL_117:.*]] = %[[VAL_6]]) : (index, index, index, i64, i64, f64, f64, i1, i1) -> (index, index, index, i64, i64, f64, f64, i1, i1) {
-// CHECK:                 %[[VAL_118:.*]] = cmpi ult, %[[VAL_109]], %[[VAL_103]] : index
-// CHECK:                 %[[VAL_119:.*]] = cmpi ult, %[[VAL_110]], %[[VAL_107]] : index
-// CHECK:                 %[[VAL_120:.*]] = and %[[VAL_118]], %[[VAL_119]] : i1
+// CHECK:                 %[[VAL_118:.*]] = arith.cmpi ult, %[[VAL_109]], %[[VAL_103]] : index
+// CHECK:                 %[[VAL_119:.*]] = arith.cmpi ult, %[[VAL_110]], %[[VAL_107]] : index
+// CHECK:                 %[[VAL_120:.*]] = arith.andi %[[VAL_118]], %[[VAL_119]] : i1
 // CHECK:                 scf.condition(%[[VAL_120]]) %[[VAL_109]], %[[VAL_110]], %[[VAL_111]], %[[VAL_112]], %[[VAL_113]], %[[VAL_114]], %[[VAL_115]], %[[VAL_116]], %[[VAL_117]] : index, index, index, i64, i64, f64, f64, i1, i1
 // CHECK:               } do {
 // CHECK:               ^bb0(%[[VAL_121:.*]]: index, %[[VAL_122:.*]]: index, %[[VAL_123:.*]]: index, %[[VAL_124:.*]]: i64, %[[VAL_125:.*]]: i64, %[[VAL_126:.*]]: f64, %[[VAL_127:.*]]: f64, %[[VAL_128:.*]]: i1, %[[VAL_129:.*]]: i1):
@@ -158,11 +158,11 @@
 // CHECK:                 } else {
 // CHECK:                   scf.yield %[[VAL_125]], %[[VAL_127]] : i64, f64
 // CHECK:                 }
-// CHECK:                 %[[VAL_136:.*]] = cmpi ult, %[[VAL_137:.*]]#0, %[[VAL_138:.*]]#0 : i64
-// CHECK:                 %[[VAL_139:.*]] = cmpi ugt, %[[VAL_137]]#0, %[[VAL_138]]#0 : i64
-// CHECK:                 %[[VAL_140:.*]] = addi %[[VAL_121]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_141:.*]] = addi %[[VAL_122]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_142:.*]] = addi %[[VAL_123]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_136:.*]] = arith.cmpi ult, %[[VAL_137:.*]]#0, %[[VAL_138:.*]]#0 : i64
+// CHECK:                 %[[VAL_139:.*]] = arith.cmpi ugt, %[[VAL_137]]#0, %[[VAL_138]]#0 : i64
+// CHECK:                 %[[VAL_140:.*]] = arith.addi %[[VAL_121]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_141:.*]] = arith.addi %[[VAL_122]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_142:.*]] = arith.addi %[[VAL_123]], %[[VAL_3]] : index
 // CHECK:                 %[[VAL_143:.*]]:5 = scf.if %[[VAL_136]] -> (index, index, index, i1, i1) {
 // CHECK:                   memref.store %[[VAL_137]]#0, %[[VAL_91]]{{\[}}%[[VAL_123]]] : memref<?xi64>
 // CHECK:                   memref.store %[[VAL_137]]#1, %[[VAL_92]]{{\[}}%[[VAL_123]]] : memref<?xf64>
@@ -174,7 +174,7 @@
 // CHECK:                     scf.yield %[[VAL_121]], %[[VAL_141]], %[[VAL_142]], %[[VAL_5]], %[[VAL_6]] : index, index, index, i1, i1
 // CHECK:                   } else {
 // CHECK:                     memref.store %[[VAL_137]]#0, %[[VAL_91]]{{\[}}%[[VAL_123]]] : memref<?xi64>
-// CHECK:                     %[[VAL_145:.*]] = cmpf olt, %[[VAL_137]]#1, %[[VAL_138]]#1 : f64
+// CHECK:                     %[[VAL_145:.*]] = arith.cmpf olt, %[[VAL_137]]#1, %[[VAL_138]]#1 : f64
 // CHECK:                     %[[VAL_146:.*]] = select %[[VAL_145]], %[[VAL_137]]#1, %[[VAL_138]]#1 : f64
 // CHECK:                     memref.store %[[VAL_146]], %[[VAL_92]]{{\[}}%[[VAL_123]]] : memref<?xf64>
 // CHECK:                     scf.yield %[[VAL_140]], %[[VAL_141]], %[[VAL_142]], %[[VAL_6]], %[[VAL_6]] : index, index, index, i1, i1
@@ -183,26 +183,26 @@
 // CHECK:                 }
 // CHECK:                 scf.yield %[[VAL_148:.*]]#0, %[[VAL_148]]#1, %[[VAL_148]]#2, %[[VAL_137]]#0, %[[VAL_138]]#0, %[[VAL_137]]#1, %[[VAL_138]]#1, %[[VAL_148]]#3, %[[VAL_148]]#4 : index, index, index, i64, i64, f64, f64, i1, i1
 // CHECK:               }
-// CHECK:               %[[VAL_149:.*]] = cmpi ult, %[[VAL_150:.*]]#0, %[[VAL_103]] : index
+// CHECK:               %[[VAL_149:.*]] = arith.cmpi ult, %[[VAL_150:.*]]#0, %[[VAL_103]] : index
 // CHECK:               %[[VAL_151:.*]] = scf.if %[[VAL_149]] -> (index) {
 // CHECK:                 %[[VAL_152:.*]] = scf.for %[[VAL_153:.*]] = %[[VAL_150]]#0 to %[[VAL_103]] step %[[VAL_3]] iter_args(%[[VAL_154:.*]] = %[[VAL_150]]#2) -> (index) {
 // CHECK:                   %[[VAL_155:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_153]]] : memref<?xi64>
 // CHECK:                   %[[VAL_156:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_153]]] : memref<?xf64>
 // CHECK:                   memref.store %[[VAL_155]], %[[VAL_91]]{{\[}}%[[VAL_154]]] : memref<?xi64>
 // CHECK:                   memref.store %[[VAL_156]], %[[VAL_92]]{{\[}}%[[VAL_154]]] : memref<?xf64>
-// CHECK:                   %[[VAL_157:.*]] = addi %[[VAL_154]], %[[VAL_3]] : index
+// CHECK:                   %[[VAL_157:.*]] = arith.addi %[[VAL_154]], %[[VAL_3]] : index
 // CHECK:                   scf.yield %[[VAL_157]] : index
 // CHECK:                 }
 // CHECK:                 scf.yield %[[VAL_158:.*]] : index
 // CHECK:               } else {
-// CHECK:                 %[[VAL_159:.*]] = cmpi ult, %[[VAL_150]]#1, %[[VAL_107]] : index
+// CHECK:                 %[[VAL_159:.*]] = arith.cmpi ult, %[[VAL_150]]#1, %[[VAL_107]] : index
 // CHECK:                 %[[VAL_160:.*]] = scf.if %[[VAL_159]] -> (index) {
 // CHECK:                   %[[VAL_161:.*]] = scf.for %[[VAL_162:.*]] = %[[VAL_150]]#1 to %[[VAL_107]] step %[[VAL_3]] iter_args(%[[VAL_163:.*]] = %[[VAL_150]]#2) -> (index) {
 // CHECK:                     %[[VAL_164:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_162]]] : memref<?xi64>
 // CHECK:                     %[[VAL_165:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_162]]] : memref<?xf64>
 // CHECK:                     memref.store %[[VAL_164]], %[[VAL_91]]{{\[}}%[[VAL_163]]] : memref<?xi64>
 // CHECK:                     memref.store %[[VAL_165]], %[[VAL_92]]{{\[}}%[[VAL_163]]] : memref<?xf64>
-// CHECK:                     %[[VAL_166:.*]] = addi %[[VAL_163]], %[[VAL_3]] : index
+// CHECK:                     %[[VAL_166:.*]] = arith.addi %[[VAL_163]], %[[VAL_3]] : index
 // CHECK:                     scf.yield %[[VAL_166]] : index
 // CHECK:                   }
 // CHECK:                   scf.yield %[[VAL_167:.*]] : index

--- a/mlir_graphblas/src/test/GraphBLAS/lower_matrix_vector_multiply_full.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_matrix_vector_multiply_full.mlir
@@ -17,14 +17,14 @@
 // CHECK-LABEL:   func @matrix_vector_multiply_plus_times(
 // CHECK-SAME:                                            %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                                            %[[VAL_1:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK-DAG:       %[[VAL_2:.*]] = constant 2 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 0 : i64
-// CHECK-DAG:       %[[VAL_4:.*]] = constant 1 : i64
-// CHECK-DAG:       %[[VAL_5:.*]] = constant 0 : index
-// CHECK-DAG:       %[[VAL_6:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_7:.*]] = constant true
-// CHECK-DAG:       %[[VAL_8:.*]] = constant false
-// CHECK-DAG:       %[[VAL_9:.*]] = constant 0.000000e+00 : f64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 2 : index
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : i64
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 1 : i64
+// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_6:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_7:.*]] = arith.constant true
+// CHECK-DAG:       %[[VAL_8:.*]] = arith.constant false
+// CHECK-DAG:       %[[VAL_9:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK:           %[[VAL_10:.*]] = tensor.dim %[[VAL_0]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_11:.*]] = tensor.dim %[[VAL_1]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_12:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_1]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
@@ -42,8 +42,8 @@
 // CHECK:           %[[VAL_22:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           %[[VAL_23:.*]] = sparse_tensor.pointers %[[VAL_14]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_24:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_6]]] : memref<?xi64>
-// CHECK:           %[[VAL_25:.*]] = index_cast %[[VAL_24]] : i64 to index
-// CHECK:           %[[VAL_26:.*]] = cmpi eq, %[[VAL_5]], %[[VAL_25]] : index
+// CHECK:           %[[VAL_25:.*]] = arith.index_cast %[[VAL_24]] : i64 to index
+// CHECK:           %[[VAL_26:.*]] = arith.cmpi eq, %[[VAL_5]], %[[VAL_25]] : index
 // CHECK:           %[[VAL_27:.*]] = scf.if %[[VAL_26]] -> (i64) {
 // CHECK:             scf.yield %[[VAL_3]] : i64
 // CHECK:           } else {
@@ -51,26 +51,26 @@
 // CHECK:             linalg.fill(%[[VAL_8]], %[[VAL_28]]) : i1, memref<?xi1>
 // CHECK:             scf.parallel (%[[VAL_29:.*]]) = (%[[VAL_5]]) to (%[[VAL_25]]) step (%[[VAL_6]]) {
 // CHECK:               %[[VAL_30:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_29]]] : memref<?xi64>
-// CHECK:               %[[VAL_31:.*]] = index_cast %[[VAL_30]] : i64 to index
+// CHECK:               %[[VAL_31:.*]] = arith.index_cast %[[VAL_30]] : i64 to index
 // CHECK:               memref.store %[[VAL_7]], %[[VAL_28]]{{\[}}%[[VAL_31]]] : memref<?xi1>
 // CHECK:               scf.yield
 // CHECK:             }
 // CHECK:             %[[VAL_32:.*]] = scf.parallel (%[[VAL_33:.*]]) = (%[[VAL_5]]) to (%[[VAL_10]]) step (%[[VAL_6]]) init (%[[VAL_3]]) -> i64 {
-// CHECK:               %[[VAL_34:.*]] = addi %[[VAL_33]], %[[VAL_6]] : index
+// CHECK:               %[[VAL_34:.*]] = arith.addi %[[VAL_33]], %[[VAL_6]] : index
 // CHECK:               %[[VAL_35:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_33]]] : memref<?xi64>
 // CHECK:               %[[VAL_36:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_34]]] : memref<?xi64>
-// CHECK:               %[[VAL_37:.*]] = cmpi eq, %[[VAL_35]], %[[VAL_36]] : i64
+// CHECK:               %[[VAL_37:.*]] = arith.cmpi eq, %[[VAL_35]], %[[VAL_36]] : i64
 // CHECK:               %[[VAL_38:.*]] = scf.if %[[VAL_37]] -> (i64) {
 // CHECK:                 scf.yield %[[VAL_3]] : i64
 // CHECK:               } else {
 // CHECK:                 %[[VAL_39:.*]] = scf.while (%[[VAL_40:.*]] = %[[VAL_35]]) : (i64) -> i64 {
-// CHECK:                   %[[VAL_41:.*]] = cmpi uge, %[[VAL_40]], %[[VAL_36]] : i64
+// CHECK:                   %[[VAL_41:.*]] = arith.cmpi uge, %[[VAL_40]], %[[VAL_36]] : i64
 // CHECK:                   %[[VAL_42:.*]]:2 = scf.if %[[VAL_41]] -> (i1, i64) {
 // CHECK:                     scf.yield %[[VAL_8]], %[[VAL_3]] : i1, i64
 // CHECK:                   } else {
-// CHECK:                     %[[VAL_43:.*]] = index_cast %[[VAL_40]] : i64 to index
+// CHECK:                     %[[VAL_43:.*]] = arith.index_cast %[[VAL_40]] : i64 to index
 // CHECK:                     %[[VAL_44:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_43]]] : memref<?xi64>
-// CHECK:                     %[[VAL_45:.*]] = index_cast %[[VAL_44]] : i64 to index
+// CHECK:                     %[[VAL_45:.*]] = arith.index_cast %[[VAL_44]] : i64 to index
 // CHECK:                     %[[VAL_46:.*]] = memref.load %[[VAL_28]]{{\[}}%[[VAL_45]]] : memref<?xi1>
 // CHECK:                     %[[VAL_47:.*]] = select %[[VAL_46]], %[[VAL_8]], %[[VAL_7]] : i1
 // CHECK:                     %[[VAL_48:.*]] = select %[[VAL_46]], %[[VAL_4]], %[[VAL_40]] : i64
@@ -79,14 +79,14 @@
 // CHECK:                   scf.condition(%[[VAL_49:.*]]#0) %[[VAL_49]]#1 : i64
 // CHECK:                 } do {
 // CHECK:                 ^bb0(%[[VAL_50:.*]]: i64):
-// CHECK:                   %[[VAL_51:.*]] = addi %[[VAL_50]], %[[VAL_4]] : i64
+// CHECK:                   %[[VAL_51:.*]] = arith.addi %[[VAL_50]], %[[VAL_4]] : i64
 // CHECK:                   scf.yield %[[VAL_51]] : i64
 // CHECK:                 }
 // CHECK:                 scf.yield %[[VAL_52:.*]] : i64
 // CHECK:               }
 // CHECK:               scf.reduce(%[[VAL_53:.*]])  : i64 {
 // CHECK:               ^bb0(%[[VAL_54:.*]]: i64, %[[VAL_55:.*]]: i64):
-// CHECK:                 %[[VAL_56:.*]] = addi %[[VAL_54]], %[[VAL_55]] : i64
+// CHECK:                 %[[VAL_56:.*]] = arith.addi %[[VAL_54]], %[[VAL_55]] : i64
 // CHECK:                 scf.reduce.return %[[VAL_56]] : i64
 // CHECK:               }
 // CHECK:               scf.yield
@@ -94,7 +94,7 @@
 // CHECK:             memref.dealloc %[[VAL_28]] : memref<?xi1>
 // CHECK:             scf.yield %[[VAL_57:.*]] : i64
 // CHECK:           }
-// CHECK:           %[[VAL_58:.*]] = index_cast %[[VAL_59:.*]] : i64 to index
+// CHECK:           %[[VAL_58:.*]] = arith.index_cast %[[VAL_59:.*]] : i64 to index
 // CHECK:           memref.store %[[VAL_59]], %[[VAL_23]]{{\[}}%[[VAL_6]]] : memref<?xi64>
 // CHECK:           %[[VAL_60:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_14]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           call @resize_index(%[[VAL_60]], %[[VAL_5]], %[[VAL_58]]) : (!llvm.ptr<i8>, index, index) -> ()
@@ -102,35 +102,35 @@
 // CHECK:           call @resize_values(%[[VAL_61]], %[[VAL_58]]) : (!llvm.ptr<i8>, index) -> ()
 // CHECK:           %[[VAL_62:.*]] = sparse_tensor.indices %[[VAL_14]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_63:.*]] = sparse_tensor.values %[[VAL_14]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_64:.*]] = cmpi ne, %[[VAL_5]], %[[VAL_58]] : index
+// CHECK:           %[[VAL_64:.*]] = arith.cmpi ne, %[[VAL_5]], %[[VAL_58]] : index
 // CHECK:           scf.if %[[VAL_64]] {
 // CHECK:             %[[VAL_65:.*]] = memref.alloc(%[[VAL_11]]) : memref<?xf64>
 // CHECK:             %[[VAL_66:.*]] = memref.alloc(%[[VAL_11]]) : memref<?xi1>
 // CHECK:             linalg.fill(%[[VAL_8]], %[[VAL_66]]) : i1, memref<?xi1>
 // CHECK:             scf.parallel (%[[VAL_67:.*]]) = (%[[VAL_5]]) to (%[[VAL_25]]) step (%[[VAL_6]]) {
 // CHECK:               %[[VAL_68:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_67]]] : memref<?xi64>
-// CHECK:               %[[VAL_69:.*]] = index_cast %[[VAL_68]] : i64 to index
+// CHECK:               %[[VAL_69:.*]] = arith.index_cast %[[VAL_68]] : i64 to index
 // CHECK:               memref.store %[[VAL_7]], %[[VAL_66]]{{\[}}%[[VAL_69]]] : memref<?xi1>
 // CHECK:               %[[VAL_70:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_67]]] : memref<?xf64>
 // CHECK:               memref.store %[[VAL_70]], %[[VAL_65]]{{\[}}%[[VAL_69]]] : memref<?xf64>
 // CHECK:               scf.yield
 // CHECK:             }
 // CHECK:             %[[VAL_71:.*]] = scf.for %[[VAL_72:.*]] = %[[VAL_5]] to %[[VAL_10]] step %[[VAL_6]] iter_args(%[[VAL_73:.*]] = %[[VAL_5]]) -> (index) {
-// CHECK:               %[[VAL_74:.*]] = index_cast %[[VAL_72]] : index to i64
-// CHECK:               %[[VAL_75:.*]] = addi %[[VAL_72]], %[[VAL_6]] : index
+// CHECK:               %[[VAL_74:.*]] = arith.index_cast %[[VAL_72]] : index to i64
+// CHECK:               %[[VAL_75:.*]] = arith.addi %[[VAL_72]], %[[VAL_6]] : index
 // CHECK:               %[[VAL_76:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_72]]] : memref<?xi64>
 // CHECK:               %[[VAL_77:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_75]]] : memref<?xi64>
-// CHECK:               %[[VAL_78:.*]] = index_cast %[[VAL_76]] : i64 to index
-// CHECK:               %[[VAL_79:.*]] = index_cast %[[VAL_77]] : i64 to index
+// CHECK:               %[[VAL_78:.*]] = arith.index_cast %[[VAL_76]] : i64 to index
+// CHECK:               %[[VAL_79:.*]] = arith.index_cast %[[VAL_77]] : i64 to index
 // CHECK:               %[[VAL_80:.*]]:2 = scf.for %[[VAL_81:.*]] = %[[VAL_78]] to %[[VAL_79]] step %[[VAL_6]] iter_args(%[[VAL_82:.*]] = %[[VAL_9]], %[[VAL_83:.*]] = %[[VAL_8]]) -> (f64, i1) {
 // CHECK:                 %[[VAL_84:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_81]]] : memref<?xi64>
-// CHECK:                 %[[VAL_85:.*]] = index_cast %[[VAL_84]] : i64 to index
+// CHECK:                 %[[VAL_85:.*]] = arith.index_cast %[[VAL_84]] : i64 to index
 // CHECK:                 %[[VAL_86:.*]] = memref.load %[[VAL_66]]{{\[}}%[[VAL_85]]] : memref<?xi1>
 // CHECK:                 %[[VAL_87:.*]]:2 = scf.if %[[VAL_86]] -> (f64, i1) {
 // CHECK:                   %[[VAL_88:.*]] = memref.load %[[VAL_65]]{{\[}}%[[VAL_85]]] : memref<?xf64>
 // CHECK:                   %[[VAL_89:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_81]]] : memref<?xf64>
-// CHECK:                   %[[VAL_90:.*]] = mulf %[[VAL_89]], %[[VAL_88]] : f64
-// CHECK:                   %[[VAL_91:.*]] = addf %[[VAL_82]], %[[VAL_90]] : f64
+// CHECK:                   %[[VAL_90:.*]] = arith.mulf %[[VAL_89]], %[[VAL_88]] : f64
+// CHECK:                   %[[VAL_91:.*]] = arith.addf %[[VAL_82]], %[[VAL_90]] : f64
 // CHECK:                   scf.yield %[[VAL_91]], %[[VAL_7]] : f64, i1
 // CHECK:                 } else {
 // CHECK:                   scf.yield %[[VAL_82]], %[[VAL_83]] : f64, i1
@@ -140,7 +140,7 @@
 // CHECK:               %[[VAL_93:.*]] = scf.if %[[VAL_94:.*]]#1 -> (index) {
 // CHECK:                 memref.store %[[VAL_74]], %[[VAL_62]]{{\[}}%[[VAL_73]]] : memref<?xi64>
 // CHECK:                 memref.store %[[VAL_94]]#0, %[[VAL_63]]{{\[}}%[[VAL_73]]] : memref<?xf64>
-// CHECK:                 %[[VAL_95:.*]] = addi %[[VAL_73]], %[[VAL_6]] : index
+// CHECK:                 %[[VAL_95:.*]] = arith.addi %[[VAL_73]], %[[VAL_6]] : index
 // CHECK:                 scf.yield %[[VAL_95]] : index
 // CHECK:               } else {
 // CHECK:                 scf.yield %[[VAL_73]] : index

--- a/mlir_graphblas/src/test/GraphBLAS/lower_noop_semiring.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_noop_semiring.mlir
@@ -19,7 +19,7 @@
 func @noop_semiring(%a: tensor<?x?xf64, #CSR64>, %b: tensor<?x?xf64, #CSC64>) -> tensor<?x?xf64, #CSR64> {
     %answer = graphblas.matrix_multiply_generic %a, %b {mask_complement = false} : (tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSC64>) to tensor<?x?xf64, #CSR64> {
         ^bb0:
-            %identity = constant 0.0 : f64
+            %identity = arith.constant 0.0 : f64
             graphblas.yield add_identity %identity : f64
     },{
         ^bb0(%add_a: f64, %add_b: f64):

--- a/mlir_graphblas/src/test/GraphBLAS/lower_random_select.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_random_select.mlir
@@ -15,9 +15,9 @@ func private @uniform_choose_n(!llvm.ptr<i8>, i64, i64, memref<?xi64, #map>, mem
 // CHECK-SAME:                                %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                                %[[VAL_1:.*]]: i64,
 // CHECK-SAME:                                %[[VAL_2:.*]]: !llvm.ptr<i8>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 0 : i64
-// CHECK-DAG:       %[[VAL_4:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_5:.*]] = constant 0 : index
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : i64
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_6:.*]] = tensor.dim %[[VAL_0]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_7:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_8:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
@@ -30,31 +30,31 @@ func private @uniform_choose_n(!llvm.ptr<i8>, i64, i64, memref<?xi64, #map>, mem
 // CHECK:           %[[VAL_15:.*]] = sparse_tensor.values %[[VAL_12]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           memref.store %[[VAL_3]], %[[VAL_13]]{{\[}}%[[VAL_5]]] : memref<?xi64>
 // CHECK:           scf.for %[[VAL_16:.*]] = %[[VAL_5]] to %[[VAL_6]] step %[[VAL_4]] {
-// CHECK:             %[[VAL_17:.*]] = addi %[[VAL_16]], %[[VAL_4]] : index
+// CHECK:             %[[VAL_17:.*]] = arith.addi %[[VAL_16]], %[[VAL_4]] : index
 // CHECK:             %[[VAL_18:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:             %[[VAL_19:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_17]]] : memref<?xi64>
-// CHECK:             %[[VAL_20:.*]] = subi %[[VAL_19]], %[[VAL_18]] : i64
-// CHECK:             %[[VAL_21:.*]] = cmpi ule, %[[VAL_20]], %[[VAL_1]] : i64
+// CHECK:             %[[VAL_20:.*]] = arith.subi %[[VAL_19]], %[[VAL_18]] : i64
+// CHECK:             %[[VAL_21:.*]] = arith.cmpi ule, %[[VAL_20]], %[[VAL_1]] : i64
 // CHECK:             %[[VAL_22:.*]] = select %[[VAL_21]], %[[VAL_20]], %[[VAL_1]] : i64
 // CHECK:             %[[VAL_23:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_16]]] : memref<?xi64>
-// CHECK:             %[[VAL_24:.*]] = addi %[[VAL_23]], %[[VAL_22]] : i64
+// CHECK:             %[[VAL_24:.*]] = arith.addi %[[VAL_23]], %[[VAL_22]] : i64
 // CHECK:             memref.store %[[VAL_24]], %[[VAL_13]]{{\[}}%[[VAL_17]]] : memref<?xi64>
 // CHECK:           }
 // CHECK:           scf.parallel (%[[VAL_25:.*]]) = (%[[VAL_5]]) to (%[[VAL_6]]) step (%[[VAL_4]]) {
-// CHECK:             %[[VAL_26:.*]] = addi %[[VAL_25]], %[[VAL_4]] : index
+// CHECK:             %[[VAL_26:.*]] = arith.addi %[[VAL_25]], %[[VAL_4]] : index
 // CHECK:             %[[VAL_27:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_25]]] : memref<?xi64>
-// CHECK:             %[[VAL_28:.*]] = index_cast %[[VAL_27]] : i64 to index
+// CHECK:             %[[VAL_28:.*]] = arith.index_cast %[[VAL_27]] : i64 to index
 // CHECK:             %[[VAL_29:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_26]]] : memref<?xi64>
-// CHECK:             %[[VAL_30:.*]] = index_cast %[[VAL_29]] : i64 to index
+// CHECK:             %[[VAL_30:.*]] = arith.index_cast %[[VAL_29]] : i64 to index
 // CHECK:             %[[VAL_31:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_25]]] : memref<?xi64>
-// CHECK:             %[[VAL_32:.*]] = index_cast %[[VAL_31]] : i64 to index
+// CHECK:             %[[VAL_32:.*]] = arith.index_cast %[[VAL_31]] : i64 to index
 // CHECK:             %[[VAL_33:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_26]]] : memref<?xi64>
-// CHECK:             %[[VAL_34:.*]] = index_cast %[[VAL_33]] : i64 to index
-// CHECK:             %[[VAL_35:.*]] = subi %[[VAL_30]], %[[VAL_28]] : index
-// CHECK:             %[[VAL_36:.*]] = index_cast %[[VAL_35]] : index to i64
-// CHECK:             %[[VAL_37:.*]] = subi %[[VAL_34]], %[[VAL_32]] : index
-// CHECK:             %[[VAL_38:.*]] = index_cast %[[VAL_37]] : index to i64
-// CHECK:             %[[VAL_39:.*]] = cmpi eq, %[[VAL_35]], %[[VAL_37]] : index
+// CHECK:             %[[VAL_34:.*]] = arith.index_cast %[[VAL_33]] : i64 to index
+// CHECK:             %[[VAL_35:.*]] = arith.subi %[[VAL_30]], %[[VAL_28]] : index
+// CHECK:             %[[VAL_36:.*]] = arith.index_cast %[[VAL_35]] : index to i64
+// CHECK:             %[[VAL_37:.*]] = arith.subi %[[VAL_34]], %[[VAL_32]] : index
+// CHECK:             %[[VAL_38:.*]] = arith.index_cast %[[VAL_37]] : index to i64
+// CHECK:             %[[VAL_39:.*]] = arith.cmpi eq, %[[VAL_35]], %[[VAL_37]] : index
 // CHECK:             %[[VAL_40:.*]] = memref.subview %[[VAL_14]]{{\[}}%[[VAL_32]]] {{\[}}%[[VAL_37]]] {{\[}}%[[VAL_4]]] : memref<?xi64> to memref<?xi64, #map>
 // CHECK:             %[[VAL_41:.*]] = memref.subview %[[VAL_15]]{{\[}}%[[VAL_32]]] {{\[}}%[[VAL_37]]] {{\[}}%[[VAL_4]]] : memref<?xf64> to memref<?xf64, #map>
 // CHECK:             %[[VAL_42:.*]] = memref.subview %[[VAL_8]]{{\[}}%[[VAL_28]]] {{\[}}%[[VAL_35]]] {{\[}}%[[VAL_4]]] : memref<?xi64> to memref<?xi64, #map>
@@ -66,7 +66,7 @@ func private @uniform_choose_n(!llvm.ptr<i8>, i64, i64, memref<?xi64, #map>, mem
 // CHECK:               call @uniform_choose_n(%[[VAL_2]], %[[VAL_38]], %[[VAL_36]], %[[VAL_40]], %[[VAL_43]]) : (!llvm.ptr<i8>, i64, i64, memref<?xi64, #map>, memref<?xf64, #map>) -> ()
 // CHECK:               scf.parallel (%[[VAL_44:.*]]) = (%[[VAL_5]]) to (%[[VAL_37]]) step (%[[VAL_4]]) {
 // CHECK:                 %[[VAL_45:.*]] = memref.load %[[VAL_40]]{{\[}}%[[VAL_44]]] : memref<?xi64, #map>
-// CHECK:                 %[[VAL_46:.*]] = index_cast %[[VAL_45]] : i64 to index
+// CHECK:                 %[[VAL_46:.*]] = arith.index_cast %[[VAL_45]] : i64 to index
 // CHECK:                 %[[VAL_47:.*]] = memref.load %[[VAL_42]]{{\[}}%[[VAL_46]]] : memref<?xi64, #map>
 // CHECK:                 %[[VAL_48:.*]] = memref.load %[[VAL_43]]{{\[}}%[[VAL_46]]] : memref<?xf64, #map>
 // CHECK:                 memref.store %[[VAL_47]], %[[VAL_40]]{{\[}}%[[VAL_44]]] : memref<?xi64, #map>

--- a/mlir_graphblas/src/test/GraphBLAS/lower_reduce_to_scalar.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_reduce_to_scalar.mlir
@@ -10,19 +10,19 @@
 module {
     // CHECK-LABEL:   func @matrix_reduce_to_scalar_f64(
     // CHECK-SAME:                                      %[[VAL_0:.*]]: tensor<?x?xf64, [[CSR:.*->.*]]>) -> f64 {
-    // CHECK-DAG:       %[[VAL_1:.*]] = constant 0.000000e+00 : f64
-    // CHECK-DAG:       %[[VAL_2:.*]] = constant 0 : index
-    // CHECK-DAG:       %[[VAL_3:.*]] = constant 1 : index
+    // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 0.000000e+00 : f64
+    // CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
+    // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : index
     // CHECK:           %[[VAL_6:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xf64, [[CSR]]> to memref<?xf64>
     // CHECK:           %[[VAL_5:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, [[CSR]]> to memref<?xi64>
     // CHECK:           %[[VAL_4:.*]] = tensor.dim %[[VAL_0]], %[[VAL_2]] : tensor<?x?xf64, [[CSR]]>
     // CHECK:           %[[VAL_7:.*]] = memref.load %[[VAL_5]]{{\[}}%[[VAL_4]]] : memref<?xi64>
-    // CHECK:           %[[VAL_8:.*]] = index_cast %[[VAL_7]] : i64 to index
+    // CHECK:           %[[VAL_8:.*]] = arith.index_cast %[[VAL_7]] : i64 to index
     // CHECK:           %[[VAL_9:.*]] = scf.parallel (%[[VAL_10:.*]]) = (%[[VAL_2]]) to (%[[VAL_8]]) step (%[[VAL_3]]) init (%[[VAL_1]]) -> f64 {
     // CHECK:             %[[VAL_11:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_10]]] : memref<?xf64>
     // CHECK:             scf.reduce(%[[VAL_11]])  : f64 {
     // CHECK:             ^bb0(%[[VAL_12:.*]]: f64, %[[VAL_13:.*]]: f64):
-    // CHECK:               %[[VAL_14:.*]] = addf %[[VAL_12]], %[[VAL_13]] : f64
+    // CHECK:               %[[VAL_14:.*]] = arith.addf %[[VAL_12]], %[[VAL_13]] : f64
     // CHECK:               scf.reduce.return %[[VAL_14]] : f64
     // CHECK:             }
     // CHECK:             scf.yield

--- a/mlir_graphblas/src/test/GraphBLAS/lower_select_gt.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_select_gt.mlir
@@ -9,10 +9,10 @@
 
 // CHECK-LABEL:   func @select_gt(
 // CHECK-SAME:                    %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK-DAG:       %[[VAL_1:.*]] = constant 0.000000e+00 : f64
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 1 : i64
-// CHECK-DAG:       %[[VAL_4:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_5:.*]] = constant 0 : index
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 0.000000e+00 : f64
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : i64
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_6:.*]] = tensor.dim %[[VAL_0]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_7:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_8:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
@@ -24,23 +24,23 @@
 // CHECK:           %[[VAL_14:.*]] = sparse_tensor.indices %[[VAL_12]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_15:.*]] = sparse_tensor.values %[[VAL_12]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           scf.for %[[VAL_16:.*]] = %[[VAL_5]] to %[[VAL_6]] step %[[VAL_4]] {
-// CHECK:             %[[VAL_17:.*]] = addi %[[VAL_16]], %[[VAL_4]] : index
+// CHECK:             %[[VAL_17:.*]] = arith.addi %[[VAL_16]], %[[VAL_4]] : index
 // CHECK:             %[[VAL_18:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:             memref.store %[[VAL_18]], %[[VAL_13]]{{\[}}%[[VAL_17]]] : memref<?xi64>
 // CHECK:             %[[VAL_19:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:             %[[VAL_20:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_17]]] : memref<?xi64>
-// CHECK:             %[[VAL_21:.*]] = index_cast %[[VAL_19]] : i64 to index
-// CHECK:             %[[VAL_22:.*]] = index_cast %[[VAL_20]] : i64 to index
+// CHECK:             %[[VAL_21:.*]] = arith.index_cast %[[VAL_19]] : i64 to index
+// CHECK:             %[[VAL_22:.*]] = arith.index_cast %[[VAL_20]] : i64 to index
 // CHECK:             scf.for %[[VAL_23:.*]] = %[[VAL_21]] to %[[VAL_22]] step %[[VAL_4]] {
 // CHECK:               %[[VAL_24:.*]] = memref.load %[[VAL_8]]{{\[}}%[[VAL_23]]] : memref<?xi64>
 // CHECK:               %[[VAL_25:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_23]]] : memref<?xf64>
-// CHECK:               %[[VAL_26:.*]] = cmpf ogt, %[[VAL_25]], %[[VAL_1]] : f64
+// CHECK:               %[[VAL_26:.*]] = arith.cmpf ogt, %[[VAL_25]], %[[VAL_1]] : f64
 // CHECK:               scf.if %[[VAL_26]] {
 // CHECK:                 %[[VAL_27:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_17]]] : memref<?xi64>
-// CHECK:                 %[[VAL_28:.*]] = index_cast %[[VAL_27]] : i64 to index
+// CHECK:                 %[[VAL_28:.*]] = arith.index_cast %[[VAL_27]] : i64 to index
 // CHECK:                 memref.store %[[VAL_24]], %[[VAL_14]]{{\[}}%[[VAL_28]]] : memref<?xi64>
 // CHECK:                 memref.store %[[VAL_25]], %[[VAL_15]]{{\[}}%[[VAL_28]]] : memref<?xf64>
-// CHECK:                 %[[VAL_29:.*]] = addi %[[VAL_27]], %[[VAL_3]] : i64
+// CHECK:                 %[[VAL_29:.*]] = arith.addi %[[VAL_27]], %[[VAL_3]] : i64
 // CHECK:                 memref.store %[[VAL_29]], %[[VAL_13]]{{\[}}%[[VAL_17]]] : memref<?xi64>
 // CHECK:               }
 // CHECK:             }
@@ -48,7 +48,7 @@
 // CHECK:           %[[VAL_30:.*]] = sparse_tensor.pointers %[[VAL_12]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_31:.*]] = tensor.dim %[[VAL_12]], %[[VAL_5]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_32:.*]] = memref.load %[[VAL_30]]{{\[}}%[[VAL_31]]] : memref<?xi64>
-// CHECK:           %[[VAL_33:.*]] = index_cast %[[VAL_32]] : i64 to index
+// CHECK:           %[[VAL_33:.*]] = arith.index_cast %[[VAL_32]] : i64 to index
 // CHECK:           %[[VAL_34:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_12]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           call @resize_index(%[[VAL_34]], %[[VAL_4]], %[[VAL_33]]) : (!llvm.ptr<i8>, index, index) -> ()
 // CHECK:           %[[VAL_35:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_12]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
@@ -57,7 +57,7 @@
 // CHECK:         }
 
 func @select_gt(%sparse_tensor: tensor<?x?xf64, #CSR64>) -> tensor<?x?xf64, #CSR64> {
-    %c0_f64 = constant 0.0 : f64
+    %c0_f64 = arith.constant 0.0 : f64
     %answer = graphblas.select %sparse_tensor, %c0_f64 { selectors = ["gt"] } : tensor<?x?xf64, #CSR64>, f64 to tensor<?x?xf64, #CSR64>
     return %answer : tensor<?x?xf64, #CSR64>
 }

--- a/mlir_graphblas/src/test/GraphBLAS/lower_select_multi.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_select_multi.mlir
@@ -8,9 +8,9 @@
 }>
 
 
-// CHECK:               %[[VAL_35:.*]] = cmpf ogt, %[[VAL_34:.*]], %[[VAL_5:.*]] : f64
-// CHECK:               %[[VAL_39:.*]] = cmpi ugt, %[[VAL_33:.*]], %[[VAL_22:.*]] : index
-// CHECK:               %[[VAL_43:.*]] = cmpi ult, %[[VAL_33:.*]], %[[VAL_22:.*]] : index
+// CHECK:               %[[VAL_35:.*]] = arith.cmpf ogt, %[[VAL_34:.*]], %[[VAL_5:.*]] : f64
+// CHECK:               %[[VAL_39:.*]] = arith.cmpi ugt, %[[VAL_33:.*]], %[[VAL_22:.*]] : index
+// CHECK:               %[[VAL_43:.*]] = arith.cmpi ult, %[[VAL_33:.*]], %[[VAL_22:.*]] : index
 // CHECK:           return %[[VAL_10:.*]], %[[VAL_14:.*]], %[[VAL_18:.*]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 func @select_multi(%sparse_tensor: tensor<?x?xf64, #CSR64>, %thunk: f64) -> (tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSR64>) {
     %answer1, %answer2, %answer3 = graphblas.select %sparse_tensor, %thunk { selectors = ["gt", "triu", "tril"] } : tensor<?x?xf64, #CSR64>, f64 to tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSR64>

--- a/mlir_graphblas/src/test/GraphBLAS/lower_select_tril.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_select_tril.mlir
@@ -9,9 +9,9 @@
 
 // CHECK-LABEL:   func @select_tril(
 // CHECK-SAME:                      %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK-DAG:       %[[VAL_2:.*]] = constant 1 : i64
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_4:.*]] = constant 0 : index
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i64
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_5:.*]] = tensor.dim %[[VAL_0]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_6:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_7:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
@@ -23,24 +23,24 @@
 // CHECK:           %[[VAL_13:.*]] = sparse_tensor.indices %[[VAL_11]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_14:.*]] = sparse_tensor.values %[[VAL_11]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           scf.for %[[VAL_15:.*]] = %[[VAL_4]] to %[[VAL_5]] step %[[VAL_3]] {
-// CHECK:             %[[VAL_16:.*]] = addi %[[VAL_15]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_16:.*]] = arith.addi %[[VAL_15]], %[[VAL_3]] : index
 // CHECK:             %[[VAL_17:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_15]]] : memref<?xi64>
 // CHECK:             memref.store %[[VAL_17]], %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:             %[[VAL_18:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_15]]] : memref<?xi64>
 // CHECK:             %[[VAL_19:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_16]]] : memref<?xi64>
-// CHECK:             %[[VAL_20:.*]] = index_cast %[[VAL_18]] : i64 to index
-// CHECK:             %[[VAL_21:.*]] = index_cast %[[VAL_19]] : i64 to index
+// CHECK:             %[[VAL_20:.*]] = arith.index_cast %[[VAL_18]] : i64 to index
+// CHECK:             %[[VAL_21:.*]] = arith.index_cast %[[VAL_19]] : i64 to index
 // CHECK:             scf.for %[[VAL_22:.*]] = %[[VAL_20]] to %[[VAL_21]] step %[[VAL_3]] {
 // CHECK:               %[[VAL_23:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_22]]] : memref<?xi64>
-// CHECK:               %[[VAL_24:.*]] = index_cast %[[VAL_23]] : i64 to index
+// CHECK:               %[[VAL_24:.*]] = arith.index_cast %[[VAL_23]] : i64 to index
 // CHECK:               %[[VAL_25:.*]] = memref.load %[[VAL_8]]{{\[}}%[[VAL_22]]] : memref<?xf64>
-// CHECK:               %[[VAL_26:.*]] = cmpi ult, %[[VAL_24]], %[[VAL_15]] : index
+// CHECK:               %[[VAL_26:.*]] = arith.cmpi ult, %[[VAL_24]], %[[VAL_15]] : index
 // CHECK:               scf.if %[[VAL_26]] {
 // CHECK:                 %[[VAL_27:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
-// CHECK:                 %[[VAL_28:.*]] = index_cast %[[VAL_27]] : i64 to index
+// CHECK:                 %[[VAL_28:.*]] = arith.index_cast %[[VAL_27]] : i64 to index
 // CHECK:                 memref.store %[[VAL_23]], %[[VAL_13]]{{\[}}%[[VAL_28]]] : memref<?xi64>
 // CHECK:                 memref.store %[[VAL_25]], %[[VAL_14]]{{\[}}%[[VAL_28]]] : memref<?xf64>
-// CHECK:                 %[[VAL_29:.*]] = addi %[[VAL_27]], %[[VAL_2]] : i64
+// CHECK:                 %[[VAL_29:.*]] = arith.addi %[[VAL_27]], %[[VAL_2]] : i64
 // CHECK:                 memref.store %[[VAL_29]], %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:               }
 // CHECK:             }
@@ -48,7 +48,7 @@
 // CHECK:           %[[VAL_30:.*]] = sparse_tensor.pointers %[[VAL_11]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_31:.*]] = tensor.dim %[[VAL_11]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_32:.*]] = memref.load %[[VAL_30]]{{\[}}%[[VAL_31]]] : memref<?xi64>
-// CHECK:           %[[VAL_33:.*]] = index_cast %[[VAL_32]] : i64 to index
+// CHECK:           %[[VAL_33:.*]] = arith.index_cast %[[VAL_32]] : i64 to index
 // CHECK:           %[[VAL_34:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           call @resize_index(%[[VAL_34]], %[[VAL_3]], %[[VAL_33]]) : (!llvm.ptr<i8>, index, index) -> ()
 // CHECK:           %[[VAL_35:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>

--- a/mlir_graphblas/src/test/GraphBLAS/lower_select_triu.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_select_triu.mlir
@@ -9,9 +9,9 @@
 
 // CHECK-LABEL:   func @select_triu(
 // CHECK-SAME:                      %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK-DAG:       %[[VAL_2:.*]] = constant 1 : i64
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_4:.*]] = constant 0 : index
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i64
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_5:.*]] = tensor.dim %[[VAL_0]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_6:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_7:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
@@ -23,24 +23,24 @@
 // CHECK:           %[[VAL_13:.*]] = sparse_tensor.indices %[[VAL_11]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_14:.*]] = sparse_tensor.values %[[VAL_11]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           scf.for %[[VAL_15:.*]] = %[[VAL_4]] to %[[VAL_5]] step %[[VAL_3]] {
-// CHECK:             %[[VAL_16:.*]] = addi %[[VAL_15]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_16:.*]] = arith.addi %[[VAL_15]], %[[VAL_3]] : index
 // CHECK:             %[[VAL_17:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_15]]] : memref<?xi64>
 // CHECK:             memref.store %[[VAL_17]], %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:             %[[VAL_18:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_15]]] : memref<?xi64>
 // CHECK:             %[[VAL_19:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_16]]] : memref<?xi64>
-// CHECK:             %[[VAL_20:.*]] = index_cast %[[VAL_18]] : i64 to index
-// CHECK:             %[[VAL_21:.*]] = index_cast %[[VAL_19]] : i64 to index
+// CHECK:             %[[VAL_20:.*]] = arith.index_cast %[[VAL_18]] : i64 to index
+// CHECK:             %[[VAL_21:.*]] = arith.index_cast %[[VAL_19]] : i64 to index
 // CHECK:             scf.for %[[VAL_22:.*]] = %[[VAL_20]] to %[[VAL_21]] step %[[VAL_3]] {
 // CHECK:               %[[VAL_23:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_22]]] : memref<?xi64>
-// CHECK:               %[[VAL_24:.*]] = index_cast %[[VAL_23]] : i64 to index
+// CHECK:               %[[VAL_24:.*]] = arith.index_cast %[[VAL_23]] : i64 to index
 // CHECK:               %[[VAL_25:.*]] = memref.load %[[VAL_8]]{{\[}}%[[VAL_22]]] : memref<?xf64>
-// CHECK:               %[[VAL_26:.*]] = cmpi ugt, %[[VAL_24]], %[[VAL_15]] : index
+// CHECK:               %[[VAL_26:.*]] = arith.cmpi ugt, %[[VAL_24]], %[[VAL_15]] : index
 // CHECK:               scf.if %[[VAL_26]] {
 // CHECK:                 %[[VAL_27:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
-// CHECK:                 %[[VAL_28:.*]] = index_cast %[[VAL_27]] : i64 to index
+// CHECK:                 %[[VAL_28:.*]] = arith.index_cast %[[VAL_27]] : i64 to index
 // CHECK:                 memref.store %[[VAL_23]], %[[VAL_13]]{{\[}}%[[VAL_28]]] : memref<?xi64>
 // CHECK:                 memref.store %[[VAL_25]], %[[VAL_14]]{{\[}}%[[VAL_28]]] : memref<?xf64>
-// CHECK:                 %[[VAL_29:.*]] = addi %[[VAL_27]], %[[VAL_2]] : i64
+// CHECK:                 %[[VAL_29:.*]] = arith.addi %[[VAL_27]], %[[VAL_2]] : i64
 // CHECK:                 memref.store %[[VAL_29]], %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<?xi64>
 // CHECK:               }
 // CHECK:             }
@@ -48,7 +48,7 @@
 // CHECK:           %[[VAL_30:.*]] = sparse_tensor.pointers %[[VAL_11]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_31:.*]] = tensor.dim %[[VAL_11]], %[[VAL_4]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_32:.*]] = memref.load %[[VAL_30]]{{\[}}%[[VAL_31]]] : memref<?xi64>
-// CHECK:           %[[VAL_33:.*]] = index_cast %[[VAL_32]] : i64 to index
+// CHECK:           %[[VAL_33:.*]] = arith.index_cast %[[VAL_32]] : i64 to index
 // CHECK:           %[[VAL_34:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           call @resize_index(%[[VAL_34]], %[[VAL_3]], %[[VAL_33]]) : (!llvm.ptr<i8>, index, index) -> ()
 // CHECK:           %[[VAL_35:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_11]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>

--- a/mlir_graphblas/src/test/GraphBLAS/lower_transpose.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_transpose.mlir
@@ -17,8 +17,8 @@
 module {
 // CHECK-LABEL:   func @transpose_different_compression(
 // CHECK-SAME:                                          %[[VAL_0:.*]]: tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:           %[[VAL_1:.*]] = constant 0 : index
-// CHECK:           %[[VAL_2:.*]] = constant 1 : index
+// CHECK:           %[[VAL_1:.*]] = arith.constant 0 : index
+// CHECK:           %[[VAL_2:.*]] = arith.constant 1 : index
 // CHECK:           %[[VAL_3:.*]] = call @matrix_csr_i64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_4:.*]] = call @dup_tensor(%[[VAL_3]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_5:.*]] = call @ptr8_to_matrix_csr_i64_p64i64(%[[VAL_4]]) : (!llvm.ptr<i8>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -37,10 +37,10 @@ module {
  
 // CHECK-LABEL:   func @transpose_same_compression(
 // CHECK-SAME:                                     %[[VAL_0:.*]]: tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:           %[[VAL_1:.*]] = constant 0 : index
-// CHECK:           %[[VAL_2:.*]] = constant 1 : index
-// CHECK:           %[[VAL_3:.*]] = constant 0 : i64
-// CHECK:           %[[VAL_4:.*]] = constant 1 : i64
+// CHECK:           %[[VAL_1:.*]] = arith.constant 0 : index
+// CHECK:           %[[VAL_2:.*]] = arith.constant 1 : index
+// CHECK:           %[[VAL_3:.*]] = arith.constant 0 : i64
+// CHECK:           %[[VAL_4:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_5:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_6:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_2]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_7:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
@@ -49,7 +49,7 @@ module {
 // CHECK:           %[[VAL_10:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_11:.*]] = tensor.dim %[[VAL_0]], %[[VAL_1]] : tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_12:.*]] = memref.load %[[VAL_10]]{{\[}}%[[VAL_11]]] : memref<?xi64>
-// CHECK:           %[[VAL_13:.*]] = index_cast %[[VAL_12]] : i64 to index
+// CHECK:           %[[VAL_13:.*]] = arith.index_cast %[[VAL_12]] : i64 to index
 // CHECK:           %[[VAL_14:.*]] = call @matrix_csr_i64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_15:.*]] = call @empty_like(%[[VAL_14]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_16:.*]] = call @ptr8_to_matrix_csr_i64_p64i64(%[[VAL_15]]) : (!llvm.ptr<i8>) -> tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -61,7 +61,7 @@ module {
 // CHECK:           call @resize_dim(%[[VAL_19]], %[[VAL_1]], %[[VAL_9]]) : (!llvm.ptr<i8>, index, index) -> ()
 // CHECK:           %[[VAL_20:.*]] = call @matrix_csr_i64_p64i64_to_ptr8(%[[VAL_16]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           call @resize_dim(%[[VAL_20]], %[[VAL_2]], %[[VAL_8]]) : (!llvm.ptr<i8>, index, index) -> ()
-// CHECK:           %[[VAL_21:.*]] = addi %[[VAL_9]], %[[VAL_2]] : index
+// CHECK:           %[[VAL_21:.*]] = arith.addi %[[VAL_9]], %[[VAL_2]] : index
 // CHECK:           %[[VAL_22:.*]] = call @matrix_csr_i64_p64i64_to_ptr8(%[[VAL_16]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           call @resize_pointers(%[[VAL_22]], %[[VAL_2]], %[[VAL_21]]) : (!llvm.ptr<i8>, index, index) -> ()
 // CHECK:           %[[VAL_23:.*]] = call @matrix_csr_i64_p64i64_to_ptr8(%[[VAL_16]]) : (tensor<?x?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
@@ -78,9 +78,9 @@ module {
 // CHECK:           }
 // CHECK:           scf.for %[[VAL_31:.*]] = %[[VAL_1]] to %[[VAL_13]] step %[[VAL_2]] {
 // CHECK:             %[[VAL_32:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_31]]] : memref<?xi64>
-// CHECK:             %[[VAL_33:.*]] = index_cast %[[VAL_32]] : i64 to index
+// CHECK:             %[[VAL_33:.*]] = arith.index_cast %[[VAL_32]] : i64 to index
 // CHECK:             %[[VAL_34:.*]] = memref.load %[[VAL_27]]{{\[}}%[[VAL_33]]] : memref<?xi64>
-// CHECK:             %[[VAL_35:.*]] = addi %[[VAL_34]], %[[VAL_4]] : i64
+// CHECK:             %[[VAL_35:.*]] = arith.addi %[[VAL_34]], %[[VAL_4]] : i64
 // CHECK:             memref.store %[[VAL_35]], %[[VAL_27]]{{\[}}%[[VAL_33]]] : memref<?xi64>
 // CHECK:           }
 // CHECK:           memref.store %[[VAL_3]], %[[VAL_27]]{{\[}}%[[VAL_9]]] : memref<?xi64>
@@ -88,26 +88,26 @@ module {
 // CHECK:             %[[VAL_37:.*]] = memref.load %[[VAL_27]]{{\[}}%[[VAL_36]]] : memref<?xi64>
 // CHECK:             %[[VAL_38:.*]] = memref.load %[[VAL_27]]{{\[}}%[[VAL_9]]] : memref<?xi64>
 // CHECK:             memref.store %[[VAL_38]], %[[VAL_27]]{{\[}}%[[VAL_36]]] : memref<?xi64>
-// CHECK:             %[[VAL_39:.*]] = addi %[[VAL_38]], %[[VAL_37]] : i64
+// CHECK:             %[[VAL_39:.*]] = arith.addi %[[VAL_38]], %[[VAL_37]] : i64
 // CHECK:             memref.store %[[VAL_39]], %[[VAL_27]]{{\[}}%[[VAL_9]]] : memref<?xi64>
 // CHECK:           }
 // CHECK:           scf.for %[[VAL_40:.*]] = %[[VAL_1]] to %[[VAL_8]] step %[[VAL_2]] {
-// CHECK:             %[[VAL_41:.*]] = index_cast %[[VAL_40]] : index to i64
+// CHECK:             %[[VAL_41:.*]] = arith.index_cast %[[VAL_40]] : index to i64
 // CHECK:             %[[VAL_42:.*]] = memref.load %[[VAL_5]]{{\[}}%[[VAL_40]]] : memref<?xi64>
-// CHECK:             %[[VAL_43:.*]] = index_cast %[[VAL_42]] : i64 to index
-// CHECK:             %[[VAL_44:.*]] = addi %[[VAL_40]], %[[VAL_2]] : index
+// CHECK:             %[[VAL_43:.*]] = arith.index_cast %[[VAL_42]] : i64 to index
+// CHECK:             %[[VAL_44:.*]] = arith.addi %[[VAL_40]], %[[VAL_2]] : index
 // CHECK:             %[[VAL_45:.*]] = memref.load %[[VAL_5]]{{\[}}%[[VAL_44]]] : memref<?xi64>
-// CHECK:             %[[VAL_46:.*]] = index_cast %[[VAL_45]] : i64 to index
+// CHECK:             %[[VAL_46:.*]] = arith.index_cast %[[VAL_45]] : i64 to index
 // CHECK:             scf.for %[[VAL_47:.*]] = %[[VAL_43]] to %[[VAL_46]] step %[[VAL_2]] {
 // CHECK:               %[[VAL_48:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_47]]] : memref<?xi64>
-// CHECK:               %[[VAL_49:.*]] = index_cast %[[VAL_48]] : i64 to index
+// CHECK:               %[[VAL_49:.*]] = arith.index_cast %[[VAL_48]] : i64 to index
 // CHECK:               %[[VAL_50:.*]] = memref.load %[[VAL_27]]{{\[}}%[[VAL_49]]] : memref<?xi64>
-// CHECK:               %[[VAL_51:.*]] = index_cast %[[VAL_50]] : i64 to index
+// CHECK:               %[[VAL_51:.*]] = arith.index_cast %[[VAL_50]] : i64 to index
 // CHECK:               memref.store %[[VAL_41]], %[[VAL_28]]{{\[}}%[[VAL_51]]] : memref<?xi64>
 // CHECK:               %[[VAL_52:.*]] = memref.load %[[VAL_7]]{{\[}}%[[VAL_47]]] : memref<?xi64>
 // CHECK:               memref.store %[[VAL_52]], %[[VAL_29]]{{\[}}%[[VAL_51]]] : memref<?xi64>
 // CHECK:               %[[VAL_53:.*]] = memref.load %[[VAL_27]]{{\[}}%[[VAL_49]]] : memref<?xi64>
-// CHECK:               %[[VAL_54:.*]] = addi %[[VAL_53]], %[[VAL_4]] : i64
+// CHECK:               %[[VAL_54:.*]] = arith.addi %[[VAL_53]], %[[VAL_4]] : i64
 // CHECK:               memref.store %[[VAL_54]], %[[VAL_27]]{{\[}}%[[VAL_49]]] : memref<?xi64>
 // CHECK:             }
 // CHECK:           }

--- a/mlir_graphblas/src/test/GraphBLAS/lower_union.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_union.mlir
@@ -17,51 +17,51 @@
 // CHECK-LABEL:   func @vector_union(
 // CHECK-SAME:                       %[[VAL_0:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                       %[[VAL_1:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK-DAG:       %[[VAL_2:.*]] = constant 0 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_4:.*]] = constant 0 : i64
-// CHECK-DAG:       %[[VAL_5:.*]] = constant false
-// CHECK-DAG:       %[[VAL_6:.*]] = constant true
-// CHECK-DAG:       %[[VAL_7:.*]] = constant 0.000000e+00 : f64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : i64
+// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant false
+// CHECK-DAG:       %[[VAL_6:.*]] = arith.constant true
+// CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK:           %[[VAL_8:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_9:.*]] = call @empty_like(%[[VAL_8]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_10:.*]] = call @ptr8_to_vector_f64_p64i64(%[[VAL_9]]) : (!llvm.ptr<i8>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_11:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_12:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_3]]] : memref<?xi64>
-// CHECK:           %[[VAL_13:.*]] = index_cast %[[VAL_12]] : i64 to index
+// CHECK:           %[[VAL_13:.*]] = arith.index_cast %[[VAL_12]] : i64 to index
 // CHECK:           %[[VAL_14:.*]] = sparse_tensor.pointers %[[VAL_1]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_15:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_3]]] : memref<?xi64>
-// CHECK:           %[[VAL_16:.*]] = index_cast %[[VAL_15]] : i64 to index
+// CHECK:           %[[VAL_16:.*]] = arith.index_cast %[[VAL_15]] : i64 to index
 // CHECK:           %[[VAL_17:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_18:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           %[[VAL_19:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_20:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           %[[VAL_21:.*]]:7 = scf.while (%[[VAL_22:.*]] = %[[VAL_2]], %[[VAL_23:.*]] = %[[VAL_2]], %[[VAL_24:.*]] = %[[VAL_2]], %[[VAL_25:.*]] = %[[VAL_2]], %[[VAL_26:.*]] = %[[VAL_6]], %[[VAL_27:.*]] = %[[VAL_6]], %[[VAL_28:.*]] = %[[VAL_2]]) : (index, index, index, index, i1, i1, index) -> (index, index, index, index, i1, i1, index) {
-// CHECK:             %[[VAL_29:.*]] = cmpi ult, %[[VAL_22]], %[[VAL_13]] : index
-// CHECK:             %[[VAL_30:.*]] = cmpi ult, %[[VAL_23]], %[[VAL_16]] : index
-// CHECK:             %[[VAL_31:.*]] = and %[[VAL_29]], %[[VAL_30]] : i1
+// CHECK:             %[[VAL_29:.*]] = arith.cmpi ult, %[[VAL_22]], %[[VAL_13]] : index
+// CHECK:             %[[VAL_30:.*]] = arith.cmpi ult, %[[VAL_23]], %[[VAL_16]] : index
+// CHECK:             %[[VAL_31:.*]] = arith.andi %[[VAL_29]], %[[VAL_30]] : i1
 // CHECK:             scf.condition(%[[VAL_31]]) %[[VAL_22]], %[[VAL_23]], %[[VAL_24]], %[[VAL_25]], %[[VAL_26]], %[[VAL_27]], %[[VAL_28]] : index, index, index, index, i1, i1, index
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_32:.*]]: index, %[[VAL_33:.*]]: index, %[[VAL_34:.*]]: index, %[[VAL_35:.*]]: index, %[[VAL_36:.*]]: i1, %[[VAL_37:.*]]: i1, %[[VAL_38:.*]]: index):
 // CHECK:             %[[VAL_39:.*]] = scf.if %[[VAL_36]] -> (index) {
 // CHECK:               %[[VAL_40:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_32]]] : memref<?xi64>
-// CHECK:               %[[VAL_41:.*]] = index_cast %[[VAL_40]] : i64 to index
+// CHECK:               %[[VAL_41:.*]] = arith.index_cast %[[VAL_40]] : i64 to index
 // CHECK:               scf.yield %[[VAL_41]] : index
 // CHECK:             } else {
 // CHECK:               scf.yield %[[VAL_34]] : index
 // CHECK:             }
 // CHECK:             %[[VAL_42:.*]] = scf.if %[[VAL_37]] -> (index) {
 // CHECK:               %[[VAL_43:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_33]]] : memref<?xi64>
-// CHECK:               %[[VAL_44:.*]] = index_cast %[[VAL_43]] : i64 to index
+// CHECK:               %[[VAL_44:.*]] = arith.index_cast %[[VAL_43]] : i64 to index
 // CHECK:               scf.yield %[[VAL_44]] : index
 // CHECK:             } else {
 // CHECK:               scf.yield %[[VAL_35]] : index
 // CHECK:             }
-// CHECK:             %[[VAL_45:.*]] = cmpi ult, %[[VAL_46:.*]], %[[VAL_47:.*]] : index
-// CHECK:             %[[VAL_48:.*]] = cmpi ugt, %[[VAL_46]], %[[VAL_47]] : index
-// CHECK:             %[[VAL_49:.*]] = addi %[[VAL_32]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_50:.*]] = addi %[[VAL_33]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_51:.*]] = addi %[[VAL_38]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_45:.*]] = arith.cmpi ult, %[[VAL_46:.*]], %[[VAL_47:.*]] : index
+// CHECK:             %[[VAL_48:.*]] = arith.cmpi ugt, %[[VAL_46]], %[[VAL_47]] : index
+// CHECK:             %[[VAL_49:.*]] = arith.addi %[[VAL_32]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_50:.*]] = arith.addi %[[VAL_33]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_51:.*]] = arith.addi %[[VAL_38]], %[[VAL_3]] : index
 // CHECK:             %[[VAL_52:.*]]:5 = scf.if %[[VAL_45]] -> (index, index, i1, i1, index) {
 // CHECK:               scf.yield %[[VAL_49]], %[[VAL_33]], %[[VAL_6]], %[[VAL_5]], %[[VAL_51]] : index, index, i1, i1, index
 // CHECK:             } else {
@@ -74,23 +74,23 @@
 // CHECK:             }
 // CHECK:             scf.yield %[[VAL_55:.*]]#0, %[[VAL_55]]#1, %[[VAL_46]], %[[VAL_47]], %[[VAL_55]]#2, %[[VAL_55]]#3, %[[VAL_55]]#4 : index, index, index, index, i1, i1, index
 // CHECK:           }
-// CHECK:           %[[VAL_56:.*]] = cmpi ult, %[[VAL_57:.*]]#0, %[[VAL_13]] : index
+// CHECK:           %[[VAL_56:.*]] = arith.cmpi ult, %[[VAL_57:.*]]#0, %[[VAL_13]] : index
 // CHECK:           %[[VAL_58:.*]] = scf.if %[[VAL_56]] -> (index) {
-// CHECK:             %[[VAL_59:.*]] = subi %[[VAL_13]], %[[VAL_57]]#0 : index
-// CHECK:             %[[VAL_60:.*]] = addi %[[VAL_57]]#6, %[[VAL_59]] : index
+// CHECK:             %[[VAL_59:.*]] = arith.subi %[[VAL_13]], %[[VAL_57]]#0 : index
+// CHECK:             %[[VAL_60:.*]] = arith.addi %[[VAL_57]]#6, %[[VAL_59]] : index
 // CHECK:             scf.yield %[[VAL_60]] : index
 // CHECK:           } else {
-// CHECK:             %[[VAL_61:.*]] = cmpi ult, %[[VAL_57]]#1, %[[VAL_16]] : index
+// CHECK:             %[[VAL_61:.*]] = arith.cmpi ult, %[[VAL_57]]#1, %[[VAL_16]] : index
 // CHECK:             %[[VAL_62:.*]] = scf.if %[[VAL_61]] -> (index) {
-// CHECK:               %[[VAL_63:.*]] = subi %[[VAL_16]], %[[VAL_57]]#1 : index
-// CHECK:               %[[VAL_64:.*]] = addi %[[VAL_57]]#6, %[[VAL_63]] : index
+// CHECK:               %[[VAL_63:.*]] = arith.subi %[[VAL_16]], %[[VAL_57]]#1 : index
+// CHECK:               %[[VAL_64:.*]] = arith.addi %[[VAL_57]]#6, %[[VAL_63]] : index
 // CHECK:               scf.yield %[[VAL_64]] : index
 // CHECK:             } else {
 // CHECK:               scf.yield %[[VAL_57]]#6 : index
 // CHECK:             }
 // CHECK:             scf.yield %[[VAL_65:.*]] : index
 // CHECK:           }
-// CHECK:           %[[VAL_66:.*]] = index_cast %[[VAL_67:.*]] : index to i64
+// CHECK:           %[[VAL_66:.*]] = arith.index_cast %[[VAL_67:.*]] : index to i64
 // CHECK:           %[[VAL_68:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_10]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           call @resize_index(%[[VAL_68]], %[[VAL_2]], %[[VAL_67]]) : (!llvm.ptr<i8>, index, index) -> ()
 // CHECK:           %[[VAL_69:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_10]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
@@ -100,9 +100,9 @@
 // CHECK:           %[[VAL_71:.*]] = sparse_tensor.indices %[[VAL_10]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_72:.*]] = sparse_tensor.values %[[VAL_10]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           %[[VAL_73:.*]]:9 = scf.while (%[[VAL_74:.*]] = %[[VAL_2]], %[[VAL_75:.*]] = %[[VAL_2]], %[[VAL_76:.*]] = %[[VAL_2]], %[[VAL_77:.*]] = %[[VAL_4]], %[[VAL_78:.*]] = %[[VAL_4]], %[[VAL_79:.*]] = %[[VAL_7]], %[[VAL_80:.*]] = %[[VAL_7]], %[[VAL_81:.*]] = %[[VAL_6]], %[[VAL_82:.*]] = %[[VAL_6]]) : (index, index, index, i64, i64, f64, f64, i1, i1) -> (index, index, index, i64, i64, f64, f64, i1, i1) {
-// CHECK:             %[[VAL_83:.*]] = cmpi ult, %[[VAL_74]], %[[VAL_13]] : index
-// CHECK:             %[[VAL_84:.*]] = cmpi ult, %[[VAL_75]], %[[VAL_16]] : index
-// CHECK:             %[[VAL_85:.*]] = and %[[VAL_83]], %[[VAL_84]] : i1
+// CHECK:             %[[VAL_83:.*]] = arith.cmpi ult, %[[VAL_74]], %[[VAL_13]] : index
+// CHECK:             %[[VAL_84:.*]] = arith.cmpi ult, %[[VAL_75]], %[[VAL_16]] : index
+// CHECK:             %[[VAL_85:.*]] = arith.andi %[[VAL_83]], %[[VAL_84]] : i1
 // CHECK:             scf.condition(%[[VAL_85]]) %[[VAL_74]], %[[VAL_75]], %[[VAL_76]], %[[VAL_77]], %[[VAL_78]], %[[VAL_79]], %[[VAL_80]], %[[VAL_81]], %[[VAL_82]] : index, index, index, i64, i64, f64, f64, i1, i1
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_86:.*]]: index, %[[VAL_87:.*]]: index, %[[VAL_88:.*]]: index, %[[VAL_89:.*]]: i64, %[[VAL_90:.*]]: i64, %[[VAL_91:.*]]: f64, %[[VAL_92:.*]]: f64, %[[VAL_93:.*]]: i1, %[[VAL_94:.*]]: i1):
@@ -120,11 +120,11 @@
 // CHECK:             } else {
 // CHECK:               scf.yield %[[VAL_90]], %[[VAL_92]] : i64, f64
 // CHECK:             }
-// CHECK:             %[[VAL_101:.*]] = cmpi ult, %[[VAL_102:.*]]#0, %[[VAL_103:.*]]#0 : i64
-// CHECK:             %[[VAL_104:.*]] = cmpi ugt, %[[VAL_102]]#0, %[[VAL_103]]#0 : i64
-// CHECK:             %[[VAL_105:.*]] = addi %[[VAL_86]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_106:.*]] = addi %[[VAL_87]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_107:.*]] = addi %[[VAL_88]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_101:.*]] = arith.cmpi ult, %[[VAL_102:.*]]#0, %[[VAL_103:.*]]#0 : i64
+// CHECK:             %[[VAL_104:.*]] = arith.cmpi ugt, %[[VAL_102]]#0, %[[VAL_103]]#0 : i64
+// CHECK:             %[[VAL_105:.*]] = arith.addi %[[VAL_86]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_106:.*]] = arith.addi %[[VAL_87]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_107:.*]] = arith.addi %[[VAL_88]], %[[VAL_3]] : index
 // CHECK:             %[[VAL_108:.*]]:5 = scf.if %[[VAL_101]] -> (index, index, index, i1, i1) {
 // CHECK:               memref.store %[[VAL_102]]#0, %[[VAL_71]]{{\[}}%[[VAL_88]]] : memref<?xi64>
 // CHECK:               memref.store %[[VAL_102]]#1, %[[VAL_72]]{{\[}}%[[VAL_88]]] : memref<?xf64>
@@ -136,7 +136,7 @@
 // CHECK:                 scf.yield %[[VAL_86]], %[[VAL_106]], %[[VAL_107]], %[[VAL_5]], %[[VAL_6]] : index, index, index, i1, i1
 // CHECK:               } else {
 // CHECK:                 memref.store %[[VAL_102]]#0, %[[VAL_71]]{{\[}}%[[VAL_88]]] : memref<?xi64>
-// CHECK:                 %[[VAL_110:.*]] = addf %[[VAL_102]]#1, %[[VAL_103]]#1 : f64
+// CHECK:                 %[[VAL_110:.*]] = arith.addf %[[VAL_102]]#1, %[[VAL_103]]#1 : f64
 // CHECK:                 memref.store %[[VAL_110]], %[[VAL_72]]{{\[}}%[[VAL_88]]] : memref<?xf64>
 // CHECK:                 scf.yield %[[VAL_105]], %[[VAL_106]], %[[VAL_107]], %[[VAL_6]], %[[VAL_6]] : index, index, index, i1, i1
 // CHECK:               }
@@ -144,26 +144,26 @@
 // CHECK:             }
 // CHECK:             scf.yield %[[VAL_112:.*]]#0, %[[VAL_112]]#1, %[[VAL_112]]#2, %[[VAL_102]]#0, %[[VAL_103]]#0, %[[VAL_102]]#1, %[[VAL_103]]#1, %[[VAL_112]]#3, %[[VAL_112]]#4 : index, index, index, i64, i64, f64, f64, i1, i1
 // CHECK:           }
-// CHECK:           %[[VAL_113:.*]] = cmpi ult, %[[VAL_114:.*]]#0, %[[VAL_13]] : index
+// CHECK:           %[[VAL_113:.*]] = arith.cmpi ult, %[[VAL_114:.*]]#0, %[[VAL_13]] : index
 // CHECK:           %[[VAL_115:.*]] = scf.if %[[VAL_113]] -> (index) {
 // CHECK:             %[[VAL_116:.*]] = scf.for %[[VAL_117:.*]] = %[[VAL_114]]#0 to %[[VAL_13]] step %[[VAL_3]] iter_args(%[[VAL_118:.*]] = %[[VAL_114]]#2) -> (index) {
 // CHECK:               %[[VAL_119:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_117]]] : memref<?xi64>
 // CHECK:               %[[VAL_120:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_117]]] : memref<?xf64>
 // CHECK:               memref.store %[[VAL_119]], %[[VAL_71]]{{\[}}%[[VAL_118]]] : memref<?xi64>
 // CHECK:               memref.store %[[VAL_120]], %[[VAL_72]]{{\[}}%[[VAL_118]]] : memref<?xf64>
-// CHECK:               %[[VAL_121:.*]] = addi %[[VAL_118]], %[[VAL_3]] : index
+// CHECK:               %[[VAL_121:.*]] = arith.addi %[[VAL_118]], %[[VAL_3]] : index
 // CHECK:               scf.yield %[[VAL_121]] : index
 // CHECK:             }
 // CHECK:             scf.yield %[[VAL_122:.*]] : index
 // CHECK:           } else {
-// CHECK:             %[[VAL_123:.*]] = cmpi ult, %[[VAL_114]]#1, %[[VAL_16]] : index
+// CHECK:             %[[VAL_123:.*]] = arith.cmpi ult, %[[VAL_114]]#1, %[[VAL_16]] : index
 // CHECK:             %[[VAL_124:.*]] = scf.if %[[VAL_123]] -> (index) {
 // CHECK:               %[[VAL_125:.*]] = scf.for %[[VAL_126:.*]] = %[[VAL_114]]#1 to %[[VAL_16]] step %[[VAL_3]] iter_args(%[[VAL_127:.*]] = %[[VAL_114]]#2) -> (index) {
 // CHECK:                 %[[VAL_128:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_126]]] : memref<?xi64>
 // CHECK:                 %[[VAL_129:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_126]]] : memref<?xf64>
 // CHECK:                 memref.store %[[VAL_128]], %[[VAL_71]]{{\[}}%[[VAL_127]]] : memref<?xi64>
 // CHECK:                 memref.store %[[VAL_129]], %[[VAL_72]]{{\[}}%[[VAL_127]]] : memref<?xf64>
-// CHECK:                 %[[VAL_130:.*]] = addi %[[VAL_127]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_130:.*]] = arith.addi %[[VAL_127]], %[[VAL_3]] : index
 // CHECK:                 scf.yield %[[VAL_130]] : index
 // CHECK:               }
 // CHECK:               scf.yield %[[VAL_131:.*]] : index
@@ -184,12 +184,12 @@ func @vector_union(%a: tensor<?xf64, #CV64>, %b: tensor<?xf64, #CV64>) -> tensor
 // CHECK-LABEL:   func @matrix_union(
 // CHECK-SAME:                       %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                       %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK-DAG:       %[[VAL_2:.*]] = constant 0 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_4:.*]] = constant 0 : i64
-// CHECK-DAG:       %[[VAL_5:.*]] = constant false
-// CHECK-DAG:       %[[VAL_6:.*]] = constant true
-// CHECK-DAG:       %[[VAL_7:.*]] = constant 0.000000e+00 : f64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : i64
+// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant false
+// CHECK-DAG:       %[[VAL_6:.*]] = arith.constant true
+// CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK:           %[[VAL_8:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_9:.*]] = call @empty_like(%[[VAL_8]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_10:.*]] = call @ptr8_to_matrix_csr_f64_p64i64(%[[VAL_9]]) : (!llvm.ptr<i8>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -202,47 +202,47 @@ func @vector_union(%a: tensor<?xf64, #CV64>, %b: tensor<?xf64, #CV64>) -> tensor
 // CHECK:           %[[VAL_17:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           %[[VAL_18:.*]] = sparse_tensor.pointers %[[VAL_10]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           scf.parallel (%[[VAL_19:.*]]) = (%[[VAL_2]]) to (%[[VAL_11]]) step (%[[VAL_3]]) {
-// CHECK:             %[[VAL_20:.*]] = addi %[[VAL_19]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_20:.*]] = arith.addi %[[VAL_19]], %[[VAL_3]] : index
 // CHECK:             %[[VAL_21:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_19]]] : memref<?xi64>
 // CHECK:             %[[VAL_22:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_20]]] : memref<?xi64>
 // CHECK:             %[[VAL_23:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_19]]] : memref<?xi64>
 // CHECK:             %[[VAL_24:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_20]]] : memref<?xi64>
-// CHECK:             %[[VAL_25:.*]] = cmpi eq, %[[VAL_21]], %[[VAL_22]] : i64
-// CHECK:             %[[VAL_26:.*]] = cmpi eq, %[[VAL_23]], %[[VAL_24]] : i64
-// CHECK:             %[[VAL_27:.*]] = and %[[VAL_25]], %[[VAL_26]] : i1
+// CHECK:             %[[VAL_25:.*]] = arith.cmpi eq, %[[VAL_21]], %[[VAL_22]] : i64
+// CHECK:             %[[VAL_26:.*]] = arith.cmpi eq, %[[VAL_23]], %[[VAL_24]] : i64
+// CHECK:             %[[VAL_27:.*]] = arith.andi %[[VAL_25]], %[[VAL_26]] : i1
 // CHECK:             %[[VAL_28:.*]] = scf.if %[[VAL_27]] -> (i64) {
 // CHECK:               scf.yield %[[VAL_4]] : i64
 // CHECK:             } else {
-// CHECK:               %[[VAL_29:.*]] = index_cast %[[VAL_21]] : i64 to index
-// CHECK:               %[[VAL_30:.*]] = index_cast %[[VAL_22]] : i64 to index
-// CHECK:               %[[VAL_31:.*]] = index_cast %[[VAL_23]] : i64 to index
-// CHECK:               %[[VAL_32:.*]] = index_cast %[[VAL_24]] : i64 to index
+// CHECK:               %[[VAL_29:.*]] = arith.index_cast %[[VAL_21]] : i64 to index
+// CHECK:               %[[VAL_30:.*]] = arith.index_cast %[[VAL_22]] : i64 to index
+// CHECK:               %[[VAL_31:.*]] = arith.index_cast %[[VAL_23]] : i64 to index
+// CHECK:               %[[VAL_32:.*]] = arith.index_cast %[[VAL_24]] : i64 to index
 // CHECK:               %[[VAL_33:.*]]:7 = scf.while (%[[VAL_34:.*]] = %[[VAL_29]], %[[VAL_35:.*]] = %[[VAL_31]], %[[VAL_36:.*]] = %[[VAL_2]], %[[VAL_37:.*]] = %[[VAL_2]], %[[VAL_38:.*]] = %[[VAL_6]], %[[VAL_39:.*]] = %[[VAL_6]], %[[VAL_40:.*]] = %[[VAL_2]]) : (index, index, index, index, i1, i1, index) -> (index, index, index, index, i1, i1, index) {
-// CHECK:                 %[[VAL_41:.*]] = cmpi ult, %[[VAL_34]], %[[VAL_30]] : index
-// CHECK:                 %[[VAL_42:.*]] = cmpi ult, %[[VAL_35]], %[[VAL_32]] : index
-// CHECK:                 %[[VAL_43:.*]] = and %[[VAL_41]], %[[VAL_42]] : i1
+// CHECK:                 %[[VAL_41:.*]] = arith.cmpi ult, %[[VAL_34]], %[[VAL_30]] : index
+// CHECK:                 %[[VAL_42:.*]] = arith.cmpi ult, %[[VAL_35]], %[[VAL_32]] : index
+// CHECK:                 %[[VAL_43:.*]] = arith.andi %[[VAL_41]], %[[VAL_42]] : i1
 // CHECK:                 scf.condition(%[[VAL_43]]) %[[VAL_34]], %[[VAL_35]], %[[VAL_36]], %[[VAL_37]], %[[VAL_38]], %[[VAL_39]], %[[VAL_40]] : index, index, index, index, i1, i1, index
 // CHECK:               } do {
 // CHECK:               ^bb0(%[[VAL_44:.*]]: index, %[[VAL_45:.*]]: index, %[[VAL_46:.*]]: index, %[[VAL_47:.*]]: index, %[[VAL_48:.*]]: i1, %[[VAL_49:.*]]: i1, %[[VAL_50:.*]]: index):
 // CHECK:                 %[[VAL_51:.*]] = scf.if %[[VAL_48]] -> (index) {
 // CHECK:                   %[[VAL_52:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_44]]] : memref<?xi64>
-// CHECK:                   %[[VAL_53:.*]] = index_cast %[[VAL_52]] : i64 to index
+// CHECK:                   %[[VAL_53:.*]] = arith.index_cast %[[VAL_52]] : i64 to index
 // CHECK:                   scf.yield %[[VAL_53]] : index
 // CHECK:                 } else {
 // CHECK:                   scf.yield %[[VAL_46]] : index
 // CHECK:                 }
 // CHECK:                 %[[VAL_54:.*]] = scf.if %[[VAL_49]] -> (index) {
 // CHECK:                   %[[VAL_55:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_45]]] : memref<?xi64>
-// CHECK:                   %[[VAL_56:.*]] = index_cast %[[VAL_55]] : i64 to index
+// CHECK:                   %[[VAL_56:.*]] = arith.index_cast %[[VAL_55]] : i64 to index
 // CHECK:                   scf.yield %[[VAL_56]] : index
 // CHECK:                 } else {
 // CHECK:                   scf.yield %[[VAL_47]] : index
 // CHECK:                 }
-// CHECK:                 %[[VAL_57:.*]] = cmpi ult, %[[VAL_58:.*]], %[[VAL_59:.*]] : index
-// CHECK:                 %[[VAL_60:.*]] = cmpi ugt, %[[VAL_58]], %[[VAL_59]] : index
-// CHECK:                 %[[VAL_61:.*]] = addi %[[VAL_44]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_62:.*]] = addi %[[VAL_45]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_63:.*]] = addi %[[VAL_50]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_57:.*]] = arith.cmpi ult, %[[VAL_58:.*]], %[[VAL_59:.*]] : index
+// CHECK:                 %[[VAL_60:.*]] = arith.cmpi ugt, %[[VAL_58]], %[[VAL_59]] : index
+// CHECK:                 %[[VAL_61:.*]] = arith.addi %[[VAL_44]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_62:.*]] = arith.addi %[[VAL_45]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_63:.*]] = arith.addi %[[VAL_50]], %[[VAL_3]] : index
 // CHECK:                 %[[VAL_64:.*]]:5 = scf.if %[[VAL_57]] -> (index, index, i1, i1, index) {
 // CHECK:                   scf.yield %[[VAL_61]], %[[VAL_45]], %[[VAL_6]], %[[VAL_5]], %[[VAL_63]] : index, index, i1, i1, index
 // CHECK:                 } else {
@@ -255,23 +255,23 @@ func @vector_union(%a: tensor<?xf64, #CV64>, %b: tensor<?xf64, #CV64>) -> tensor
 // CHECK:                 }
 // CHECK:                 scf.yield %[[VAL_67:.*]]#0, %[[VAL_67]]#1, %[[VAL_58]], %[[VAL_59]], %[[VAL_67]]#2, %[[VAL_67]]#3, %[[VAL_67]]#4 : index, index, index, index, i1, i1, index
 // CHECK:               }
-// CHECK:               %[[VAL_68:.*]] = cmpi ult, %[[VAL_69:.*]]#0, %[[VAL_30]] : index
+// CHECK:               %[[VAL_68:.*]] = arith.cmpi ult, %[[VAL_69:.*]]#0, %[[VAL_30]] : index
 // CHECK:               %[[VAL_70:.*]] = scf.if %[[VAL_68]] -> (index) {
-// CHECK:                 %[[VAL_71:.*]] = subi %[[VAL_30]], %[[VAL_69]]#0 : index
-// CHECK:                 %[[VAL_72:.*]] = addi %[[VAL_69]]#6, %[[VAL_71]] : index
+// CHECK:                 %[[VAL_71:.*]] = arith.subi %[[VAL_30]], %[[VAL_69]]#0 : index
+// CHECK:                 %[[VAL_72:.*]] = arith.addi %[[VAL_69]]#6, %[[VAL_71]] : index
 // CHECK:                 scf.yield %[[VAL_72]] : index
 // CHECK:               } else {
-// CHECK:                 %[[VAL_73:.*]] = cmpi ult, %[[VAL_69]]#1, %[[VAL_32]] : index
+// CHECK:                 %[[VAL_73:.*]] = arith.cmpi ult, %[[VAL_69]]#1, %[[VAL_32]] : index
 // CHECK:                 %[[VAL_74:.*]] = scf.if %[[VAL_73]] -> (index) {
-// CHECK:                   %[[VAL_75:.*]] = subi %[[VAL_32]], %[[VAL_69]]#1 : index
-// CHECK:                   %[[VAL_76:.*]] = addi %[[VAL_69]]#6, %[[VAL_75]] : index
+// CHECK:                   %[[VAL_75:.*]] = arith.subi %[[VAL_32]], %[[VAL_69]]#1 : index
+// CHECK:                   %[[VAL_76:.*]] = arith.addi %[[VAL_69]]#6, %[[VAL_75]] : index
 // CHECK:                   scf.yield %[[VAL_76]] : index
 // CHECK:                 } else {
 // CHECK:                   scf.yield %[[VAL_69]]#6 : index
 // CHECK:                 }
 // CHECK:                 scf.yield %[[VAL_77:.*]] : index
 // CHECK:               }
-// CHECK:               %[[VAL_78:.*]] = index_cast %[[VAL_79:.*]] : index to i64
+// CHECK:               %[[VAL_78:.*]] = arith.index_cast %[[VAL_79:.*]] : index to i64
 // CHECK:               scf.yield %[[VAL_78]] : i64
 // CHECK:             }
 // CHECK:             memref.store %[[VAL_80:.*]], %[[VAL_18]]{{\[}}%[[VAL_19]]] : memref<?xi64>
@@ -282,13 +282,13 @@ func @vector_union(%a: tensor<?xf64, #CV64>, %b: tensor<?xf64, #CV64>) -> tensor
 // CHECK:             %[[VAL_82:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_81]]] : memref<?xi64>
 // CHECK:             %[[VAL_83:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_11]]] : memref<?xi64>
 // CHECK:             memref.store %[[VAL_83]], %[[VAL_18]]{{\[}}%[[VAL_81]]] : memref<?xi64>
-// CHECK:             %[[VAL_84:.*]] = addi %[[VAL_83]], %[[VAL_82]] : i64
+// CHECK:             %[[VAL_84:.*]] = arith.addi %[[VAL_83]], %[[VAL_82]] : i64
 // CHECK:             memref.store %[[VAL_84]], %[[VAL_18]]{{\[}}%[[VAL_11]]] : memref<?xi64>
 // CHECK:           }
 // CHECK:           %[[VAL_85:.*]] = sparse_tensor.pointers %[[VAL_10]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_86:.*]] = tensor.dim %[[VAL_10]], %[[VAL_2]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_87:.*]] = memref.load %[[VAL_85]]{{\[}}%[[VAL_86]]] : memref<?xi64>
-// CHECK:           %[[VAL_88:.*]] = index_cast %[[VAL_87]] : i64 to index
+// CHECK:           %[[VAL_88:.*]] = arith.index_cast %[[VAL_87]] : i64 to index
 // CHECK:           %[[VAL_89:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_10]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           call @resize_index(%[[VAL_89]], %[[VAL_3]], %[[VAL_88]]) : (!llvm.ptr<i8>, index, index) -> ()
 // CHECK:           %[[VAL_90:.*]] = call @matrix_csr_f64_p64i64_to_ptr8(%[[VAL_10]]) : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
@@ -296,25 +296,25 @@ func @vector_union(%a: tensor<?xf64, #CV64>, %b: tensor<?xf64, #CV64>) -> tensor
 // CHECK:           %[[VAL_91:.*]] = sparse_tensor.indices %[[VAL_10]], %[[VAL_3]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_92:.*]] = sparse_tensor.values %[[VAL_10]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           scf.parallel (%[[VAL_93:.*]]) = (%[[VAL_2]]) to (%[[VAL_11]]) step (%[[VAL_3]]) {
-// CHECK:             %[[VAL_94:.*]] = addi %[[VAL_93]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_94:.*]] = arith.addi %[[VAL_93]], %[[VAL_3]] : index
 // CHECK:             %[[VAL_95:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_93]]] : memref<?xi64>
 // CHECK:             %[[VAL_96:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_94]]] : memref<?xi64>
-// CHECK:             %[[VAL_97:.*]] = cmpi ne, %[[VAL_95]], %[[VAL_96]] : i64
+// CHECK:             %[[VAL_97:.*]] = arith.cmpi ne, %[[VAL_95]], %[[VAL_96]] : i64
 // CHECK:             scf.if %[[VAL_97]] {
 // CHECK:               %[[VAL_98:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_93]]] : memref<?xi64>
-// CHECK:               %[[VAL_99:.*]] = index_cast %[[VAL_98]] : i64 to index
+// CHECK:               %[[VAL_99:.*]] = arith.index_cast %[[VAL_98]] : i64 to index
 // CHECK:               %[[VAL_100:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_93]]] : memref<?xi64>
 // CHECK:               %[[VAL_101:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_94]]] : memref<?xi64>
-// CHECK:               %[[VAL_102:.*]] = index_cast %[[VAL_100]] : i64 to index
-// CHECK:               %[[VAL_103:.*]] = index_cast %[[VAL_101]] : i64 to index
+// CHECK:               %[[VAL_102:.*]] = arith.index_cast %[[VAL_100]] : i64 to index
+// CHECK:               %[[VAL_103:.*]] = arith.index_cast %[[VAL_101]] : i64 to index
 // CHECK:               %[[VAL_104:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_93]]] : memref<?xi64>
 // CHECK:               %[[VAL_105:.*]] = memref.load %[[VAL_15]]{{\[}}%[[VAL_94]]] : memref<?xi64>
-// CHECK:               %[[VAL_106:.*]] = index_cast %[[VAL_104]] : i64 to index
-// CHECK:               %[[VAL_107:.*]] = index_cast %[[VAL_105]] : i64 to index
+// CHECK:               %[[VAL_106:.*]] = arith.index_cast %[[VAL_104]] : i64 to index
+// CHECK:               %[[VAL_107:.*]] = arith.index_cast %[[VAL_105]] : i64 to index
 // CHECK:               %[[VAL_108:.*]]:9 = scf.while (%[[VAL_109:.*]] = %[[VAL_102]], %[[VAL_110:.*]] = %[[VAL_106]], %[[VAL_111:.*]] = %[[VAL_99]], %[[VAL_112:.*]] = %[[VAL_4]], %[[VAL_113:.*]] = %[[VAL_4]], %[[VAL_114:.*]] = %[[VAL_7]], %[[VAL_115:.*]] = %[[VAL_7]], %[[VAL_116:.*]] = %[[VAL_6]], %[[VAL_117:.*]] = %[[VAL_6]]) : (index, index, index, i64, i64, f64, f64, i1, i1) -> (index, index, index, i64, i64, f64, f64, i1, i1) {
-// CHECK:                 %[[VAL_118:.*]] = cmpi ult, %[[VAL_109]], %[[VAL_103]] : index
-// CHECK:                 %[[VAL_119:.*]] = cmpi ult, %[[VAL_110]], %[[VAL_107]] : index
-// CHECK:                 %[[VAL_120:.*]] = and %[[VAL_118]], %[[VAL_119]] : i1
+// CHECK:                 %[[VAL_118:.*]] = arith.cmpi ult, %[[VAL_109]], %[[VAL_103]] : index
+// CHECK:                 %[[VAL_119:.*]] = arith.cmpi ult, %[[VAL_110]], %[[VAL_107]] : index
+// CHECK:                 %[[VAL_120:.*]] = arith.andi %[[VAL_118]], %[[VAL_119]] : i1
 // CHECK:                 scf.condition(%[[VAL_120]]) %[[VAL_109]], %[[VAL_110]], %[[VAL_111]], %[[VAL_112]], %[[VAL_113]], %[[VAL_114]], %[[VAL_115]], %[[VAL_116]], %[[VAL_117]] : index, index, index, i64, i64, f64, f64, i1, i1
 // CHECK:               } do {
 // CHECK:               ^bb0(%[[VAL_121:.*]]: index, %[[VAL_122:.*]]: index, %[[VAL_123:.*]]: index, %[[VAL_124:.*]]: i64, %[[VAL_125:.*]]: i64, %[[VAL_126:.*]]: f64, %[[VAL_127:.*]]: f64, %[[VAL_128:.*]]: i1, %[[VAL_129:.*]]: i1):
@@ -332,11 +332,11 @@ func @vector_union(%a: tensor<?xf64, #CV64>, %b: tensor<?xf64, #CV64>) -> tensor
 // CHECK:                 } else {
 // CHECK:                   scf.yield %[[VAL_125]], %[[VAL_127]] : i64, f64
 // CHECK:                 }
-// CHECK:                 %[[VAL_136:.*]] = cmpi ult, %[[VAL_137:.*]]#0, %[[VAL_138:.*]]#0 : i64
-// CHECK:                 %[[VAL_139:.*]] = cmpi ugt, %[[VAL_137]]#0, %[[VAL_138]]#0 : i64
-// CHECK:                 %[[VAL_140:.*]] = addi %[[VAL_121]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_141:.*]] = addi %[[VAL_122]], %[[VAL_3]] : index
-// CHECK:                 %[[VAL_142:.*]] = addi %[[VAL_123]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_136:.*]] = arith.cmpi ult, %[[VAL_137:.*]]#0, %[[VAL_138:.*]]#0 : i64
+// CHECK:                 %[[VAL_139:.*]] = arith.cmpi ugt, %[[VAL_137]]#0, %[[VAL_138]]#0 : i64
+// CHECK:                 %[[VAL_140:.*]] = arith.addi %[[VAL_121]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_141:.*]] = arith.addi %[[VAL_122]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_142:.*]] = arith.addi %[[VAL_123]], %[[VAL_3]] : index
 // CHECK:                 %[[VAL_143:.*]]:5 = scf.if %[[VAL_136]] -> (index, index, index, i1, i1) {
 // CHECK:                   memref.store %[[VAL_137]]#0, %[[VAL_91]]{{\[}}%[[VAL_123]]] : memref<?xi64>
 // CHECK:                   memref.store %[[VAL_137]]#1, %[[VAL_92]]{{\[}}%[[VAL_123]]] : memref<?xf64>
@@ -348,7 +348,7 @@ func @vector_union(%a: tensor<?xf64, #CV64>, %b: tensor<?xf64, #CV64>) -> tensor
 // CHECK:                     scf.yield %[[VAL_121]], %[[VAL_141]], %[[VAL_142]], %[[VAL_5]], %[[VAL_6]] : index, index, index, i1, i1
 // CHECK:                   } else {
 // CHECK:                     memref.store %[[VAL_137]]#0, %[[VAL_91]]{{\[}}%[[VAL_123]]] : memref<?xi64>
-// CHECK:                     %[[VAL_145:.*]] = addf %[[VAL_137]]#1, %[[VAL_138]]#1 : f64
+// CHECK:                     %[[VAL_145:.*]] = arith.addf %[[VAL_137]]#1, %[[VAL_138]]#1 : f64
 // CHECK:                     memref.store %[[VAL_145]], %[[VAL_92]]{{\[}}%[[VAL_123]]] : memref<?xf64>
 // CHECK:                     scf.yield %[[VAL_140]], %[[VAL_141]], %[[VAL_142]], %[[VAL_6]], %[[VAL_6]] : index, index, index, i1, i1
 // CHECK:                   }
@@ -356,26 +356,26 @@ func @vector_union(%a: tensor<?xf64, #CV64>, %b: tensor<?xf64, #CV64>) -> tensor
 // CHECK:                 }
 // CHECK:                 scf.yield %[[VAL_147:.*]]#0, %[[VAL_147]]#1, %[[VAL_147]]#2, %[[VAL_137]]#0, %[[VAL_138]]#0, %[[VAL_137]]#1, %[[VAL_138]]#1, %[[VAL_147]]#3, %[[VAL_147]]#4 : index, index, index, i64, i64, f64, f64, i1, i1
 // CHECK:               }
-// CHECK:               %[[VAL_148:.*]] = cmpi ult, %[[VAL_149:.*]]#0, %[[VAL_103]] : index
+// CHECK:               %[[VAL_148:.*]] = arith.cmpi ult, %[[VAL_149:.*]]#0, %[[VAL_103]] : index
 // CHECK:               %[[VAL_150:.*]] = scf.if %[[VAL_148]] -> (index) {
 // CHECK:                 %[[VAL_151:.*]] = scf.for %[[VAL_152:.*]] = %[[VAL_149]]#0 to %[[VAL_103]] step %[[VAL_3]] iter_args(%[[VAL_153:.*]] = %[[VAL_149]]#2) -> (index) {
 // CHECK:                   %[[VAL_154:.*]] = memref.load %[[VAL_13]]{{\[}}%[[VAL_152]]] : memref<?xi64>
 // CHECK:                   %[[VAL_155:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_152]]] : memref<?xf64>
 // CHECK:                   memref.store %[[VAL_154]], %[[VAL_91]]{{\[}}%[[VAL_153]]] : memref<?xi64>
 // CHECK:                   memref.store %[[VAL_155]], %[[VAL_92]]{{\[}}%[[VAL_153]]] : memref<?xf64>
-// CHECK:                   %[[VAL_156:.*]] = addi %[[VAL_153]], %[[VAL_3]] : index
+// CHECK:                   %[[VAL_156:.*]] = arith.addi %[[VAL_153]], %[[VAL_3]] : index
 // CHECK:                   scf.yield %[[VAL_156]] : index
 // CHECK:                 }
 // CHECK:                 scf.yield %[[VAL_157:.*]] : index
 // CHECK:               } else {
-// CHECK:                 %[[VAL_158:.*]] = cmpi ult, %[[VAL_149]]#1, %[[VAL_107]] : index
+// CHECK:                 %[[VAL_158:.*]] = arith.cmpi ult, %[[VAL_149]]#1, %[[VAL_107]] : index
 // CHECK:                 %[[VAL_159:.*]] = scf.if %[[VAL_158]] -> (index) {
 // CHECK:                   %[[VAL_160:.*]] = scf.for %[[VAL_161:.*]] = %[[VAL_149]]#1 to %[[VAL_107]] step %[[VAL_3]] iter_args(%[[VAL_162:.*]] = %[[VAL_149]]#2) -> (index) {
 // CHECK:                     %[[VAL_163:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_161]]] : memref<?xi64>
 // CHECK:                     %[[VAL_164:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_161]]] : memref<?xf64>
 // CHECK:                     memref.store %[[VAL_163]], %[[VAL_91]]{{\[}}%[[VAL_162]]] : memref<?xi64>
 // CHECK:                     memref.store %[[VAL_164]], %[[VAL_92]]{{\[}}%[[VAL_162]]] : memref<?xf64>
-// CHECK:                     %[[VAL_165:.*]] = addi %[[VAL_162]], %[[VAL_3]] : index
+// CHECK:                     %[[VAL_165:.*]] = arith.addi %[[VAL_162]], %[[VAL_3]] : index
 // CHECK:                     scf.yield %[[VAL_165]] : index
 // CHECK:                   }
 // CHECK:                   scf.yield %[[VAL_166:.*]] : index

--- a/mlir_graphblas/src/test/GraphBLAS/lower_vector_argminmax.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_vector_argminmax.mlir
@@ -9,16 +9,16 @@
 module {
 
 // CHECK:         func @vector_argmin(%[[VAL_0:.*]]: tensor<3xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> i64 {
-// CHECK:           %[[VAL_1:.*]] = constant 0 : index
-// CHECK:           %[[VAL_2:.*]] = constant 1 : index
+// CHECK:           %[[VAL_1:.*]] = arith.constant 0 : index
+// CHECK:           %[[VAL_2:.*]] = arith.constant 1 : index
 // CHECK:           %[[VAL_3:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_1]] : tensor<3xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_4:.*]] = memref.load %[[VAL_3]]{{\[}}%[[VAL_2]]] : memref<?xi64>
-// CHECK:           %[[VAL_5:.*]] = index_cast %[[VAL_4]] : i64 to index
+// CHECK:           %[[VAL_5:.*]] = arith.index_cast %[[VAL_4]] : i64 to index
 // CHECK:           %[[VAL_6:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<3xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_7:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_1]]] : memref<?xi64>
 // CHECK:           %[[VAL_8:.*]]:2 = scf.for %[[VAL_9:.*]] = %[[VAL_2]] to %[[VAL_5]] step %[[VAL_2]] iter_args(%[[VAL_10:.*]] = %[[VAL_7]], %[[VAL_11:.*]] = %[[VAL_1]]) -> (i64, index) {
 // CHECK:             %[[VAL_12:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_9]]] : memref<?xi64>
-// CHECK:             %[[VAL_13:.*]] = cmpi slt, %[[VAL_12]], %[[VAL_10]] : i64
+// CHECK:             %[[VAL_13:.*]] = arith.cmpi slt, %[[VAL_12]], %[[VAL_10]] : i64
 // CHECK:             %[[VAL_14:.*]]:2 = scf.if %[[VAL_13]] -> (i64, index) {
 // CHECK:               scf.yield %[[VAL_12]], %[[VAL_9]] : i64, index
 // CHECK:             } else {
@@ -37,16 +37,16 @@ module {
    }
    
 // CHECK:         func @vector_argmax(%[[VAL_0:.*]]: tensor<?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> i64 {
-// CHECK:           %[[VAL_1:.*]] = constant 0 : index
-// CHECK:           %[[VAL_2:.*]] = constant 1 : index
+// CHECK:           %[[VAL_1:.*]] = arith.constant 0 : index
+// CHECK:           %[[VAL_2:.*]] = arith.constant 1 : index
 // CHECK:           %[[VAL_3:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_1]] : tensor<?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_4:.*]] = memref.load %[[VAL_3]]{{\[}}%[[VAL_2]]] : memref<?xi64>
-// CHECK:           %[[VAL_5:.*]] = index_cast %[[VAL_4]] : i64 to index
+// CHECK:           %[[VAL_5:.*]] = arith.index_cast %[[VAL_4]] : i64 to index
 // CHECK:           %[[VAL_6:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?xi64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_7:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_1]]] : memref<?xi64>
 // CHECK:           %[[VAL_8:.*]]:2 = scf.for %[[VAL_9:.*]] = %[[VAL_2]] to %[[VAL_5]] step %[[VAL_2]] iter_args(%[[VAL_10:.*]] = %[[VAL_7]], %[[VAL_11:.*]] = %[[VAL_1]]) -> (i64, index) {
 // CHECK:             %[[VAL_12:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_9]]] : memref<?xi64>
-// CHECK:             %[[VAL_13:.*]] = cmpi sgt, %[[VAL_12]], %[[VAL_10]] : i64
+// CHECK:             %[[VAL_13:.*]] = arith.cmpi sgt, %[[VAL_12]], %[[VAL_10]] : i64
 // CHECK:             %[[VAL_14:.*]]:2 = scf.if %[[VAL_13]] -> (i64, index) {
 // CHECK:               scf.yield %[[VAL_12]], %[[VAL_9]] : i64, index
 // CHECK:             } else {

--- a/mlir_graphblas/src/test/GraphBLAS/lower_vector_matrix_multiply_full.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_vector_matrix_multiply_full.mlir
@@ -16,14 +16,14 @@
 // CHECK-LABEL:   func @vector_matrix_multiply_plus_times(
 // CHECK-SAME:                                            %[[VAL_0:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                                            %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK-DAG:       %[[VAL_2:.*]] = constant 2 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 0 : i64
-// CHECK-DAG:       %[[VAL_4:.*]] = constant 1 : i64
-// CHECK-DAG:       %[[VAL_5:.*]] = constant 0 : index
-// CHECK-DAG:       %[[VAL_6:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_7:.*]] = constant true
-// CHECK-DAG:       %[[VAL_8:.*]] = constant false
-// CHECK-DAG:       %[[VAL_9:.*]] = constant 0.000000e+00 : f64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 2 : index
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : i64
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 1 : i64
+// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_6:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_7:.*]] = arith.constant true
+// CHECK-DAG:       %[[VAL_8:.*]] = arith.constant false
+// CHECK-DAG:       %[[VAL_9:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK:           %[[VAL_10:.*]] = tensor.dim %[[VAL_1]], %[[VAL_6]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_11:.*]] = tensor.dim %[[VAL_0]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_12:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
@@ -41,8 +41,8 @@
 // CHECK:           %[[VAL_22:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           %[[VAL_23:.*]] = sparse_tensor.pointers %[[VAL_14]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_24:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_6]]] : memref<?xi64>
-// CHECK:           %[[VAL_25:.*]] = index_cast %[[VAL_24]] : i64 to index
-// CHECK:           %[[VAL_26:.*]] = cmpi eq, %[[VAL_5]], %[[VAL_25]] : index
+// CHECK:           %[[VAL_25:.*]] = arith.index_cast %[[VAL_24]] : i64 to index
+// CHECK:           %[[VAL_26:.*]] = arith.cmpi eq, %[[VAL_5]], %[[VAL_25]] : index
 // CHECK:           %[[VAL_27:.*]] = scf.if %[[VAL_26]] -> (i64) {
 // CHECK:             scf.yield %[[VAL_3]] : i64
 // CHECK:           } else {
@@ -50,26 +50,26 @@
 // CHECK:             linalg.fill(%[[VAL_8]], %[[VAL_28]]) : i1, memref<?xi1>
 // CHECK:             scf.parallel (%[[VAL_29:.*]]) = (%[[VAL_5]]) to (%[[VAL_25]]) step (%[[VAL_6]]) {
 // CHECK:               %[[VAL_30:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_29]]] : memref<?xi64>
-// CHECK:               %[[VAL_31:.*]] = index_cast %[[VAL_30]] : i64 to index
+// CHECK:               %[[VAL_31:.*]] = arith.index_cast %[[VAL_30]] : i64 to index
 // CHECK:               memref.store %[[VAL_7]], %[[VAL_28]]{{\[}}%[[VAL_31]]] : memref<?xi1>
 // CHECK:               scf.yield
 // CHECK:             }
 // CHECK:             %[[VAL_32:.*]] = scf.parallel (%[[VAL_33:.*]]) = (%[[VAL_5]]) to (%[[VAL_10]]) step (%[[VAL_6]]) init (%[[VAL_3]]) -> i64 {
-// CHECK:               %[[VAL_34:.*]] = addi %[[VAL_33]], %[[VAL_6]] : index
+// CHECK:               %[[VAL_34:.*]] = arith.addi %[[VAL_33]], %[[VAL_6]] : index
 // CHECK:               %[[VAL_35:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_33]]] : memref<?xi64>
 // CHECK:               %[[VAL_36:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_34]]] : memref<?xi64>
-// CHECK:               %[[VAL_37:.*]] = cmpi eq, %[[VAL_35]], %[[VAL_36]] : i64
+// CHECK:               %[[VAL_37:.*]] = arith.cmpi eq, %[[VAL_35]], %[[VAL_36]] : i64
 // CHECK:               %[[VAL_38:.*]] = scf.if %[[VAL_37]] -> (i64) {
 // CHECK:                 scf.yield %[[VAL_3]] : i64
 // CHECK:               } else {
 // CHECK:                 %[[VAL_39:.*]] = scf.while (%[[VAL_40:.*]] = %[[VAL_35]]) : (i64) -> i64 {
-// CHECK:                   %[[VAL_41:.*]] = cmpi uge, %[[VAL_40]], %[[VAL_36]] : i64
+// CHECK:                   %[[VAL_41:.*]] = arith.cmpi uge, %[[VAL_40]], %[[VAL_36]] : i64
 // CHECK:                   %[[VAL_42:.*]]:2 = scf.if %[[VAL_41]] -> (i1, i64) {
 // CHECK:                     scf.yield %[[VAL_8]], %[[VAL_3]] : i1, i64
 // CHECK:                   } else {
-// CHECK:                     %[[VAL_43:.*]] = index_cast %[[VAL_40]] : i64 to index
+// CHECK:                     %[[VAL_43:.*]] = arith.index_cast %[[VAL_40]] : i64 to index
 // CHECK:                     %[[VAL_44:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_43]]] : memref<?xi64>
-// CHECK:                     %[[VAL_45:.*]] = index_cast %[[VAL_44]] : i64 to index
+// CHECK:                     %[[VAL_45:.*]] = arith.index_cast %[[VAL_44]] : i64 to index
 // CHECK:                     %[[VAL_46:.*]] = memref.load %[[VAL_28]]{{\[}}%[[VAL_45]]] : memref<?xi1>
 // CHECK:                     %[[VAL_47:.*]] = select %[[VAL_46]], %[[VAL_8]], %[[VAL_7]] : i1
 // CHECK:                     %[[VAL_48:.*]] = select %[[VAL_46]], %[[VAL_4]], %[[VAL_40]] : i64
@@ -78,14 +78,14 @@
 // CHECK:                   scf.condition(%[[VAL_49:.*]]#0) %[[VAL_49]]#1 : i64
 // CHECK:                 } do {
 // CHECK:                 ^bb0(%[[VAL_50:.*]]: i64):
-// CHECK:                   %[[VAL_51:.*]] = addi %[[VAL_50]], %[[VAL_4]] : i64
+// CHECK:                   %[[VAL_51:.*]] = arith.addi %[[VAL_50]], %[[VAL_4]] : i64
 // CHECK:                   scf.yield %[[VAL_51]] : i64
 // CHECK:                 }
 // CHECK:                 scf.yield %[[VAL_52:.*]] : i64
 // CHECK:               }
 // CHECK:               scf.reduce(%[[VAL_53:.*]])  : i64 {
 // CHECK:               ^bb0(%[[VAL_54:.*]]: i64, %[[VAL_55:.*]]: i64):
-// CHECK:                 %[[VAL_56:.*]] = addi %[[VAL_54]], %[[VAL_55]] : i64
+// CHECK:                 %[[VAL_56:.*]] = arith.addi %[[VAL_54]], %[[VAL_55]] : i64
 // CHECK:                 scf.reduce.return %[[VAL_56]] : i64
 // CHECK:               }
 // CHECK:               scf.yield
@@ -93,7 +93,7 @@
 // CHECK:             memref.dealloc %[[VAL_28]] : memref<?xi1>
 // CHECK:             scf.yield %[[VAL_57:.*]] : i64
 // CHECK:           }
-// CHECK:           %[[VAL_58:.*]] = index_cast %[[VAL_59:.*]] : i64 to index
+// CHECK:           %[[VAL_58:.*]] = arith.index_cast %[[VAL_59:.*]] : i64 to index
 // CHECK:           memref.store %[[VAL_59]], %[[VAL_23]]{{\[}}%[[VAL_6]]] : memref<?xi64>
 // CHECK:           %[[VAL_60:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_14]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           call @resize_index(%[[VAL_60]], %[[VAL_5]], %[[VAL_58]]) : (!llvm.ptr<i8>, index, index) -> ()
@@ -101,35 +101,35 @@
 // CHECK:           call @resize_values(%[[VAL_61]], %[[VAL_58]]) : (!llvm.ptr<i8>, index) -> ()
 // CHECK:           %[[VAL_62:.*]] = sparse_tensor.indices %[[VAL_14]], %[[VAL_5]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_63:.*]] = sparse_tensor.values %[[VAL_14]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
-// CHECK:           %[[VAL_64:.*]] = cmpi ne, %[[VAL_5]], %[[VAL_58]] : index
+// CHECK:           %[[VAL_64:.*]] = arith.cmpi ne, %[[VAL_5]], %[[VAL_58]] : index
 // CHECK:           scf.if %[[VAL_64]] {
 // CHECK:             %[[VAL_65:.*]] = memref.alloc(%[[VAL_11]]) : memref<?xf64>
 // CHECK:             %[[VAL_66:.*]] = memref.alloc(%[[VAL_11]]) : memref<?xi1>
 // CHECK:             linalg.fill(%[[VAL_8]], %[[VAL_66]]) : i1, memref<?xi1>
 // CHECK:             scf.parallel (%[[VAL_67:.*]]) = (%[[VAL_5]]) to (%[[VAL_25]]) step (%[[VAL_6]]) {
 // CHECK:               %[[VAL_68:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_67]]] : memref<?xi64>
-// CHECK:               %[[VAL_69:.*]] = index_cast %[[VAL_68]] : i64 to index
+// CHECK:               %[[VAL_69:.*]] = arith.index_cast %[[VAL_68]] : i64 to index
 // CHECK:               memref.store %[[VAL_7]], %[[VAL_66]]{{\[}}%[[VAL_69]]] : memref<?xi1>
 // CHECK:               %[[VAL_70:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_67]]] : memref<?xf64>
 // CHECK:               memref.store %[[VAL_70]], %[[VAL_65]]{{\[}}%[[VAL_69]]] : memref<?xf64>
 // CHECK:               scf.yield
 // CHECK:             }
 // CHECK:             %[[VAL_71:.*]] = scf.for %[[VAL_72:.*]] = %[[VAL_5]] to %[[VAL_10]] step %[[VAL_6]] iter_args(%[[VAL_73:.*]] = %[[VAL_5]]) -> (index) {
-// CHECK:               %[[VAL_74:.*]] = index_cast %[[VAL_72]] : index to i64
-// CHECK:               %[[VAL_75:.*]] = addi %[[VAL_72]], %[[VAL_6]] : index
+// CHECK:               %[[VAL_74:.*]] = arith.index_cast %[[VAL_72]] : index to i64
+// CHECK:               %[[VAL_75:.*]] = arith.addi %[[VAL_72]], %[[VAL_6]] : index
 // CHECK:               %[[VAL_76:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_72]]] : memref<?xi64>
 // CHECK:               %[[VAL_77:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_75]]] : memref<?xi64>
-// CHECK:               %[[VAL_78:.*]] = index_cast %[[VAL_76]] : i64 to index
-// CHECK:               %[[VAL_79:.*]] = index_cast %[[VAL_77]] : i64 to index
+// CHECK:               %[[VAL_78:.*]] = arith.index_cast %[[VAL_76]] : i64 to index
+// CHECK:               %[[VAL_79:.*]] = arith.index_cast %[[VAL_77]] : i64 to index
 // CHECK:               %[[VAL_80:.*]]:2 = scf.for %[[VAL_81:.*]] = %[[VAL_78]] to %[[VAL_79]] step %[[VAL_6]] iter_args(%[[VAL_82:.*]] = %[[VAL_9]], %[[VAL_83:.*]] = %[[VAL_8]]) -> (f64, i1) {
 // CHECK:                 %[[VAL_84:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_81]]] : memref<?xi64>
-// CHECK:                 %[[VAL_85:.*]] = index_cast %[[VAL_84]] : i64 to index
+// CHECK:                 %[[VAL_85:.*]] = arith.index_cast %[[VAL_84]] : i64 to index
 // CHECK:                 %[[VAL_86:.*]] = memref.load %[[VAL_66]]{{\[}}%[[VAL_85]]] : memref<?xi1>
 // CHECK:                 %[[VAL_87:.*]]:2 = scf.if %[[VAL_86]] -> (f64, i1) {
 // CHECK:                   %[[VAL_88:.*]] = memref.load %[[VAL_65]]{{\[}}%[[VAL_85]]] : memref<?xf64>
 // CHECK:                   %[[VAL_89:.*]] = memref.load %[[VAL_22]]{{\[}}%[[VAL_81]]] : memref<?xf64>
-// CHECK:                   %[[VAL_90:.*]] = mulf %[[VAL_88]], %[[VAL_89]] : f64
-// CHECK:                   %[[VAL_91:.*]] = addf %[[VAL_82]], %[[VAL_90]] : f64
+// CHECK:                   %[[VAL_90:.*]] = arith.mulf %[[VAL_88]], %[[VAL_89]] : f64
+// CHECK:                   %[[VAL_91:.*]] = arith.addf %[[VAL_82]], %[[VAL_90]] : f64
 // CHECK:                   scf.yield %[[VAL_91]], %[[VAL_7]] : f64, i1
 // CHECK:                 } else {
 // CHECK:                   scf.yield %[[VAL_82]], %[[VAL_83]] : f64, i1
@@ -139,7 +139,7 @@
 // CHECK:               %[[VAL_93:.*]] = scf.if %[[VAL_94:.*]]#1 -> (index) {
 // CHECK:                 memref.store %[[VAL_74]], %[[VAL_62]]{{\[}}%[[VAL_73]]] : memref<?xi64>
 // CHECK:                 memref.store %[[VAL_94]]#0, %[[VAL_63]]{{\[}}%[[VAL_73]]] : memref<?xf64>
-// CHECK:                 %[[VAL_95:.*]] = addi %[[VAL_73]], %[[VAL_6]] : index
+// CHECK:                 %[[VAL_95:.*]] = arith.addi %[[VAL_73]], %[[VAL_6]] : index
 // CHECK:                 scf.yield %[[VAL_95]] : index
 // CHECK:               } else {
 // CHECK:                 scf.yield %[[VAL_73]] : index

--- a/mlir_graphblas/src/test/GraphBLAS/lower_vector_update_accumulate.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_vector_update_accumulate.mlir
@@ -9,51 +9,51 @@
 // CHECK-LABEL:   func @vector_update_accumulate(
 // CHECK-SAME:                                   %[[VAL_0:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                                   %[[VAL_1:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> index {
-// CHECK-DAG:       %[[VAL_2:.*]] = constant 0 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_4:.*]] = constant 0 : i64
-// CHECK-DAG:       %[[VAL_5:.*]] = constant false
-// CHECK-DAG:       %[[VAL_6:.*]] = constant true
-// CHECK-DAG:       %[[VAL_7:.*]] = constant 0.000000e+00 : f64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 0 : i64
+// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant false
+// CHECK-DAG:       %[[VAL_6:.*]] = arith.constant true
+// CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK:           %[[VAL_8:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_1]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_9:.*]] = call @dup_tensor(%[[VAL_8]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_10:.*]] = call @ptr8_to_vector_f64_p64i64(%[[VAL_9]]) : (!llvm.ptr<i8>) -> tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_11:.*]] = sparse_tensor.pointers %[[VAL_0]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_12:.*]] = memref.load %[[VAL_11]]{{\[}}%[[VAL_3]]] : memref<?xi64>
-// CHECK:           %[[VAL_13:.*]] = index_cast %[[VAL_12]] : i64 to index
+// CHECK:           %[[VAL_13:.*]] = arith.index_cast %[[VAL_12]] : i64 to index
 // CHECK:           %[[VAL_14:.*]] = sparse_tensor.pointers %[[VAL_10]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_15:.*]] = memref.load %[[VAL_14]]{{\[}}%[[VAL_3]]] : memref<?xi64>
-// CHECK:           %[[VAL_16:.*]] = index_cast %[[VAL_15]] : i64 to index
+// CHECK:           %[[VAL_16:.*]] = arith.index_cast %[[VAL_15]] : i64 to index
 // CHECK:           %[[VAL_17:.*]] = sparse_tensor.indices %[[VAL_0]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_18:.*]] = sparse_tensor.values %[[VAL_0]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           %[[VAL_19:.*]] = sparse_tensor.indices %[[VAL_10]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_20:.*]] = sparse_tensor.values %[[VAL_10]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           %[[VAL_21:.*]]:7 = scf.while (%[[VAL_22:.*]] = %[[VAL_2]], %[[VAL_23:.*]] = %[[VAL_2]], %[[VAL_24:.*]] = %[[VAL_2]], %[[VAL_25:.*]] = %[[VAL_2]], %[[VAL_26:.*]] = %[[VAL_6]], %[[VAL_27:.*]] = %[[VAL_6]], %[[VAL_28:.*]] = %[[VAL_2]]) : (index, index, index, index, i1, i1, index) -> (index, index, index, index, i1, i1, index) {
-// CHECK:             %[[VAL_29:.*]] = cmpi ult, %[[VAL_22]], %[[VAL_13]] : index
-// CHECK:             %[[VAL_30:.*]] = cmpi ult, %[[VAL_23]], %[[VAL_16]] : index
-// CHECK:             %[[VAL_31:.*]] = and %[[VAL_29]], %[[VAL_30]] : i1
+// CHECK:             %[[VAL_29:.*]] = arith.cmpi ult, %[[VAL_22]], %[[VAL_13]] : index
+// CHECK:             %[[VAL_30:.*]] = arith.cmpi ult, %[[VAL_23]], %[[VAL_16]] : index
+// CHECK:             %[[VAL_31:.*]] = arith.andi %[[VAL_29]], %[[VAL_30]] : i1
 // CHECK:             scf.condition(%[[VAL_31]]) %[[VAL_22]], %[[VAL_23]], %[[VAL_24]], %[[VAL_25]], %[[VAL_26]], %[[VAL_27]], %[[VAL_28]] : index, index, index, index, i1, i1, index
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_32:.*]]: index, %[[VAL_33:.*]]: index, %[[VAL_34:.*]]: index, %[[VAL_35:.*]]: index, %[[VAL_36:.*]]: i1, %[[VAL_37:.*]]: i1, %[[VAL_38:.*]]: index):
 // CHECK:             %[[VAL_39:.*]] = scf.if %[[VAL_36]] -> (index) {
 // CHECK:               %[[VAL_40:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_32]]] : memref<?xi64>
-// CHECK:               %[[VAL_41:.*]] = index_cast %[[VAL_40]] : i64 to index
+// CHECK:               %[[VAL_41:.*]] = arith.index_cast %[[VAL_40]] : i64 to index
 // CHECK:               scf.yield %[[VAL_41]] : index
 // CHECK:             } else {
 // CHECK:               scf.yield %[[VAL_34]] : index
 // CHECK:             }
 // CHECK:             %[[VAL_42:.*]] = scf.if %[[VAL_37]] -> (index) {
 // CHECK:               %[[VAL_43:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_33]]] : memref<?xi64>
-// CHECK:               %[[VAL_44:.*]] = index_cast %[[VAL_43]] : i64 to index
+// CHECK:               %[[VAL_44:.*]] = arith.index_cast %[[VAL_43]] : i64 to index
 // CHECK:               scf.yield %[[VAL_44]] : index
 // CHECK:             } else {
 // CHECK:               scf.yield %[[VAL_35]] : index
 // CHECK:             }
-// CHECK:             %[[VAL_45:.*]] = cmpi ult, %[[VAL_46:.*]], %[[VAL_47:.*]] : index
-// CHECK:             %[[VAL_48:.*]] = cmpi ugt, %[[VAL_46]], %[[VAL_47]] : index
-// CHECK:             %[[VAL_49:.*]] = addi %[[VAL_32]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_50:.*]] = addi %[[VAL_33]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_51:.*]] = addi %[[VAL_38]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_45:.*]] = arith.cmpi ult, %[[VAL_46:.*]], %[[VAL_47:.*]] : index
+// CHECK:             %[[VAL_48:.*]] = arith.cmpi ugt, %[[VAL_46]], %[[VAL_47]] : index
+// CHECK:             %[[VAL_49:.*]] = arith.addi %[[VAL_32]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_50:.*]] = arith.addi %[[VAL_33]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_51:.*]] = arith.addi %[[VAL_38]], %[[VAL_3]] : index
 // CHECK:             %[[VAL_52:.*]]:5 = scf.if %[[VAL_45]] -> (index, index, i1, i1, index) {
 // CHECK:               scf.yield %[[VAL_49]], %[[VAL_33]], %[[VAL_6]], %[[VAL_5]], %[[VAL_51]] : index, index, i1, i1, index
 // CHECK:             } else {
@@ -66,23 +66,23 @@
 // CHECK:             }
 // CHECK:             scf.yield %[[VAL_55:.*]]#0, %[[VAL_55]]#1, %[[VAL_46]], %[[VAL_47]], %[[VAL_55]]#2, %[[VAL_55]]#3, %[[VAL_55]]#4 : index, index, index, index, i1, i1, index
 // CHECK:           }
-// CHECK:           %[[VAL_56:.*]] = cmpi ult, %[[VAL_57:.*]]#0, %[[VAL_13]] : index
+// CHECK:           %[[VAL_56:.*]] = arith.cmpi ult, %[[VAL_57:.*]]#0, %[[VAL_13]] : index
 // CHECK:           %[[VAL_58:.*]] = scf.if %[[VAL_56]] -> (index) {
-// CHECK:             %[[VAL_59:.*]] = subi %[[VAL_13]], %[[VAL_57]]#0 : index
-// CHECK:             %[[VAL_60:.*]] = addi %[[VAL_57]]#6, %[[VAL_59]] : index
+// CHECK:             %[[VAL_59:.*]] = arith.subi %[[VAL_13]], %[[VAL_57]]#0 : index
+// CHECK:             %[[VAL_60:.*]] = arith.addi %[[VAL_57]]#6, %[[VAL_59]] : index
 // CHECK:             scf.yield %[[VAL_60]] : index
 // CHECK:           } else {
-// CHECK:             %[[VAL_61:.*]] = cmpi ult, %[[VAL_57]]#1, %[[VAL_16]] : index
+// CHECK:             %[[VAL_61:.*]] = arith.cmpi ult, %[[VAL_57]]#1, %[[VAL_16]] : index
 // CHECK:             %[[VAL_62:.*]] = scf.if %[[VAL_61]] -> (index) {
-// CHECK:               %[[VAL_63:.*]] = subi %[[VAL_16]], %[[VAL_57]]#1 : index
-// CHECK:               %[[VAL_64:.*]] = addi %[[VAL_57]]#6, %[[VAL_63]] : index
+// CHECK:               %[[VAL_63:.*]] = arith.subi %[[VAL_16]], %[[VAL_57]]#1 : index
+// CHECK:               %[[VAL_64:.*]] = arith.addi %[[VAL_57]]#6, %[[VAL_63]] : index
 // CHECK:               scf.yield %[[VAL_64]] : index
 // CHECK:             } else {
 // CHECK:               scf.yield %[[VAL_57]]#6 : index
 // CHECK:             }
 // CHECK:             scf.yield %[[VAL_65:.*]] : index
 // CHECK:           }
-// CHECK:           %[[VAL_66:.*]] = index_cast %[[VAL_67:.*]] : index to i64
+// CHECK:           %[[VAL_66:.*]] = arith.index_cast %[[VAL_67:.*]] : index to i64
 // CHECK:           %[[VAL_68:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_1]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           call @resize_index(%[[VAL_68]], %[[VAL_2]], %[[VAL_67]]) : (!llvm.ptr<i8>, index, index) -> ()
 // CHECK:           %[[VAL_69:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_1]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
@@ -92,9 +92,9 @@
 // CHECK:           %[[VAL_71:.*]] = sparse_tensor.indices %[[VAL_1]], %[[VAL_2]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_72:.*]] = sparse_tensor.values %[[VAL_1]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           %[[VAL_73:.*]]:9 = scf.while (%[[VAL_74:.*]] = %[[VAL_2]], %[[VAL_75:.*]] = %[[VAL_2]], %[[VAL_76:.*]] = %[[VAL_2]], %[[VAL_77:.*]] = %[[VAL_4]], %[[VAL_78:.*]] = %[[VAL_4]], %[[VAL_79:.*]] = %[[VAL_7]], %[[VAL_80:.*]] = %[[VAL_7]], %[[VAL_81:.*]] = %[[VAL_6]], %[[VAL_82:.*]] = %[[VAL_6]]) : (index, index, index, i64, i64, f64, f64, i1, i1) -> (index, index, index, i64, i64, f64, f64, i1, i1) {
-// CHECK:             %[[VAL_83:.*]] = cmpi ult, %[[VAL_74]], %[[VAL_13]] : index
-// CHECK:             %[[VAL_84:.*]] = cmpi ult, %[[VAL_75]], %[[VAL_16]] : index
-// CHECK:             %[[VAL_85:.*]] = and %[[VAL_83]], %[[VAL_84]] : i1
+// CHECK:             %[[VAL_83:.*]] = arith.cmpi ult, %[[VAL_74]], %[[VAL_13]] : index
+// CHECK:             %[[VAL_84:.*]] = arith.cmpi ult, %[[VAL_75]], %[[VAL_16]] : index
+// CHECK:             %[[VAL_85:.*]] = arith.andi %[[VAL_83]], %[[VAL_84]] : i1
 // CHECK:             scf.condition(%[[VAL_85]]) %[[VAL_74]], %[[VAL_75]], %[[VAL_76]], %[[VAL_77]], %[[VAL_78]], %[[VAL_79]], %[[VAL_80]], %[[VAL_81]], %[[VAL_82]] : index, index, index, i64, i64, f64, f64, i1, i1
 // CHECK:           } do {
 // CHECK:           ^bb0(%[[VAL_86:.*]]: index, %[[VAL_87:.*]]: index, %[[VAL_88:.*]]: index, %[[VAL_89:.*]]: i64, %[[VAL_90:.*]]: i64, %[[VAL_91:.*]]: f64, %[[VAL_92:.*]]: f64, %[[VAL_93:.*]]: i1, %[[VAL_94:.*]]: i1):
@@ -112,11 +112,11 @@
 // CHECK:             } else {
 // CHECK:               scf.yield %[[VAL_90]], %[[VAL_92]] : i64, f64
 // CHECK:             }
-// CHECK:             %[[VAL_101:.*]] = cmpi ult, %[[VAL_102:.*]]#0, %[[VAL_103:.*]]#0 : i64
-// CHECK:             %[[VAL_104:.*]] = cmpi ugt, %[[VAL_102]]#0, %[[VAL_103]]#0 : i64
-// CHECK:             %[[VAL_105:.*]] = addi %[[VAL_86]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_106:.*]] = addi %[[VAL_87]], %[[VAL_3]] : index
-// CHECK:             %[[VAL_107:.*]] = addi %[[VAL_88]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_101:.*]] = arith.cmpi ult, %[[VAL_102:.*]]#0, %[[VAL_103:.*]]#0 : i64
+// CHECK:             %[[VAL_104:.*]] = arith.cmpi ugt, %[[VAL_102]]#0, %[[VAL_103]]#0 : i64
+// CHECK:             %[[VAL_105:.*]] = arith.addi %[[VAL_86]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_106:.*]] = arith.addi %[[VAL_87]], %[[VAL_3]] : index
+// CHECK:             %[[VAL_107:.*]] = arith.addi %[[VAL_88]], %[[VAL_3]] : index
 // CHECK:             %[[VAL_108:.*]]:5 = scf.if %[[VAL_101]] -> (index, index, index, i1, i1) {
 // CHECK:               memref.store %[[VAL_102]]#0, %[[VAL_71]]{{\[}}%[[VAL_88]]] : memref<?xi64>
 // CHECK:               memref.store %[[VAL_102]]#1, %[[VAL_72]]{{\[}}%[[VAL_88]]] : memref<?xf64>
@@ -128,7 +128,7 @@
 // CHECK:                 scf.yield %[[VAL_86]], %[[VAL_106]], %[[VAL_107]], %[[VAL_5]], %[[VAL_6]] : index, index, index, i1, i1
 // CHECK:               } else {
 // CHECK:                 memref.store %[[VAL_102]]#0, %[[VAL_71]]{{\[}}%[[VAL_88]]] : memref<?xi64>
-// CHECK:                 %[[VAL_110:.*]] = addf %[[VAL_102]]#1, %[[VAL_103]]#1 : f64
+// CHECK:                 %[[VAL_110:.*]] = arith.addf %[[VAL_102]]#1, %[[VAL_103]]#1 : f64
 // CHECK:                 memref.store %[[VAL_110]], %[[VAL_72]]{{\[}}%[[VAL_88]]] : memref<?xf64>
 // CHECK:                 scf.yield %[[VAL_105]], %[[VAL_106]], %[[VAL_107]], %[[VAL_6]], %[[VAL_6]] : index, index, index, i1, i1
 // CHECK:               }
@@ -136,26 +136,26 @@
 // CHECK:             }
 // CHECK:             scf.yield %[[VAL_112:.*]]#0, %[[VAL_112]]#1, %[[VAL_112]]#2, %[[VAL_102]]#0, %[[VAL_103]]#0, %[[VAL_102]]#1, %[[VAL_103]]#1, %[[VAL_112]]#3, %[[VAL_112]]#4 : index, index, index, i64, i64, f64, f64, i1, i1
 // CHECK:           }
-// CHECK:           %[[VAL_113:.*]] = cmpi ult, %[[VAL_114:.*]]#0, %[[VAL_13]] : index
+// CHECK:           %[[VAL_113:.*]] = arith.cmpi ult, %[[VAL_114:.*]]#0, %[[VAL_13]] : index
 // CHECK:           %[[VAL_115:.*]] = scf.if %[[VAL_113]] -> (index) {
 // CHECK:             %[[VAL_116:.*]] = scf.for %[[VAL_117:.*]] = %[[VAL_114]]#0 to %[[VAL_13]] step %[[VAL_3]] iter_args(%[[VAL_118:.*]] = %[[VAL_114]]#2) -> (index) {
 // CHECK:               %[[VAL_119:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_117]]] : memref<?xi64>
 // CHECK:               %[[VAL_120:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_117]]] : memref<?xf64>
 // CHECK:               memref.store %[[VAL_119]], %[[VAL_71]]{{\[}}%[[VAL_118]]] : memref<?xi64>
 // CHECK:               memref.store %[[VAL_120]], %[[VAL_72]]{{\[}}%[[VAL_118]]] : memref<?xf64>
-// CHECK:               %[[VAL_121:.*]] = addi %[[VAL_118]], %[[VAL_3]] : index
+// CHECK:               %[[VAL_121:.*]] = arith.addi %[[VAL_118]], %[[VAL_3]] : index
 // CHECK:               scf.yield %[[VAL_121]] : index
 // CHECK:             }
 // CHECK:             scf.yield %[[VAL_122:.*]] : index
 // CHECK:           } else {
-// CHECK:             %[[VAL_123:.*]] = cmpi ult, %[[VAL_114]]#1, %[[VAL_16]] : index
+// CHECK:             %[[VAL_123:.*]] = arith.cmpi ult, %[[VAL_114]]#1, %[[VAL_16]] : index
 // CHECK:             %[[VAL_124:.*]] = scf.if %[[VAL_123]] -> (index) {
 // CHECK:               %[[VAL_125:.*]] = scf.for %[[VAL_126:.*]] = %[[VAL_114]]#1 to %[[VAL_16]] step %[[VAL_3]] iter_args(%[[VAL_127:.*]] = %[[VAL_114]]#2) -> (index) {
 // CHECK:                 %[[VAL_128:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_126]]] : memref<?xi64>
 // CHECK:                 %[[VAL_129:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_126]]] : memref<?xf64>
 // CHECK:                 memref.store %[[VAL_128]], %[[VAL_71]]{{\[}}%[[VAL_127]]] : memref<?xi64>
 // CHECK:                 memref.store %[[VAL_129]], %[[VAL_72]]{{\[}}%[[VAL_127]]] : memref<?xf64>
-// CHECK:                 %[[VAL_130:.*]] = addi %[[VAL_127]], %[[VAL_3]] : index
+// CHECK:                 %[[VAL_130:.*]] = arith.addi %[[VAL_127]], %[[VAL_3]] : index
 // CHECK:                 scf.yield %[[VAL_130]] : index
 // CHECK:               }
 // CHECK:               scf.yield %[[VAL_131:.*]] : index

--- a/mlir_graphblas/src/test/GraphBLAS/lower_vector_vector_multiply_full.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/lower_vector_vector_multiply_full.mlir
@@ -9,12 +9,12 @@
 // CHECK-LABEL:   func @vector_vector_multiply_plus_times(
 // CHECK-SAME:                                            %[[VAL_0:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                                            %[[VAL_1:.*]]: tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> f64 {
-// CHECK-DAG:       %[[VAL_2:.*]] = constant 2 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = constant 0 : index
-// CHECK-DAG:       %[[VAL_4:.*]] = constant 1 : index
-// CHECK-DAG:       %[[VAL_5:.*]] = constant true
-// CHECK-DAG:       %[[VAL_6:.*]] = constant false
-// CHECK-DAG:       %[[VAL_7:.*]] = constant 0.000000e+00 : f64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 2 : index
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant true
+// CHECK-DAG:       %[[VAL_6:.*]] = arith.constant false
+// CHECK-DAG:       %[[VAL_7:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK:           %[[VAL_8:.*]] = tensor.dim %[[VAL_0]], %[[VAL_3]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:           %[[VAL_9:.*]] = call @vector_f64_p64i64_to_ptr8(%[[VAL_0]]) : (tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_10:.*]] = call @empty_like(%[[VAL_9]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
@@ -36,34 +36,34 @@
 // CHECK:           %[[VAL_22:.*]] = sparse_tensor.indices %[[VAL_11]], %[[VAL_3]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xi64>
 // CHECK:           %[[VAL_23:.*]] = sparse_tensor.values %[[VAL_11]] : tensor<?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to memref<?xf64>
 // CHECK:           %[[VAL_24:.*]] = memref.load %[[VAL_16]]{{\[}}%[[VAL_4]]] : memref<?xi64>
-// CHECK:           %[[VAL_25:.*]] = index_cast %[[VAL_24]] : i64 to index
+// CHECK:           %[[VAL_25:.*]] = arith.index_cast %[[VAL_24]] : i64 to index
 // CHECK:           %[[VAL_26:.*]] = memref.alloc(%[[VAL_8]]) : memref<?xf64>
 // CHECK:           %[[VAL_27:.*]] = memref.alloc(%[[VAL_8]]) : memref<?xi1>
 // CHECK:           linalg.fill(%[[VAL_6]], %[[VAL_27]]) : i1, memref<?xi1>
 // CHECK:           scf.parallel (%[[VAL_28:.*]]) = (%[[VAL_3]]) to (%[[VAL_25]]) step (%[[VAL_4]]) {
 // CHECK:             %[[VAL_29:.*]] = memref.load %[[VAL_17]]{{\[}}%[[VAL_28]]] : memref<?xi64>
-// CHECK:             %[[VAL_30:.*]] = index_cast %[[VAL_29]] : i64 to index
+// CHECK:             %[[VAL_30:.*]] = arith.index_cast %[[VAL_29]] : i64 to index
 // CHECK:             memref.store %[[VAL_5]], %[[VAL_27]]{{\[}}%[[VAL_30]]] : memref<?xi1>
 // CHECK:             %[[VAL_31:.*]] = memref.load %[[VAL_18]]{{\[}}%[[VAL_28]]] : memref<?xf64>
 // CHECK:             memref.store %[[VAL_31]], %[[VAL_26]]{{\[}}%[[VAL_30]]] : memref<?xf64>
 // CHECK:             scf.yield
 // CHECK:           }
 // CHECK:           %[[VAL_32:.*]] = scf.for %[[VAL_33:.*]] = %[[VAL_3]] to %[[VAL_4]] step %[[VAL_4]] iter_args(%[[VAL_34:.*]] = %[[VAL_3]]) -> (index) {
-// CHECK:             %[[VAL_35:.*]] = index_cast %[[VAL_33]] : index to i64
-// CHECK:             %[[VAL_36:.*]] = addi %[[VAL_33]], %[[VAL_4]] : index
+// CHECK:             %[[VAL_35:.*]] = arith.index_cast %[[VAL_33]] : index to i64
+// CHECK:             %[[VAL_36:.*]] = arith.addi %[[VAL_33]], %[[VAL_4]] : index
 // CHECK:             %[[VAL_37:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_33]]] : memref<?xi64>
 // CHECK:             %[[VAL_38:.*]] = memref.load %[[VAL_19]]{{\[}}%[[VAL_36]]] : memref<?xi64>
-// CHECK:             %[[VAL_39:.*]] = index_cast %[[VAL_37]] : i64 to index
-// CHECK:             %[[VAL_40:.*]] = index_cast %[[VAL_38]] : i64 to index
+// CHECK:             %[[VAL_39:.*]] = arith.index_cast %[[VAL_37]] : i64 to index
+// CHECK:             %[[VAL_40:.*]] = arith.index_cast %[[VAL_38]] : i64 to index
 // CHECK:             %[[VAL_41:.*]]:2 = scf.for %[[VAL_42:.*]] = %[[VAL_39]] to %[[VAL_40]] step %[[VAL_4]] iter_args(%[[VAL_43:.*]] = %[[VAL_7]], %[[VAL_44:.*]] = %[[VAL_6]]) -> (f64, i1) {
 // CHECK:               %[[VAL_45:.*]] = memref.load %[[VAL_20]]{{\[}}%[[VAL_42]]] : memref<?xi64>
-// CHECK:               %[[VAL_46:.*]] = index_cast %[[VAL_45]] : i64 to index
+// CHECK:               %[[VAL_46:.*]] = arith.index_cast %[[VAL_45]] : i64 to index
 // CHECK:               %[[VAL_47:.*]] = memref.load %[[VAL_27]]{{\[}}%[[VAL_46]]] : memref<?xi1>
 // CHECK:               %[[VAL_48:.*]]:2 = scf.if %[[VAL_47]] -> (f64, i1) {
 // CHECK:                 %[[VAL_49:.*]] = memref.load %[[VAL_26]]{{\[}}%[[VAL_46]]] : memref<?xf64>
 // CHECK:                 %[[VAL_50:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_42]]] : memref<?xf64>
-// CHECK:                 %[[VAL_51:.*]] = mulf %[[VAL_49]], %[[VAL_50]] : f64
-// CHECK:                 %[[VAL_52:.*]] = addf %[[VAL_43]], %[[VAL_51]] : f64
+// CHECK:                 %[[VAL_51:.*]] = arith.mulf %[[VAL_49]], %[[VAL_50]] : f64
+// CHECK:                 %[[VAL_52:.*]] = arith.addf %[[VAL_43]], %[[VAL_51]] : f64
 // CHECK:                 scf.yield %[[VAL_52]], %[[VAL_5]] : f64, i1
 // CHECK:               } else {
 // CHECK:                 scf.yield %[[VAL_43]], %[[VAL_44]] : f64, i1
@@ -73,7 +73,7 @@
 // CHECK:             %[[VAL_54:.*]] = scf.if %[[VAL_55:.*]]#1 -> (index) {
 // CHECK:               memref.store %[[VAL_35]], %[[VAL_22]]{{\[}}%[[VAL_34]]] : memref<?xi64>
 // CHECK:               memref.store %[[VAL_55]]#0, %[[VAL_23]]{{\[}}%[[VAL_34]]] : memref<?xf64>
-// CHECK:               %[[VAL_56:.*]] = addi %[[VAL_34]], %[[VAL_4]] : index
+// CHECK:               %[[VAL_56:.*]] = arith.addi %[[VAL_34]], %[[VAL_4]] : index
 // CHECK:               scf.yield %[[VAL_56]] : index
 // CHECK:             } else {
 // CHECK:               scf.yield %[[VAL_34]] : index

--- a/mlir_graphblas/src/test/GraphBLAS/opt_matrix_multiply_reduce.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/opt_matrix_multiply_reduce.mlir
@@ -16,46 +16,46 @@
 // CHECK-LABEL:   func @fuse_adjacent(
 // CHECK-SAME:                        %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                        %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> f64 {
-// CHECK:           %[[VAL_2:.*]] = constant 0.000000e+00 : f64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK:           %[[VAL_3:.*]] = graphblas.matrix_multiply_reduce_to_scalar_generic %[[VAL_0]], %[[VAL_1]] {mask_complement = false} : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) to f64  {
 // CHECK:             graphblas.yield add_identity %[[VAL_2]] : f64
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_4:.*]]: f64, %[[VAL_5:.*]]: f64):
-// CHECK:             %[[VAL_6:.*]] = addf %[[VAL_4]], %[[VAL_5]] : f64
+// CHECK:             %[[VAL_6:.*]] = arith.addf %[[VAL_4]], %[[VAL_5]] : f64
 // CHECK:             graphblas.yield add %[[VAL_6]] : f64
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_7:.*]]: f64, %[[VAL_8:.*]]: f64):
-// CHECK:             %[[VAL_9:.*]] = mulf %[[VAL_7]], %[[VAL_8]] : f64
+// CHECK:             %[[VAL_9:.*]] = arith.mulf %[[VAL_7]], %[[VAL_8]] : f64
 // CHECK:             graphblas.yield mult %[[VAL_9]] : f64
 // CHECK:           },  {
 // CHECK:             graphblas.yield agg_identity %[[VAL_2]] : f64
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_10:.*]]: f64, %[[VAL_11:.*]]: f64):
-// CHECK:             %[[VAL_12:.*]] = addf %[[VAL_10]], %[[VAL_11]] : f64
+// CHECK:             %[[VAL_12:.*]] = arith.addf %[[VAL_10]], %[[VAL_11]] : f64
 // CHECK:             graphblas.yield agg %[[VAL_12]] : f64
 // CHECK:           }
 // CHECK:           return %[[VAL_3]] : f64
 // CHECK:         }
 func @fuse_adjacent(%A: tensor<?x?xf64, #CSR64>, %B: tensor<?x?xf64, #CSC64>) -> f64 {
-    %cst = constant 0.000000e+00 : f64
+    %cst = arith.constant 0.000000e+00 : f64
     %C = graphblas.matrix_multiply_generic %A, %B {mask_complement = false} : (tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSC64>) to tensor<?x?xf64, #CSR64> {
         ^bb0:
-            %identity = constant 0.0 : f64
+            %identity = arith.constant 0.0 : f64
             graphblas.yield add_identity %identity : f64
     },{
         ^bb0(%add_a: f64, %add_b: f64):
-            %add_result = std.addf %add_a, %add_b : f64
+            %add_result = arith.addf %add_a, %add_b : f64
             graphblas.yield add %add_result : f64
     },{
         ^bb0(%mult_a: f64, %mult_b: f64):
-            %mult_result = std.mulf %mult_a, %mult_b : f64
+            %mult_result = arith.mulf %mult_a, %mult_b : f64
             graphblas.yield mult %mult_result : f64
     }
     %reduce_result = graphblas.reduce_to_scalar_generic %C : tensor<?x?xf64, #CSR64> to f64  {
       graphblas.yield agg_identity %cst : f64
     },  {
     ^bb0(%arg1: f64, %arg2: f64):
-      %1 = addf %arg1, %arg2 : f64
+      %1 = arith.addf %arg1, %arg2 : f64
       graphblas.yield agg %1 : f64
     }
     return %reduce_result : f64
@@ -65,46 +65,46 @@ func @fuse_adjacent(%A: tensor<?x?xf64, #CSR64>, %B: tensor<?x?xf64, #CSC64>) ->
 // CHECK-LABEL:   func @fuse_adjacent_with_mask(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                                  %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> f64 {
-// CHECK:           %[[VAL_2:.*]] = constant 0.000000e+00 : f64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK:           %[[VAL_3:.*]] = graphblas.matrix_multiply_reduce_to_scalar_generic %[[VAL_0]], %[[VAL_1]], %[[VAL_0]] {mask_complement = false} : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) to f64  {
 // CHECK:             graphblas.yield add_identity %[[VAL_2]] : f64
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_4:.*]]: f64, %[[VAL_5:.*]]: f64):
-// CHECK:             %[[VAL_6:.*]] = addf %[[VAL_4]], %[[VAL_5]] : f64
+// CHECK:             %[[VAL_6:.*]] = arith.addf %[[VAL_4]], %[[VAL_5]] : f64
 // CHECK:             graphblas.yield add %[[VAL_6]] : f64
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_7:.*]]: f64, %[[VAL_8:.*]]: f64):
-// CHECK:             %[[VAL_9:.*]] = mulf %[[VAL_7]], %[[VAL_8]] : f64
+// CHECK:             %[[VAL_9:.*]] = arith.mulf %[[VAL_7]], %[[VAL_8]] : f64
 // CHECK:             graphblas.yield mult %[[VAL_9]] : f64
 // CHECK:           },  {
 // CHECK:             graphblas.yield agg_identity %[[VAL_2]] : f64
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_10:.*]]: f64, %[[VAL_11:.*]]: f64):
-// CHECK:             %[[VAL_12:.*]] = addf %[[VAL_10]], %[[VAL_11]] : f64
+// CHECK:             %[[VAL_12:.*]] = arith.addf %[[VAL_10]], %[[VAL_11]] : f64
 // CHECK:             graphblas.yield agg %[[VAL_12]] : f64
 // CHECK:           }
 // CHECK:           return %[[VAL_3]] : f64
 // CHECK:         }
 func @fuse_adjacent_with_mask(%A: tensor<?x?xf64, #CSR64>, %B: tensor<?x?xf64, #CSC64>) -> f64 {
-    %cst = constant 0.000000e+00 : f64
+    %cst = arith.constant 0.000000e+00 : f64
     %C = graphblas.matrix_multiply_generic %A, %B, %A {mask_complement = false} : (tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSC64>, tensor<?x?xf64, #CSR64>) to tensor<?x?xf64, #CSR64> {
         ^bb0:
-            %identity = constant 0.0 : f64
+            %identity = arith.constant 0.0 : f64
             graphblas.yield add_identity %identity : f64
     },{
         ^bb0(%add_a: f64, %add_b: f64):
-            %add_result = std.addf %add_a, %add_b : f64
+            %add_result = arith.addf %add_a, %add_b : f64
             graphblas.yield add %add_result : f64
     },{
         ^bb0(%mult_a: f64, %mult_b: f64):
-            %mult_result = std.mulf %mult_a, %mult_b : f64
+            %mult_result = arith.mulf %mult_a, %mult_b : f64
             graphblas.yield mult %mult_result : f64
     }
     %reduce_result = graphblas.reduce_to_scalar_generic %C : tensor<?x?xf64, #CSR64> to f64  {
       graphblas.yield agg_identity %cst : f64
     },  {
     ^bb0(%arg1: f64, %arg2: f64):
-      %1 = addf %arg1, %arg2 : f64
+      %1 = arith.addf %arg1, %arg2 : f64
       graphblas.yield agg %1 : f64
     }
     return %reduce_result : f64
@@ -113,47 +113,47 @@ func @fuse_adjacent_with_mask(%A: tensor<?x?xf64, #CSR64>, %B: tensor<?x?xf64, #
 // CHECK-LABEL:   func @nofuse_multi_use(
 // CHECK-SAME:                           %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                           %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> (f64, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) {
-// CHECK:           %[[VAL_2:.*]] = constant 0.000000e+00 : f64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK:           %[[VAL_3:.*]] = graphblas.matrix_multiply_generic %[[VAL_0]], %[[VAL_1]], %[[VAL_0]] {mask_complement = false} : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) to tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:             graphblas.yield add_identity %[[VAL_2]] : f64
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_4:.*]]: f64, %[[VAL_5:.*]]: f64):
-// CHECK:             %[[VAL_6:.*]] = addf %[[VAL_4]], %[[VAL_5]] : f64
+// CHECK:             %[[VAL_6:.*]] = arith.addf %[[VAL_4]], %[[VAL_5]] : f64
 // CHECK:             graphblas.yield add %[[VAL_6]] : f64
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_7:.*]]: f64, %[[VAL_8:.*]]: f64):
-// CHECK:             %[[VAL_9:.*]] = mulf %[[VAL_7]], %[[VAL_8]] : f64
+// CHECK:             %[[VAL_9:.*]] = arith.mulf %[[VAL_7]], %[[VAL_8]] : f64
 // CHECK:             graphblas.yield mult %[[VAL_9]] : f64
 // CHECK:           }
 // CHECK:           %[[VAL_10:.*]] = graphblas.reduce_to_scalar_generic %[[VAL_11:.*]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to f64  {
 // CHECK:             graphblas.yield agg_identity %[[VAL_2]] : f64
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_12:.*]]: f64, %[[VAL_13:.*]]: f64):
-// CHECK:             %[[VAL_14:.*]] = addf %[[VAL_12]], %[[VAL_13]] : f64
+// CHECK:             %[[VAL_14:.*]] = arith.addf %[[VAL_12]], %[[VAL_13]] : f64
 // CHECK:             graphblas.yield agg %[[VAL_14]] : f64
 // CHECK:           }
 // CHECK:           return %[[VAL_10]], %[[VAL_3]] : f64, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
 // CHECK:         }
 func @nofuse_multi_use(%A: tensor<?x?xf64, #CSR64>, %B: tensor<?x?xf64, #CSC64>) -> (f64, tensor<?x?xf64, #CSR64>) {
-    %cst = constant 0.000000e+00 : f64
+    %cst = arith.constant 0.000000e+00 : f64
     %C = graphblas.matrix_multiply_generic %A, %B, %A {mask_complement = false} : (tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSC64>, tensor<?x?xf64, #CSR64>) to tensor<?x?xf64, #CSR64> {
         ^bb0:
-            %identity = constant 0.0 : f64
+            %identity = arith.constant 0.0 : f64
             graphblas.yield add_identity %identity : f64
     },{
         ^bb0(%add_a: f64, %add_b: f64):
-            %add_result = std.addf %add_a, %add_b : f64
+            %add_result = arith.addf %add_a, %add_b : f64
             graphblas.yield add %add_result : f64
     },{
         ^bb0(%mult_a: f64, %mult_b: f64):
-            %mult_result = std.mulf %mult_a, %mult_b : f64
+            %mult_result = arith.mulf %mult_a, %mult_b : f64
             graphblas.yield mult %mult_result : f64
     }
     %reduce_result = graphblas.reduce_to_scalar_generic %C : tensor<?x?xf64, #CSR64> to f64  {
       graphblas.yield agg_identity %cst : f64
     },  {
     ^bb0(%arg1: f64, %arg2: f64):
-      %1 = addf %arg1, %arg2 : f64
+      %1 = arith.addf %arg1, %arg2 : f64
       graphblas.yield agg %1 : f64
     }
     return %reduce_result, %C : f64, tensor<?x?xf64, #CSR64>

--- a/mlir_graphblas/src/test/GraphBLAS/opt_multiply_apply.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/opt_multiply_apply.mlir
@@ -19,20 +19,20 @@
 // CHECK-SAME:                        %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                        %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                        %[[VAL_2:.*]]: f64) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:           %[[VAL_3:.*]] = constant 0.000000e+00 : f64
+// CHECK:           %[[VAL_3:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK:           %[[VAL_4:.*]] = graphblas.matrix_multiply_generic %[[VAL_0]], %[[VAL_1]] {mask_complement = false} : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) to tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:             graphblas.yield add_identity %[[VAL_3]] : f64
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_5:.*]]: f64, %[[VAL_6:.*]]: f64):
-// CHECK:             %[[VAL_7:.*]] = addf %[[VAL_5]], %[[VAL_6]] : f64
+// CHECK:             %[[VAL_7:.*]] = arith.addf %[[VAL_5]], %[[VAL_6]] : f64
 // CHECK:             graphblas.yield add %[[VAL_7]] : f64
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_8:.*]]: f64, %[[VAL_9:.*]]: f64):
-// CHECK:             %[[VAL_10:.*]] = addf %[[VAL_8]], %[[VAL_9]] : f64
+// CHECK:             %[[VAL_10:.*]] = arith.addf %[[VAL_8]], %[[VAL_9]] : f64
 // CHECK:             graphblas.yield mult %[[VAL_10]] : f64
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_11:.*]]: f64):
-// CHECK:             %[[VAL_12:.*]] = cmpf olt, %[[VAL_11]], %[[VAL_2]] : f64
+// CHECK:             %[[VAL_12:.*]] = arith.cmpf olt, %[[VAL_11]], %[[VAL_2]] : f64
 // CHECK:             %[[VAL_13:.*]] = select %[[VAL_12]], %[[VAL_11]], %[[VAL_2]] : f64
 // CHECK:             graphblas.yield transform_out %[[VAL_13]] : f64
 // CHECK:           }
@@ -49,20 +49,20 @@ func @fuse_adjacent(%A: tensor<?x?xf64, #CSR64>, %B: tensor<?x?xf64, #CSC64>, %t
 // CHECK-SAME:                                               %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                                               %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                                               %[[VAL_2:.*]]: f64) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:           %[[VAL_3:.*]] = constant 0.000000e+00 : f64
+// CHECK:           %[[VAL_3:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK:           %[[VAL_4:.*]] = graphblas.matrix_multiply_generic %[[VAL_0]], %[[VAL_1]] {mask_complement = false} : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) to tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:             graphblas.yield add_identity %[[VAL_3]] : f64
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_5:.*]]: f64, %[[VAL_6:.*]]: f64):
-// CHECK:             %[[VAL_7:.*]] = addf %[[VAL_5]], %[[VAL_6]] : f64
+// CHECK:             %[[VAL_7:.*]] = arith.addf %[[VAL_5]], %[[VAL_6]] : f64
 // CHECK:             graphblas.yield add %[[VAL_7]] : f64
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_8:.*]]: f64, %[[VAL_9:.*]]: f64):
-// CHECK:             %[[VAL_10:.*]] = addf %[[VAL_8]], %[[VAL_9]] : f64
+// CHECK:             %[[VAL_10:.*]] = arith.addf %[[VAL_8]], %[[VAL_9]] : f64
 // CHECK:             graphblas.yield mult %[[VAL_10]] : f64
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_11:.*]]: f64):
-// CHECK:             %[[VAL_12:.*]] = divf %[[VAL_2]], %[[VAL_11]] : f64
+// CHECK:             %[[VAL_12:.*]] = arith.divf %[[VAL_2]], %[[VAL_11]] : f64
 // CHECK:             graphblas.yield transform_out %[[VAL_12]] : f64
 // CHECK:           }
 // CHECK:           return %[[VAL_13:.*]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -77,20 +77,20 @@ func @fuse_adjacent_left_thunk_div(%A: tensor<?x?xf64, #CSR64>, %B: tensor<?x?xf
 // CHECK-LABEL:   func @fuse_adjacent_with_mask(
 // CHECK-SAME:                                          %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                                          %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:           %[[VAL_2:.*]] = constant 0.000000e+00 : f64
-// CHECK:           %[[VAL_3:.*]] = constant 1.000000e+00 : f64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 0.000000e+00 : f64
+// CHECK:           %[[VAL_3:.*]] = arith.constant 1.000000e+00 : f64
 // CHECK:           %[[VAL_4:.*]] = graphblas.matrix_multiply_generic %[[VAL_0]], %[[VAL_1]], %[[VAL_0]] {mask_complement = false} : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) to tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:             graphblas.yield add_identity %[[VAL_2]] : f64
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_5:.*]]: f64, %[[VAL_6:.*]]: f64):
-// CHECK:             %[[VAL_7:.*]] = addf %[[VAL_5]], %[[VAL_6]] : f64
+// CHECK:             %[[VAL_7:.*]] = arith.addf %[[VAL_5]], %[[VAL_6]] : f64
 // CHECK:             graphblas.yield add %[[VAL_7]] : f64
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_8:.*]]: f64, %[[VAL_9:.*]]: f64):
 // CHECK:             graphblas.yield mult %[[VAL_3]] : f64
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_10:.*]]: f64):
-// CHECK:             %[[VAL_11:.*]] = divf %[[VAL_3]], %[[VAL_10]] : f64
+// CHECK:             %[[VAL_11:.*]] = arith.divf %[[VAL_3]], %[[VAL_10]] : f64
 // CHECK:             graphblas.yield transform_out %[[VAL_11]] : f64
 // CHECK:           }
 // CHECK:           return %[[VAL_12:.*]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -105,24 +105,24 @@ func @fuse_adjacent_with_mask(%A: tensor<?x?xf64, #CSR64>, %B: tensor<?x?xf64, #
 // CHECK-LABEL:   func @nofuse_multi_use(
 // CHECK-SAME:                                   %[[VAL_0:.*]]: tensor<?x?xi32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                                   %[[VAL_1:.*]]: tensor<?x?xi32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> (tensor<?x?xi32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xi32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) {
-// CHECK:           %[[VAL_2:.*]] = constant 0 : i32
-// CHECK:           %[[VAL_3:.*]] = constant 31 : i32
+// CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i32
+// CHECK:           %[[VAL_3:.*]] = arith.constant 31 : i32
 // CHECK:           %[[VAL_4:.*]] = graphblas.matrix_multiply_generic %[[VAL_0]], %[[VAL_1]] {mask_complement = false} : (tensor<?x?xi32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xi32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) to tensor<?x?xi32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:             graphblas.yield add_identity %[[VAL_2]] : i32
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32):
-// CHECK:             %[[VAL_7:.*]] = addi %[[VAL_5]], %[[VAL_6]] : i32
+// CHECK:             %[[VAL_7:.*]] = arith.addi %[[VAL_5]], %[[VAL_6]] : i32
 // CHECK:             graphblas.yield add %[[VAL_7]] : i32
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_8:.*]]: i32, %[[VAL_9:.*]]: i32):
-// CHECK:             %[[VAL_10:.*]] = addi %[[VAL_8]], %[[VAL_9]] : i32
+// CHECK:             %[[VAL_10:.*]] = arith.addi %[[VAL_8]], %[[VAL_9]] : i32
 // CHECK:             graphblas.yield mult %[[VAL_10]] : i32
 // CHECK:           }
 // CHECK:           %[[VAL_11:.*]] = graphblas.apply_generic %[[VAL_12:.*]] : tensor<?x?xi32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<?x?xi32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:           ^bb0(%[[VAL_13:.*]]: i32):
-// CHECK:             %[[VAL_14:.*]] = shift_right_signed %[[VAL_13]], %[[VAL_3]] : i32
-// CHECK:             %[[VAL_15:.*]] = addi %[[VAL_14]], %[[VAL_13]] : i32
-// CHECK:             %[[VAL_16:.*]] = xor %[[VAL_14]], %[[VAL_15]] : i32
+// CHECK:             %[[VAL_14:.*]] = arith.shrsi %[[VAL_13]], %[[VAL_3]] : i32
+// CHECK:             %[[VAL_15:.*]] = arith.addi %[[VAL_14]], %[[VAL_13]] : i32
+// CHECK:             %[[VAL_16:.*]] = arith.xori %[[VAL_14]], %[[VAL_15]] : i32
 // CHECK:             graphblas.yield transform_out %[[VAL_16]] : i32
 // CHECK:           }
 // CHECK:           return %[[VAL_17:.*]], %[[VAL_18:.*]] : tensor<?x?xi32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xi32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>

--- a/mlir_graphblas/src/test/GraphBLAS/print.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/print.mlir
@@ -23,9 +23,9 @@
 
 module {
   func @print_arbitrary_content() -> () {
-      %c99 = constant 99 : index
-      %0 = constant 1.3 : f32
-      %1 = constant 34 : i8
+      %c99 = arith.constant 99 : index
+      %0 = arith.constant 1.3 : f32
+      %1 = arith.constant 34 : i8
       // CHECK: first line : 1.3 1.3 1.3 1.3
       graphblas.print %0, %0, %0, %0 { strings = ["first line : "] } : f32, f32, f32, f32
       // CHECK: second line : 99 string_a  string_b  string_c 

--- a/mlir_graphblas/src/test/GraphBLAS/structuralize_apply.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/structuralize_apply.mlir
@@ -18,7 +18,7 @@ module {
 // CHECK:           func @apply_left_thunk_min_float_matrix(%[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, %[[VAL_1:.*]]: f64) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:             %[[VAL_2:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:             ^bb0(%[[VAL_3:.*]]: f64):
-// CHECK:               %[[VAL_4:.*]] = cmpf olt, %[[VAL_3]], %[[VAL_1]] : f64
+// CHECK:               %[[VAL_4:.*]] = arith.cmpf olt, %[[VAL_3]], %[[VAL_1]] : f64
 // CHECK:               %[[VAL_5:.*]] = select %[[VAL_4]], %[[VAL_3]], %[[VAL_1]] : f64
 // CHECK:               graphblas.yield transform_out %[[VAL_5]] : f64
 // CHECK:             }
@@ -33,7 +33,7 @@ module {
 // CHECK:           func @apply_left_thunk_min_float_vector(%[[VAL_7:.*]]: tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, %[[VAL_8:.*]]: f64) -> tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:             %[[VAL_9:.*]] = graphblas.apply_generic %[[VAL_7]] : tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:             ^bb0(%[[VAL_10:.*]]: f64):
-// CHECK:               %[[VAL_11:.*]] = cmpf olt, %[[VAL_10]], %[[VAL_8]] : f64
+// CHECK:               %[[VAL_11:.*]] = arith.cmpf olt, %[[VAL_10]], %[[VAL_8]] : f64
 // CHECK:               %[[VAL_12:.*]] = select %[[VAL_11]], %[[VAL_10]], %[[VAL_8]] : f64
 // CHECK:               graphblas.yield transform_out %[[VAL_12]] : f64
 // CHECK:             }
@@ -48,7 +48,7 @@ module {
 // CHECK:           func @apply_right_thunk_min_float_matrix(%[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, %[[VAL_1:.*]]: f64) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:             %[[VAL_2:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:             ^bb0(%[[VAL_3:.*]]: f64):
-// CHECK:               %[[VAL_4:.*]] = cmpf olt, %[[VAL_3]], %[[VAL_1]] : f64
+// CHECK:               %[[VAL_4:.*]] = arith.cmpf olt, %[[VAL_3]], %[[VAL_1]] : f64
 // CHECK:               %[[VAL_5:.*]] = select %[[VAL_4]], %[[VAL_3]], %[[VAL_1]] : f64
 // CHECK:               graphblas.yield transform_out %[[VAL_5]] : f64
 // CHECK:             }
@@ -63,7 +63,7 @@ module {
 // CHECK:           func @apply_right_thunk_min_float_vector(%[[VAL_7:.*]]: tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, %[[VAL_8:.*]]: f64) -> tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:             %[[VAL_9:.*]] = graphblas.apply_generic %[[VAL_7]] : tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:             ^bb0(%[[VAL_10:.*]]: f64):
-// CHECK:               %[[VAL_11:.*]] = cmpf olt, %[[VAL_10]], %[[VAL_8]] : f64
+// CHECK:               %[[VAL_11:.*]] = arith.cmpf olt, %[[VAL_10]], %[[VAL_8]] : f64
 // CHECK:               %[[VAL_12:.*]] = select %[[VAL_11]], %[[VAL_10]], %[[VAL_8]] : f64
 // CHECK:               graphblas.yield transform_out %[[VAL_12]] : f64
 // CHECK:             }
@@ -80,7 +80,7 @@ module {
 // CHECK-SAME:                                                    %[[VAL_1:.*]]: f64) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:           %[[VAL_2:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:           ^bb0(%[[VAL_3:.*]]: f64):
-// CHECK:             %[[VAL_4:.*]] = divf %[[VAL_1]], %[[VAL_3]] : f64
+// CHECK:             %[[VAL_4:.*]] = arith.divf %[[VAL_1]], %[[VAL_3]] : f64
 // CHECK:             graphblas.yield transform_out %[[VAL_4]] : f64
 // CHECK:           }
 // CHECK:           return %[[VAL_5:.*]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -96,7 +96,7 @@ module {
 // CHECK-SAME:                                                    %[[VAL_1:.*]]: f64) -> tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:           %[[VAL_2:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:           ^bb0(%[[VAL_3:.*]]: f64):
-// CHECK:             %[[VAL_4:.*]] = divf %[[VAL_1]], %[[VAL_3]] : f64
+// CHECK:             %[[VAL_4:.*]] = arith.divf %[[VAL_1]], %[[VAL_3]] : f64
 // CHECK:             graphblas.yield transform_out %[[VAL_4]] : f64
 // CHECK:           }
 // CHECK:           return %[[VAL_5:.*]] : tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -112,7 +112,7 @@ module {
 // CHECK-SAME:                                                     %[[VAL_1:.*]]: f64) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:           %[[VAL_2:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:           ^bb0(%[[VAL_3:.*]]: f64):
-// CHECK:             %[[VAL_4:.*]] = divf %[[VAL_3]], %[[VAL_1]] : f64
+// CHECK:             %[[VAL_4:.*]] = arith.divf %[[VAL_3]], %[[VAL_1]] : f64
 // CHECK:             graphblas.yield transform_out %[[VAL_4]] : f64
 // CHECK:           }
 // CHECK:           return %[[VAL_5:.*]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -128,7 +128,7 @@ module {
 // CHECK-SAME:                                                     %[[VAL_1:.*]]: f64) -> tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:           %[[VAL_2:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:           ^bb0(%[[VAL_3:.*]]: f64):
-// CHECK:             %[[VAL_4:.*]] = divf %[[VAL_3]], %[[VAL_1]] : f64
+// CHECK:             %[[VAL_4:.*]] = arith.divf %[[VAL_3]], %[[VAL_1]] : f64
 // CHECK:             graphblas.yield transform_out %[[VAL_4]] : f64
 // CHECK:           }
 // CHECK:           return %[[VAL_5:.*]] : tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -142,7 +142,7 @@ module {
 // CHECK:           func @apply_abs_float_matrix(%[[VAL_14:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:             %[[VAL_15:.*]] = graphblas.apply_generic %[[VAL_14]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:             ^bb0(%[[VAL_16:.*]]: f64):
-// CHECK:               %[[VAL_17:.*]] = absf %[[VAL_16]] : f64
+// CHECK:               %[[VAL_17:.*]] = math.abs %[[VAL_16]] : f64
 // CHECK:               graphblas.yield transform_out %[[VAL_17]] : f64
 // CHECK:             }
 // CHECK:             return %[[VAL_18:.*]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -156,7 +156,7 @@ module {
 // CHECK:           func @apply_abs_float_vector(%[[VAL_19:.*]]: tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:             %[[VAL_20:.*]] = graphblas.apply_generic %[[VAL_19]] : tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:             ^bb0(%[[VAL_21:.*]]: f64):
-// CHECK:               %[[VAL_22:.*]] = absf %[[VAL_21]] : f64
+// CHECK:               %[[VAL_22:.*]] = math.abs %[[VAL_21]] : f64
 // CHECK:               graphblas.yield transform_out %[[VAL_22]] : f64
 // CHECK:             }
 // CHECK:             return %[[VAL_23:.*]] : tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -169,10 +169,10 @@ module {
 
 // CHECK-LABEL:   func @apply_minv_float_matrix(
 // CHECK-SAME:                                          %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:           %[[VAL_1:.*]] = constant 1.000000e+00 : f64
+// CHECK:           %[[VAL_1:.*]] = arith.constant 1.000000e+00 : f64
 // CHECK:           %[[VAL_2:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:           ^bb0(%[[VAL_3:.*]]: f64):
-// CHECK:             %[[VAL_4:.*]] = divf %[[VAL_1]], %[[VAL_3]] : f64
+// CHECK:             %[[VAL_4:.*]] = arith.divf %[[VAL_1]], %[[VAL_3]] : f64
 // CHECK:             graphblas.yield transform_out %[[VAL_4]] : f64
 // CHECK:           }
 // CHECK:           return %[[VAL_5:.*]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -185,10 +185,10 @@ module {
     
 // CHECK-LABEL:   func @apply_minv_float_vector(
 // CHECK-SAME:                                          %[[VAL_0:.*]]: tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:           %[[VAL_1:.*]] = constant 1.000000e+00 : f64
+// CHECK:           %[[VAL_1:.*]] = arith.constant 1.000000e+00 : f64
 // CHECK:           %[[VAL_2:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:           ^bb0(%[[VAL_3:.*]]: f64):
-// CHECK:             %[[VAL_4:.*]] = divf %[[VAL_1]], %[[VAL_3]] : f64
+// CHECK:             %[[VAL_4:.*]] = arith.divf %[[VAL_1]], %[[VAL_3]] : f64
 // CHECK:             graphblas.yield transform_out %[[VAL_4]] : f64
 // CHECK:           }
 // CHECK:           return %[[VAL_5:.*]] : tensor<8xf64, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -206,7 +206,7 @@ module {
 // CHECK:           func @apply_left_thunk_min_int_matrix(%[[VAL_0:.*]]: tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, %[[VAL_1:.*]]: i8) -> tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:             %[[VAL_2:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:             ^bb0(%[[VAL_3:.*]]: i8):
-// CHECK:               %[[VAL_4:.*]] = cmpi slt, %[[VAL_3]], %[[VAL_1]] : i8
+// CHECK:               %[[VAL_4:.*]] = arith.cmpi slt, %[[VAL_3]], %[[VAL_1]] : i8
 // CHECK:               %[[VAL_5:.*]] = select %[[VAL_4]], %[[VAL_3]], %[[VAL_1]] : i8
 // CHECK:               graphblas.yield transform_out %[[VAL_5]] : i8
 // CHECK:             }
@@ -221,7 +221,7 @@ module {
 // CHECK:           func @apply_left_thunk_min_int_vector(%[[VAL_7:.*]]: tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, %[[VAL_8:.*]]: i8) -> tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:             %[[VAL_9:.*]] = graphblas.apply_generic %[[VAL_7]] : tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:             ^bb0(%[[VAL_10:.*]]: i8):
-// CHECK:               %[[VAL_11:.*]] = cmpi slt, %[[VAL_10]], %[[VAL_8]] : i8
+// CHECK:               %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_10]], %[[VAL_8]] : i8
 // CHECK:               %[[VAL_12:.*]] = select %[[VAL_11]], %[[VAL_10]], %[[VAL_8]] : i8
 // CHECK:               graphblas.yield transform_out %[[VAL_12]] : i8
 // CHECK:             }
@@ -236,7 +236,7 @@ module {
 // CHECK:           func @apply_right_thunk_min_int_matrix(%[[VAL_0:.*]]: tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, %[[VAL_1:.*]]: i8) -> tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:             %[[VAL_2:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:             ^bb0(%[[VAL_3:.*]]: i8):
-// CHECK:               %[[VAL_4:.*]] = cmpi slt, %[[VAL_3]], %[[VAL_1]] : i8
+// CHECK:               %[[VAL_4:.*]] = arith.cmpi slt, %[[VAL_3]], %[[VAL_1]] : i8
 // CHECK:               %[[VAL_5:.*]] = select %[[VAL_4]], %[[VAL_3]], %[[VAL_1]] : i8
 // CHECK:               graphblas.yield transform_out %[[VAL_5]] : i8
 // CHECK:             }
@@ -251,7 +251,7 @@ module {
 // CHECK:           func @apply_right_thunk_min_int_vector(%[[VAL_7:.*]]: tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>, %[[VAL_8:.*]]: i8) -> tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:             %[[VAL_9:.*]] = graphblas.apply_generic %[[VAL_7]] : tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:             ^bb0(%[[VAL_10:.*]]: i8):
-// CHECK:               %[[VAL_11:.*]] = cmpi slt, %[[VAL_10]], %[[VAL_8]] : i8
+// CHECK:               %[[VAL_11:.*]] = arith.cmpi slt, %[[VAL_10]], %[[VAL_8]] : i8
 // CHECK:               %[[VAL_12:.*]] = select %[[VAL_11]], %[[VAL_10]], %[[VAL_8]] : i8
 // CHECK:               graphblas.yield transform_out %[[VAL_12]] : i8
 // CHECK:             }
@@ -268,7 +268,7 @@ module {
 // CHECK-SAME:                                                  %[[VAL_1:.*]]: i8) -> tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:           %[[VAL_2:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:           ^bb0(%[[VAL_3:.*]]: i8):
-// CHECK:             %[[VAL_4:.*]] = divi_signed %[[VAL_1]], %[[VAL_3]] : i8
+// CHECK:             %[[VAL_4:.*]] = arith.divsi %[[VAL_1]], %[[VAL_3]] : i8
 // CHECK:             graphblas.yield transform_out %[[VAL_4]] : i8
 // CHECK:           }
 // CHECK:           return %[[VAL_5:.*]] : tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -284,7 +284,7 @@ module {
 // CHECK-SAME:                                                  %[[VAL_1:.*]]: i8) -> tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:           %[[VAL_2:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:           ^bb0(%[[VAL_3:.*]]: i8):
-// CHECK:             %[[VAL_4:.*]] = divi_signed %[[VAL_1]], %[[VAL_3]] : i8
+// CHECK:             %[[VAL_4:.*]] = arith.divsi %[[VAL_1]], %[[VAL_3]] : i8
 // CHECK:             graphblas.yield transform_out %[[VAL_4]] : i8
 // CHECK:           }
 // CHECK:           return %[[VAL_5:.*]] : tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -300,7 +300,7 @@ module {
 // CHECK-SAME:                                                   %[[VAL_1:.*]]: i8) -> tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:           %[[VAL_2:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:           ^bb0(%[[VAL_3:.*]]: i8):
-// CHECK:             %[[VAL_4:.*]] = divi_signed %[[VAL_3]], %[[VAL_1]] : i8
+// CHECK:             %[[VAL_4:.*]] = arith.divsi %[[VAL_3]], %[[VAL_1]] : i8
 // CHECK:             graphblas.yield transform_out %[[VAL_4]] : i8
 // CHECK:           }
 // CHECK:           return %[[VAL_5:.*]] : tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -316,7 +316,7 @@ module {
 // CHECK-SAME:                                                   %[[VAL_1:.*]]: i8) -> tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
 // CHECK:           %[[VAL_2:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:           ^bb0(%[[VAL_3:.*]]: i8):
-// CHECK:             %[[VAL_4:.*]] = divi_signed %[[VAL_3]], %[[VAL_1]] : i8
+// CHECK:             %[[VAL_4:.*]] = arith.divsi %[[VAL_3]], %[[VAL_1]] : i8
 // CHECK:             graphblas.yield transform_out %[[VAL_4]] : i8
 // CHECK:           }
 // CHECK:           return %[[VAL_5:.*]] : tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -328,12 +328,12 @@ module {
     }
 
 // CHECK:           func @apply_abs_int_matrix(%[[VAL_0:.*]]: tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:             %[[VAL_1:.*]] = constant 7 : i8
+// CHECK:             %[[VAL_1:.*]] = arith.constant 7 : i8
 // CHECK:             %[[VAL_2:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:             ^bb0(%[[VAL_3:.*]]: i8):
-// CHECK:               %[[VAL_4:.*]] = shift_right_signed %[[VAL_3]], %[[VAL_1]] : i8
-// CHECK:               %[[VAL_5:.*]] = addi %[[VAL_4]], %[[VAL_3]] : i8
-// CHECK:               %[[VAL_6:.*]] = xor %[[VAL_4]], %[[VAL_5]] : i8
+// CHECK:               %[[VAL_4:.*]] = arith.shrsi %[[VAL_3]], %[[VAL_1]] : i8
+// CHECK:               %[[VAL_5:.*]] = arith.addi %[[VAL_4]], %[[VAL_3]] : i8
+// CHECK:               %[[VAL_6:.*]] = arith.xori %[[VAL_4]], %[[VAL_5]] : i8
 // CHECK:               graphblas.yield transform_out %[[VAL_6]] : i8
 // CHECK:             }
 // CHECK:             return %[[VAL_7:.*]] : tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -345,12 +345,12 @@ module {
     }
 
 // CHECK:           func @apply_abs_int_vector(%[[VAL_8:.*]]: tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:             %[[VAL_9:.*]] = constant 7 : i8
+// CHECK:             %[[VAL_9:.*]] = arith.constant 7 : i8
 // CHECK:             %[[VAL_10:.*]] = graphblas.apply_generic %[[VAL_8]] : tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:             ^bb0(%[[VAL_11:.*]]: i8):
-// CHECK:               %[[VAL_12:.*]] = shift_right_signed %[[VAL_11]], %[[VAL_9]] : i8
-// CHECK:               %[[VAL_13:.*]] = addi %[[VAL_12]], %[[VAL_11]] : i8
-// CHECK:               %[[VAL_14:.*]] = xor %[[VAL_12]], %[[VAL_13]] : i8
+// CHECK:               %[[VAL_12:.*]] = arith.shrsi %[[VAL_11]], %[[VAL_9]] : i8
+// CHECK:               %[[VAL_13:.*]] = arith.addi %[[VAL_12]], %[[VAL_11]] : i8
+// CHECK:               %[[VAL_14:.*]] = arith.xori %[[VAL_12]], %[[VAL_13]] : i8
 // CHECK:               graphblas.yield transform_out %[[VAL_14]] : i8
 // CHECK:             }
 // CHECK:             return %[[VAL_15:.*]] : tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -363,16 +363,16 @@ module {
 
 // CHECK-LABEL:   func @apply_minv_int_matrix(
 // CHECK-SAME:                                        %[[VAL_0:.*]]: tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:           %[[VAL_1:.*]] = constant 7 : i8
-// CHECK:           %[[VAL_2:.*]] = constant 1 : i8
+// CHECK:           %[[VAL_1:.*]] = arith.constant 7 : i8
+// CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i8
 // CHECK:           %[[VAL_3:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:           ^bb0(%[[VAL_4:.*]]: i8):
-// CHECK:             %[[VAL_5:.*]] = shift_right_signed %[[VAL_4]], %[[VAL_1]] : i8
-// CHECK:             %[[VAL_6:.*]] = addi %[[VAL_5]], %[[VAL_4]] : i8
-// CHECK:             %[[VAL_7:.*]] = xor %[[VAL_5]], %[[VAL_6]] : i8
-// CHECK:             %[[VAL_8:.*]] = cmpi eq, %[[VAL_7]], %[[VAL_2]] : i8
-// CHECK:             %[[VAL_9:.*]] = sexti %[[VAL_8]] : i1 to i8
-// CHECK:             %[[VAL_10:.*]] = and %[[VAL_9]], %[[VAL_4]] : i8
+// CHECK:             %[[VAL_5:.*]] = arith.shrsi %[[VAL_4]], %[[VAL_1]] : i8
+// CHECK:             %[[VAL_6:.*]] = arith.addi %[[VAL_5]], %[[VAL_4]] : i8
+// CHECK:             %[[VAL_7:.*]] = arith.xori %[[VAL_5]], %[[VAL_6]] : i8
+// CHECK:             %[[VAL_8:.*]] = arith.cmpi eq, %[[VAL_7]], %[[VAL_2]] : i8
+// CHECK:             %[[VAL_9:.*]] = arith.extsi %[[VAL_8]] : i1 to i8
+// CHECK:             %[[VAL_10:.*]] = arith.andi %[[VAL_9]], %[[VAL_4]] : i8
 // CHECK:             graphblas.yield transform_out %[[VAL_10]] : i8
 // CHECK:           }
 // CHECK:           return %[[VAL_11:.*]] : tensor<?x?xi8, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>
@@ -385,16 +385,16 @@ module {
 
 // CHECK-LABEL:   func @apply_minv_int_vector(
 // CHECK-SAME:                                        %[[VAL_0:.*]]: tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:           %[[VAL_1:.*]] = constant 7 : i8
-// CHECK:           %[[VAL_2:.*]] = constant 1 : i8
+// CHECK:           %[[VAL_1:.*]] = arith.constant 7 : i8
+// CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i8
 // CHECK:           %[[VAL_3:.*]] = graphblas.apply_generic %[[VAL_0]] : tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>> to tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:           ^bb0(%[[VAL_4:.*]]: i8):
-// CHECK:             %[[VAL_5:.*]] = shift_right_signed %[[VAL_4]], %[[VAL_1]] : i8
-// CHECK:             %[[VAL_6:.*]] = addi %[[VAL_5]], %[[VAL_4]] : i8
-// CHECK:             %[[VAL_7:.*]] = xor %[[VAL_5]], %[[VAL_6]] : i8
-// CHECK:             %[[VAL_8:.*]] = cmpi eq, %[[VAL_7]], %[[VAL_2]] : i8
-// CHECK:             %[[VAL_9:.*]] = sexti %[[VAL_8]] : i1 to i8
-// CHECK:             %[[VAL_10:.*]] = and %[[VAL_9]], %[[VAL_4]] : i8
+// CHECK:             %[[VAL_5:.*]] = arith.shrsi %[[VAL_4]], %[[VAL_1]] : i8
+// CHECK:             %[[VAL_6:.*]] = arith.addi %[[VAL_5]], %[[VAL_4]] : i8
+// CHECK:             %[[VAL_7:.*]] = arith.xori %[[VAL_5]], %[[VAL_6]] : i8
+// CHECK:             %[[VAL_8:.*]] = arith.cmpi eq, %[[VAL_7]], %[[VAL_2]] : i8
+// CHECK:             %[[VAL_9:.*]] = arith.extsi %[[VAL_8]] : i1 to i8
+// CHECK:             %[[VAL_10:.*]] = arith.andi %[[VAL_9]], %[[VAL_4]] : i8
 // CHECK:             graphblas.yield transform_out %[[VAL_10]] : i8
 // CHECK:           }
 // CHECK:           return %[[VAL_11:.*]] : tensor<8xi8, #sparse_tensor.encoding<{ dimLevelType = [ "compressed" ], pointerBitWidth = 64, indexBitWidth = 64 }>>

--- a/mlir_graphblas/src/test/GraphBLAS/structuralize_matrix_multiply.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/structuralize_matrix_multiply.mlir
@@ -17,16 +17,16 @@
 // CHECK-LABEL:   func @matrix_multiply_plus_times(
 // CHECK-SAME:                                     %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>,
 // CHECK-SAME:                                     %[[VAL_1:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> {
-// CHECK:           %[[VAL_2:.*]] = constant 0.000000e+00 : f64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK:           %[[VAL_3:.*]] = graphblas.matrix_multiply_generic %[[VAL_0]], %[[VAL_1]] {mask_complement = false} : (tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>, tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d1, d0)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) to tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>  {
 // CHECK:             graphblas.yield add_identity %[[VAL_2]] : f64
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_5:.*]]: f64, %[[VAL_6:.*]]: f64):
-// CHECK:             %[[VAL_7:.*]] = addf %[[VAL_5]], %[[VAL_6]] : f64
+// CHECK:             %[[VAL_7:.*]] = arith.addf %[[VAL_5]], %[[VAL_6]] : f64
 // CHECK:             graphblas.yield add %[[VAL_7]] : f64
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_8:.*]]: f64, %[[VAL_9:.*]]: f64):
-// CHECK:             %[[VAL_10:.*]] = mulf %[[VAL_8]], %[[VAL_9]] : f64
+// CHECK:             %[[VAL_10:.*]] = arith.mulf %[[VAL_8]], %[[VAL_9]] : f64
 // CHECK:             graphblas.yield mult %[[VAL_10]] : f64
 // CHECK:           }
 // CHECK:           return %[[VAL_11:.*]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>

--- a/mlir_graphblas/src/test/GraphBLAS/structuralize_reduce_to_scalar.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/structuralize_reduce_to_scalar.mlir
@@ -11,12 +11,12 @@ module {
 
     // CHECK-LABEL:   func @matrix_reduce_to_scalar_f64(
     // CHECK-SAME:                                      %[[VAL_0:.*]]: tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>>) -> f64 {
-    // CHECK:           %[[VAL_1:.*]] = constant 0.000000e+00 : f64
+    // CHECK:           %[[VAL_1:.*]] = arith.constant 0.000000e+00 : f64
     // CHECK:           %[[VAL_2:.*]] = graphblas.reduce_to_scalar_generic %[[VAL_0]] : tensor<?x?xf64, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], dimOrdering = affine_map<(d0, d1) -> (d0, d1)>, pointerBitWidth = 64, indexBitWidth = 64 }>> to f64  {
     // CHECK:             graphblas.yield agg_identity %[[VAL_1]] : f64
     // CHECK:           },  {
     // CHECK:           ^bb0(%[[VAL_3:.*]]: f64, %[[VAL_4:.*]]: f64):
-    // CHECK:             %[[VAL_5:.*]] = addf %[[VAL_3]], %[[VAL_4]] : f64
+    // CHECK:             %[[VAL_5:.*]] = arith.addf %[[VAL_3]], %[[VAL_4]] : f64
     // CHECK:             graphblas.yield agg %[[VAL_5]] : f64
     // CHECK:           }
     // CHECK:           return %[[VAL_2]] : f64

--- a/mlir_graphblas/src/test/GraphBLAS/structuralize_semirings.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/structuralize_semirings.mlir
@@ -16,14 +16,14 @@
 
 // COM: TODO as part of https://github.com/metagraph-dev/mlir-graphblas/issues/66 , handle all posssible semirings here.
 
-// additive operations
+// arith.additive operations
 
 // CHECK-LABEL:   func @matrix_multiply_plus_X(
-// CHECK:           %[[VAL_2:.*]] = constant 0.000000e+00 : f64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK:             graphblas.yield add_identity %[[VAL_2]] : f64
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_5:.*]]: f64, %[[VAL_6:.*]]: f64):
-// CHECK:             %[[VAL_7:.*]] = addf %[[VAL_5]], %[[VAL_6]] : f64
+// CHECK:             %[[VAL_7:.*]] = arith.addf %[[VAL_5]], %[[VAL_6]] : f64
 // CHECK:             graphblas.yield add %[[VAL_7]] : f64
 // CHECK:           },  {
 func @matrix_multiply_plus_X(%a: tensor<?x?xf64, #CSR64>, %b: tensor<?x?xf64, #CSC64>) -> tensor<?x?xf64, #CSR64> {
@@ -32,11 +32,11 @@ func @matrix_multiply_plus_X(%a: tensor<?x?xf64, #CSR64>, %b: tensor<?x?xf64, #C
 }
 
 // CHECK-LABEL:   func @matrix_multiply_min_X(
-// CHECK:           %[[VAL_2:.*]] = constant 1.7976931348623157E+308 : f64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 1.7976931348623157E+308 : f64
 // CHECK:             graphblas.yield add_identity %[[VAL_2]] : f64
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_5:.*]]: f64, %[[VAL_6:.*]]: f64):
-// CHECK:             %[[VAL_7:.*]] = cmpf olt, %[[VAL_5]], %[[VAL_6]] : f64
+// CHECK:             %[[VAL_7:.*]] = arith.cmpf olt, %[[VAL_5]], %[[VAL_6]] : f64
 // CHECK:             %[[VAL_8:.*]] = select %[[VAL_7]], %[[VAL_5]], %[[VAL_6]] : f64
 // CHECK:             graphblas.yield add %[[VAL_8]] : f64
 // CHECK:           },  {
@@ -46,7 +46,7 @@ func @matrix_multiply_min_X(%a: tensor<?x?xf64, #CSR64>, %b: tensor<?x?xf64, #CS
 }
 
 // CHECK-LABEL:   func @matrix_multiply_any_X(
-// CHECK:           %[[VAL_2:.*]] = constant 0.000000e+00 : f64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK:             graphblas.yield add_identity %[[VAL_2]] : f64
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_5:.*]]: f64, %[[VAL_6:.*]]: f64):
@@ -60,7 +60,7 @@ func @matrix_multiply_any_X(%a: tensor<?x?xf64, #CSR64>, %b: tensor<?x?xf64, #CS
 // multiplicative operations
 
 // CHECK-LABEL:   func @matrix_multiply_X_pair(
-// CHECK:           %[[VAL_3:.*]] = constant 1.000000e+00 : f64
+// CHECK:           %[[VAL_3:.*]] = arith.constant 1.000000e+00 : f64
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_7:.*]]: f64, %[[VAL_8:.*]]: f64):
 // CHECK:             graphblas.yield mult %[[VAL_3]] : f64
@@ -73,7 +73,7 @@ func @matrix_multiply_X_pair(%a: tensor<?x?xf64, #CSR64>, %b: tensor<?x?xf64, #C
 // CHECK-LABEL:   func @matrix_multiply_X_times(
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_6:.*]]: f64, %[[VAL_7:.*]]: f64):
-// CHECK:             %[[VAL_8:.*]] = mulf %[[VAL_6]], %[[VAL_7]] : f64
+// CHECK:             %[[VAL_8:.*]] = arith.mulf %[[VAL_6]], %[[VAL_7]] : f64
 // CHECK:             graphblas.yield mult %[[VAL_8]] : f64
 // CHECK:           }
 func @matrix_multiply_X_times(%a: tensor<?x?xf64, #CSR64>, %b: tensor<?x?xf64, #CSC64>) -> tensor<?x?xf64, #CSR64> {
@@ -84,7 +84,7 @@ func @matrix_multiply_X_times(%a: tensor<?x?xf64, #CSR64>, %b: tensor<?x?xf64, #
 // CHECK-LABEL:   func @matrix_multiply_X_plus(
 // CHECK:           },  {
 // CHECK:           ^bb0(%[[VAL_6:.*]]: f64, %[[VAL_7:.*]]: f64):
-// CHECK:             %[[VAL_8:.*]] = addf %[[VAL_6]], %[[VAL_7]] : f64
+// CHECK:             %[[VAL_8:.*]] = arith.addf %[[VAL_6]], %[[VAL_7]] : f64
 // CHECK:             graphblas.yield mult %[[VAL_8]] : f64
 // CHECK:           }
 func @matrix_multiply_X_plus(%a: tensor<?x?xf64, #CSR64>, %b: tensor<?x?xf64, #CSC64>) -> tensor<?x?xf64, #CSR64> {

--- a/mlir_graphblas/tests/test_cli.py
+++ b/mlir_graphblas/tests/test_cli.py
@@ -19,7 +19,7 @@ func @scale_func(%input: tensor<?xf32>, %scale: f32) -> tensor<?xf32> {
      ins(%input: tensor<?xf32>)
      outs(%input: tensor<?xf32>) {
       ^bb(%a: f32, %s: f32):
-        %0 = mulf %a, %scale  : f32
+        %0 = arith.mulf %a, %scale  : f32
         linalg.yield %0 : f32
   } -> tensor<?xf32>
   return %0 : tensor<?xf32>
@@ -43,21 +43,21 @@ def test_apply_passes(cli_input):
         == """\
 module  {
   func @scale_func(%arg0: memref<?xf32>, %arg1: f32) -> memref<?xf32> {
-    %c0 = constant 0 : index
+    %c0 = arith.constant 0 : index
     %0 = memref.dim %arg0, %c0 : memref<?xf32>
     %1 = memref.alloc(%0) : memref<?xf32>
     %2 = memref.dim %arg0, %c0 : memref<?xf32>
-    %c0_0 = constant 0 : index
-    %c1 = constant 1 : index
+    %c0_0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
     br ^bb1(%c0_0 : index)
   ^bb1(%3: index):  // 2 preds: ^bb0, ^bb2
-    %4 = cmpi slt, %3, %2 : index
+    %4 = arith.cmpi slt, %3, %2 : index
     cond_br %4, ^bb2, ^bb3
   ^bb2:  // pred: ^bb1
     %5 = memref.load %arg0[%3] : memref<?xf32>
-    %6 = mulf %5, %arg1 : f32
+    %6 = arith.mulf %5, %arg1 : f32
     memref.store %6, %1[%3] : memref<?xf32>
-    %7 = addi %3, %c1 : index
+    %7 = arith.addi %3, %c1 : index
     br ^bb1(%7 : index)
   ^bb3:  // pred: ^bb1
     return %1 : memref<?xf32>

--- a/mlir_graphblas/tests/test_jit_engine.py
+++ b/mlir_graphblas/tests/test_jit_engine.py
@@ -24,7 +24,7 @@ SIMPLE_TEST_CASES = [  # elements are ( mlir_template, args, expected_result )
     #     ins(%arga, %argb: tensor<?x?x{mlir_type}>, tensor<?x?x{mlir_type}>)
     #    outs(%arga: tensor<?x?x{mlir_type}>) {{
     #      ^bb(%a: {mlir_type}, %b: {mlir_type}, %s: {mlir_type}):
-    #        %sum = {std_add} %a, %b : {mlir_type}
+    #        %sum = {arith_add} %a, %b : {mlir_type}
     #        linalg.yield %sum : {mlir_type}
     #  }} -> tensor<?x?x{mlir_type}>
     #  return %answer : tensor<?x?x{mlir_type}>
@@ -50,7 +50,7 @@ func @{func_name}(%arga: tensor<2x4x{mlir_type}>, %argb: tensor<2x4x{mlir_type}>
     ins(%arga, %argb: tensor<2x4x{mlir_type}>, tensor<2x4x{mlir_type}>)
    outs(%arga: tensor<2x4x{mlir_type}>) {{
      ^bb(%a: {mlir_type}, %b: {mlir_type}, %s: {mlir_type}):
-       %sum = {std_add} %a, %b : {mlir_type}
+       %sum = {arith_add} %a, %b : {mlir_type}
        linalg.yield %sum : {mlir_type}
  }} -> tensor<2x4x{mlir_type}>
  return %answer : tensor<2x4x{mlir_type}>
@@ -77,7 +77,7 @@ func @{func_name}(%arga: tensor<2x4x{mlir_type}>, %argb: tensor<2x4x{mlir_type}>
     #     ins(%arga, %argb: tensor<?x?x{mlir_type}>, tensor<2x4x{mlir_type}>)
     #    outs(%arga: tensor<?x?x{mlir_type}>) {{
     #      ^bb(%a: {mlir_type}, %b: {mlir_type}, %s: {mlir_type}):
-    #        %sum = {std_add} %a, %b : {mlir_type}
+    #        %sum = {arith_add} %a, %b : {mlir_type}
     #        linalg.yield %sum : {mlir_type}
     #  }} -> tensor<?x?x{mlir_type}>
     #  return %answer : tensor<?x?x{mlir_type}>
@@ -102,7 +102,7 @@ func @{func_name}(%arg_tensor: tensor<2x4x{mlir_type}>, %arg_scalar: {mlir_type}
     ins(%arg_tensor: tensor<2x4x{mlir_type}>)
    outs(%arg_tensor: tensor<2x4x{mlir_type}>) {{
      ^bb(%a: {mlir_type}, %s: {mlir_type}):
-       %sum = {std_add} %a, %arg_scalar : {mlir_type}
+       %sum = {arith_add} %a, %arg_scalar : {mlir_type}
        linalg.yield %sum : {mlir_type}
  }} -> tensor<2x4x{mlir_type}>
  return %answer : tensor<2x4x{mlir_type}>
@@ -128,8 +128,8 @@ func @{func_name}(%tensor_a: tensor<2x4x{mlir_type}>, %arg_scalar: {mlir_type}, 
     ins(%tensor_a, %tensor_b: tensor<2x4x{mlir_type}>, tensor<?x?x{mlir_type}>)
    outs(%tensor_a: tensor<2x4x{mlir_type}>) {{
      ^bb(%a: {mlir_type}, %b: {mlir_type}, %s: {mlir_type}):
-       %ab = {std_add} %a, %b : {mlir_type}
-       %sum = {std_add} %ab, %arg_scalar : {mlir_type}
+       %ab = {arith_add} %a, %b : {mlir_type}
+       %sum = {arith_add} %ab, %arg_scalar : {mlir_type}
        linalg.yield %sum : {mlir_type}
  }} -> tensor<2x4x{mlir_type}>
  return %answer : tensor<2x4x{mlir_type}>
@@ -142,7 +142,7 @@ func @{func_name}(%tensor_a: tensor<2x4x{mlir_type}>, %arg_scalar: {mlir_type}, 
     pytest.param(  # arbitrary size 1D tensor -> scalar
         """
 func @{func_name}(%arg0: tensor<?x{mlir_type}>) -> {mlir_type} {{
-  %c3 = constant 3 : index
+  %c3 = arith.constant 3 : index
   %ans = tensor.extract %arg0[%c3] : tensor<?x{mlir_type}>
   return %ans : {mlir_type}
 }}
@@ -154,9 +154,9 @@ func @{func_name}(%arg0: tensor<?x{mlir_type}>) -> {mlir_type} {{
     pytest.param(  # arbitrary size 1D tensor, scalar -> scalar
         """
 func @{func_name}(%tensor_arg: tensor<?x{mlir_type}>, %scalar_arg: {mlir_type}) -> {mlir_type} {{
-  %c3 = constant 3 : index
+  %c3 = arith.constant 3 : index
   %element_3 = tensor.extract %tensor_arg[%c3] : tensor<?x{mlir_type}>
-  %ans = {std_add} %element_3, %scalar_arg : {mlir_type}
+  %ans = {arith_add} %element_3, %scalar_arg : {mlir_type}
   return %ans : {mlir_type}
 }}
 """,
@@ -167,11 +167,11 @@ func @{func_name}(%tensor_arg: tensor<?x{mlir_type}>, %scalar_arg: {mlir_type}) 
     pytest.param(  # arbitrary size 1D tensor, arbitrary size 1D tensor -> scalar
         """
 func @{func_name}(%arg0: tensor<?x{mlir_type}>, %arg1: tensor<?x{mlir_type}>) -> {mlir_type} {{
-  %c3 = constant 3 : index
-  %c4 = constant 4 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
   %arg0_3 = tensor.extract %arg0[%c3] : tensor<?x{mlir_type}>
   %arg1_4 = tensor.extract %arg1[%c4] : tensor<?x{mlir_type}>
-  %ans = {std_add} %arg0_3, %arg1_4 : {mlir_type}
+  %ans = {arith_add} %arg0_3, %arg1_4 : {mlir_type}
   return %ans : {mlir_type}
 }}
 """,
@@ -182,12 +182,12 @@ func @{func_name}(%arg0: tensor<?x{mlir_type}>, %arg1: tensor<?x{mlir_type}>) ->
     pytest.param(  # scalar, arbitrary size 1D tensor, arbitrary size 1D tensor -> scalar
         """
 func @{func_name}(%scalar: {mlir_type}, %arg0: tensor<?x{mlir_type}>, %arg1: tensor<?x{mlir_type}>) -> {mlir_type} {{
-  %c3 = constant 3 : index
-  %c4 = constant 4 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
   %arg0_3 = tensor.extract %arg0[%c3] : tensor<?x{mlir_type}>
   %arg1_4 = tensor.extract %arg1[%c4] : tensor<?x{mlir_type}>
-  %tensor_element_result = {std_add} %arg0_3, %arg1_4 : {mlir_type}
-  %ans = {std_add} %tensor_element_result, %scalar : {mlir_type}
+  %tensor_element_result = {arith_add} %arg0_3, %arg1_4 : {mlir_type}
+  %ans = {arith_add} %tensor_element_result, %scalar : {mlir_type}
   return %ans : {mlir_type}
 }}
 """,
@@ -201,12 +201,12 @@ func @{func_name}(%scalar: {mlir_type}, %arg0: tensor<?x{mlir_type}>, %arg1: ten
 !mlir_tensor_type_alias = type tensor<?x!mlir_type_alias>
 
 func @{func_name}(%scalar: {mlir_type}, %arg0: tensor<?x!mlir_type_alias>, %arg1: !mlir_tensor_type_alias) -> {mlir_type} {{
-  %c3 = constant 3 : index
-  %c4 = constant 4 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
   %arg0_3 = tensor.extract %arg0[%c3] : tensor<?x{mlir_type}>
   %arg1_4 = tensor.extract %arg1[%c4] : tensor<?x{mlir_type}>
-  %tensor_element_result = {std_add} %arg0_3, %arg1_4 : {mlir_type}
-  %ans = {std_add} %tensor_element_result, %scalar : {mlir_type}
+  %tensor_element_result = {arith_add} %arg0_3, %arg1_4 : {mlir_type}
+  %ans = {arith_add} %tensor_element_result, %scalar : {mlir_type}
   return %ans : !mlir_type_alias
 }}
 """,
@@ -217,7 +217,7 @@ func @{func_name}(%scalar: {mlir_type}, %arg0: tensor<?x!mlir_type_alias>, %arg1
     pytest.param(  # partially fixed size tensor -> scalar
         """
 func @{func_name}(%arg_tensor: tensor<?x4x{mlir_type}>) -> {mlir_type} {{
-  %c0 = constant 0 : index
+  %c0 = arith.constant 0 : index
   %ans = tensor.extract %arg_tensor[%c0, %c0] : tensor<?x4x{mlir_type}>
   return %ans : {mlir_type}
 }}
@@ -239,9 +239,13 @@ def test_jit_engine_simple(engine, mlir_template, args, expected_result, mlir_ty
 
     std_operations_prefixes = ("add", "sub", "mul")
     if issubclass(np_type, np.integer):
-        std_operations = {f"std_{op}": f"{op}i" for op in std_operations_prefixes}
+        std_operations = {
+            f"arith_{op}": f"arith.{op}i" for op in std_operations_prefixes
+        }
     elif issubclass(np_type, np.floating):
-        std_operations = {f"std_{op}": f"{op}f" for op in std_operations_prefixes}
+        std_operations = {
+            f"arith_{op}": f"arith.{op}f" for op in std_operations_prefixes
+        }
     else:
         raise ValueError(f"No MLIR type for {np_type}.")
 
@@ -292,12 +296,12 @@ def test_jit_engine_sparse_tensor(engine, mlir_type):
 }}>
 
 func @{func_name}(%argA: tensor<10x20x30x{mlir_type}, #sparseTensor>) -> {mlir_type} {{
-  %out_tensor = constant dense<0.0> : tensor<{mlir_type}>
+  %out_tensor = arith.constant dense<0.0> : tensor<{mlir_type}>
   %reduction = linalg.generic #trait_sum_reduction
      ins(%argA: tensor<10x20x30x{mlir_type}, #sparseTensor>)
     outs(%out_tensor: tensor<{mlir_type}>) {{
       ^bb(%a: {mlir_type}, %x: {mlir_type}):
-        %0 = addf %x, %a : {mlir_type}
+        %0 = arith.addf %x, %a : {mlir_type}
         linalg.yield %0 : {mlir_type}
   }} -> tensor<{mlir_type}>
   %answer = tensor.extract %reduction[] : tensor<{mlir_type}>
@@ -340,7 +344,7 @@ Expected Result: {expected_result}
 def test_jit_engine_singleton_tuple_return_value(engine, mlir_type):
     mlir_text = f"""
 func @func_singleton_tuple_return_value_{mlir_type}() -> ({mlir_type}) {{
-    %result_0 = constant 12.34 : {mlir_type}
+    %result_0 = arith.constant 12.34 : {mlir_type}
     return %result_0 : {mlir_type}
 }}
 """
@@ -363,12 +367,12 @@ func @func_singleton_tuple_return_value_{mlir_type}() -> ({mlir_type}) {{
 def test_jit_engine_multiple_scalar_return_values(engine):
     mlir_text = """
 func @func_multiple_scalar_return_values() -> (i8, i16, i32, i64, f32, f64) {
-    %result_0 = constant 8 : i8
-    %result_1 = constant 16 : i16
-    %result_2 = constant 32 : i32
-    %result_3 = constant 64 : i64
-    %result_4 = constant 12.34 : f32
-    %result_5 = constant 5.6e200 : f64
+    %result_0 = arith.constant 8 : i8
+    %result_1 = arith.constant 16 : i16
+    %result_2 = arith.constant 32 : i32
+    %result_3 = arith.constant 64 : i64
+    %result_4 = arith.constant 12.34 : f32
+    %result_5 = arith.constant 5.6e200 : f64
     return %result_0, %result_1, %result_2, %result_3, %result_4, %result_5 : i8, i16, i32, i64, f32, f64
 }
 """
@@ -389,9 +393,9 @@ func @func_multiple_scalar_return_values() -> (i8, i16, i32, i64, f32, f64) {
 def test_jit_engine_multiple_dense_tensor_return_values(engine):
     mlir_text = """
 func @func_multiple_dense_tensor_return_values(%dummy_input_a: tensor<1xi8>, %dummy_input_b: i64) -> (f32, tensor<2x2xf32>, tensor<3x3xi8>) {
-    %result_0 = constant 12.34 : f32
-    %result_1 = constant dense<[[1.0, 2.0], [3.0, 4.0]]> : tensor<2x2xf32>
-    %result_2 = constant dense<[[1, 2, 3], [4, 5, 6], [7, 8, 9]]> : tensor<3x3xi8>
+    %result_0 = arith.constant 12.34 : f32
+    %result_1 = arith.constant dense<[[1.0, 2.0], [3.0, 4.0]]> : tensor<2x2xf32>
+    %result_2 = arith.constant dense<[[1, 2, 3], [4, 5, 6], [7, 8, 9]]> : tensor<3x3xi8>
     return %result_0, %result_1, %result_2 : f32, tensor<2x2xf32>, tensor<3x3xi8>
 }
 """
@@ -425,18 +429,18 @@ def test_jit_engine_sequence_of_scalars_input(engine, mlir_type):
     mlir_template, args, expected_result = (  # sequence of scalars -> scalar
         """
 func @{func_name}(%sequence: !llvm.ptr<{mlir_type}>) -> {mlir_type} {{
-  %czero = constant {zero_str} : {mlir_type}
+  %czero = arith.constant {zero_str} : {mlir_type}
 
   %sum_memref = memref.alloc() : memref<{mlir_type}>
   memref.store %czero, %sum_memref[] : memref<{mlir_type}>
   
-  %c0 = constant 0 : index
-  %c1 = constant 1 : index
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
 
-  %sequence_length = constant 5 : index // hard-coded length
+  %sequence_length = arith.constant 5 : index // hard-coded length
 
-  %ci0 = constant 0 : i64
-  %ci1 = constant 1 : i64
+  %ci0 = arith.constant 0 : i64
+  %ci1 = arith.constant 1 : i64
 
   scf.for %i = %c0 to %sequence_length step %c1 iter_args(%iter=%ci0) -> (i64) {{
   
@@ -447,10 +451,10 @@ func @{func_name}(%sequence: !llvm.ptr<{mlir_type}>) -> {mlir_type} {{
     %element = llvm.load %element_ptr : !llvm.ptr<{mlir_type}>
     
     %current_sum = memref.load %sum_memref[] : memref<{mlir_type}>
-    %updated_sum = {std_add} %current_sum, %element : {mlir_type}
+    %updated_sum = {arith_add} %current_sum, %element : {mlir_type}
     memref.store %updated_sum, %sum_memref[] : memref<{mlir_type}>
   
-    %plus_one = addi %iter, %ci1 : i64
+    %plus_one = arith.addi %iter, %ci1 : i64
     scf.yield %plus_one : i64
   }}
   
@@ -470,9 +474,13 @@ func @{func_name}(%sequence: !llvm.ptr<{mlir_type}>) -> {mlir_type} {{
 
     std_operations_prefixes = ("add", "sub", "mul")
     if issubclass(np_type, np.integer):
-        std_operations = {f"std_{op}": f"{op}i" for op in std_operations_prefixes}
+        std_operations = {
+            f"arith_{op}": f"arith.{op}i" for op in std_operations_prefixes
+        }
     elif issubclass(np_type, np.floating):
-        std_operations = {f"std_{op}": f"{op}f" for op in std_operations_prefixes}
+        std_operations = {
+            f"arith_{op}": f"arith.{op}f" for op in std_operations_prefixes
+        }
     else:
         raise ValueError(f"No MLIR type for {np_type}.")
 
@@ -527,13 +535,13 @@ func private @ptr8_to_matrix_csr_f64_p64i64(!llvm.ptr<i8>) -> tensor<2x3xf64, #s
 func @sparse_tensors_summation(%sequence: !llvm.ptr<!llvm.ptr<i8>>, %sequence_length: index) -> f64 {
   // Take an array of sparse 2x3 matrices
 
-  %output_storage = constant dense<0.0> : tensor<f64>
+  %output_storage = arith.constant dense<0.0> : tensor<f64>
 
-  %c0 = constant 0 : index
-  %c1 = constant 1 : index
-  %ci0 = constant 0 : i64
-  %ci1 = constant 1 : i64
-  %cf0 = constant 0.0 : f64
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %ci0 = arith.constant 0 : i64
+  %ci1 = arith.constant 1 : i64
+  %cf0 = arith.constant 0.0 : f64
 
   %sum_memref = memref.alloc() : memref<f64>
   memref.store %cf0, %sum_memref[] : memref<f64>
@@ -552,16 +560,16 @@ func @sparse_tensors_summation(%sequence: !llvm.ptr<!llvm.ptr<i8>>, %sequence_le
         ins(%sparse_tensor: tensor<2x3xf64, #sparseTensor>)
         outs(%output_storage: tensor<f64>) {
           ^bb(%a: f64, %x: f64):
-            %0 = addf %x, %a : f64
+            %0 = arith.addf %x, %a : f64
             linalg.yield %0 : f64
       } -> tensor<f64>
     %reduction_value = tensor.extract %reduction[] : tensor<f64>
 
     %current_sum = memref.load %sum_memref[] : memref<f64>
-    %updated_sum = addf %reduction_value, %current_sum : f64
+    %updated_sum = arith.addf %reduction_value, %current_sum : f64
     memref.store %updated_sum, %sum_memref[] : memref<f64>
 
-    %plus_one = addi %iter, %ci1 : i64
+    %plus_one = arith.addi %iter, %ci1 : i64
     scf.yield %plus_one : i64
   }
 
@@ -623,8 +631,8 @@ def test_jit_engine_zero_values(engine):
       func private @sparseDimSize(!llvm.ptr<i8>, index) -> index
 
       func @transpose(%output: !llvm.ptr<i8>, %input: !llvm.ptr<i8>) {
-        %c0 = constant 0 : index
-        %c1 = constant 1 : index
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
 
 
         %n_row = call @sparseDimSize(%input, %c0) : (!llvm.ptr<i8>, index) -> index
@@ -645,7 +653,7 @@ def test_jit_engine_zero_values(engine):
         scf.for %n = %c0 to %nnz step %c1 {
           %colA = memref.load %Aj[%n] : memref<?xindex>
           %colB = memref.load %Bp[%colA] : memref<?xindex>
-          %colB1 = addi %colB, %c1 : index
+          %colB1 = arith.addi %colB, %c1 : index
           memref.store %colB1, %Bp[%colA] : memref<?xindex>
         }
 
@@ -655,13 +663,13 @@ def test_jit_engine_zero_values(engine):
           %temp = memref.load %Bp[%col] : memref<?xindex>
           %cumsum = memref.load %Bp[%n_col] : memref<?xindex>
           memref.store %cumsum, %Bp[%col] : memref<?xindex>
-          %cumsum2 = addi %cumsum, %temp : index
+          %cumsum2 = arith.addi %cumsum, %temp : index
           memref.store %cumsum2, %Bp[%n_col] : memref<?xindex>
         }
 
         scf.for %row = %c0 to %n_row step %c1 {
           %j_start = memref.load %Ap[%row] : memref<?xindex>
-          %row_plus1 = addi %row, %c1 : index
+          %row_plus1 = arith.addi %row, %c1 : index
           %j_end = memref.load %Ap[%row_plus1] : memref<?xindex>
           scf.for %jj = %j_start to %j_end step %c1 {
             %col = memref.load %Aj[%jj] : memref<?xindex>
@@ -673,7 +681,7 @@ def test_jit_engine_zero_values(engine):
 
             // Bp[col]++
             %bp_inc = memref.load %Bp[%col] : memref<?xindex>
-            %bp_inc1 = addi %bp_inc, %c1 : index
+            %bp_inc1 = arith.addi %bp_inc, %c1 : index
             memref.store %bp_inc1, %Bp[%col]: memref<?xindex>
           }
         }
@@ -723,8 +731,8 @@ def test_jit_engine_skip(engine):
     # scf.if cannot be parsed by pymlir currently
     mlir_code = r"""
 func private @relu_scalar(%arg0: f32) -> f32 {
-  %cst = constant 0.000000e+00 : f32
-  %0 = cmpf uge, %arg0, %cst : f32
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = arith.cmpf uge, %arg0, %cst : f32
   %1 = scf.if %0 -> (f32) {
     scf.yield %arg0 : f32
   } else {

--- a/mlir_graphblas/tests/test_jit_engine_bad_inputs.py
+++ b/mlir_graphblas/tests/test_jit_engine_bad_inputs.py
@@ -29,7 +29,7 @@ func @many_inputs_constant_output(
    %arg_f32: f32,
    %arg_pointer: !llvm.ptr<i64>
 ) -> i32 {
- %c1234 = constant 1234 : i32
+ %c1234 = arith.constant 1234 : i32
  return %c1234 : i32
 }
 """

--- a/mlir_graphblas/tests/test_mlir_builder.py
+++ b/mlir_graphblas/tests/test_mlir_builder.py
@@ -186,11 +186,11 @@ def test_ir_builder_for_loop_float_iter(engine: MlirJitEngine, aliases: AliasMap
         "times_three", input_types=["f64"], return_types=["f64"], aliases=aliases
     )
     (input_var,) = ir_builder.inputs
-    zero_f64 = ir_builder.constant(0.0, "f64")
+    zero_f64 = ir_builder.arith.constant(0.0, "f64")
     total = ir_builder.new_var("f64")
 
     with ir_builder.for_loop(0, 3, iter_vars=[(total, zero_f64)]) as for_vars:
-        updated_sum = ir_builder.addf(input_var, total)
+        updated_sum = ir_builder.arith.addf(input_var, total)
         for_vars.yield_vars(updated_sum)
 
     result_var = for_vars.returned_variable[0]
@@ -230,11 +230,11 @@ def test_ir_builder_for_loop_user_specified_vars(engine: MlirJitEngine):
     (input_var,) = ir_builder.inputs
     total = ir_builder.new_var("i64")
 
-    lower_index_var = ir_builder.constant(lower_index, "index")
-    upper_index_var = ir_builder.constant(upper_index, "index")
-    delta_index_var = ir_builder.constant(delta_index, "index")
-    lower_i64_var = ir_builder.constant(lower_i64, "i64")
-    delta_i64_var = ir_builder.constant(delta_i64, "i64")
+    lower_index_var = ir_builder.arith.constant(lower_index, "index")
+    upper_index_var = ir_builder.arith.constant(upper_index, "index")
+    delta_index_var = ir_builder.arith.constant(delta_index, "index")
+    lower_i64_var = ir_builder.arith.constant(lower_i64, "i64")
+    delta_i64_var = ir_builder.arith.constant(delta_i64, "i64")
     iter_i64_var = ir_builder.new_var("i64")
 
     with ir_builder.for_loop(
@@ -247,21 +247,21 @@ def test_ir_builder_for_loop_user_specified_vars(engine: MlirJitEngine):
         assert upper_index_var == for_vars.upper_var_index
         assert delta_index_var == for_vars.step_var_index
         assert [iter_i64_var, total] == for_vars.iter_vars
-        prod_of_index_vars_0 = ir_builder.muli(
+        prod_of_index_vars_0 = ir_builder.arith.muli(
             for_vars.lower_var_index, for_vars.upper_var_index
         )
-        prod_of_index_vars_1 = ir_builder.muli(
+        prod_of_index_vars_1 = ir_builder.arith.muli(
             prod_of_index_vars_0, for_vars.step_var_index
         )
-        prod_of_index_vars = ir_builder.index_cast(prod_of_index_vars_1, "i64")
-        prod_of_i64_vars = ir_builder.muli(lower_i64_var, delta_i64_var)
-        iter_index_i64 = ir_builder.index_cast(for_vars.iter_var_index, "i64")
-        prod_of_iter_vars = ir_builder.muli(iter_index_i64, iter_i64_var)
-        updated_sum_0 = ir_builder.addi(total, prod_of_index_vars)
-        updated_sum_1 = ir_builder.addi(updated_sum_0, prod_of_i64_vars)
-        updated_sum = ir_builder.addi(updated_sum_1, prod_of_iter_vars)
+        prod_of_index_vars = ir_builder.arith.index_cast(prod_of_index_vars_1, "i64")
+        prod_of_i64_vars = ir_builder.arith.muli(lower_i64_var, delta_i64_var)
+        iter_index_i64 = ir_builder.arith.index_cast(for_vars.iter_var_index, "i64")
+        prod_of_iter_vars = ir_builder.arith.muli(iter_index_i64, iter_i64_var)
+        updated_sum_0 = ir_builder.arith.addi(total, prod_of_index_vars)
+        updated_sum_1 = ir_builder.arith.addi(updated_sum_0, prod_of_i64_vars)
+        updated_sum = ir_builder.arith.addi(updated_sum_1, prod_of_iter_vars)
 
-        incremented_iter_i64_var = ir_builder.addi(iter_i64_var, delta_i64_var)
+        incremented_iter_i64_var = ir_builder.arith.addi(iter_i64_var, delta_i64_var)
         for_vars.yield_vars(incremented_iter_i64_var, updated_sum)
 
     result_var = for_vars.returned_variable[1]
@@ -431,8 +431,8 @@ def test_ir_gt_thunk(engine: MlirJitEngine, aliases: AliasMap):
         aliases=aliases,
     )
     M, threshold = ir_builder.inputs
-    twelve_scalar = ir_builder.constant(12, "f64")
-    thirty_four_scalar = ir_builder.constant(34, "f64")
+    twelve_scalar = ir_builder.arith.constant(12, "f64")
+    thirty_four_scalar = ir_builder.arith.constant(34, "f64")
     M2 = ir_builder.graphblas.apply(M, "div", left=twelve_scalar)
     M3 = ir_builder.graphblas.apply(M2, "div", right=thirty_four_scalar)
     filtered = ir_builder.graphblas.select(M3, [threshold], ["gt"])
@@ -537,7 +537,7 @@ def test_ir_reduce_to_vector(
     reduced_rows = ir_builder.graphblas.reduce_to_vector(matrix, "plus", 1)
     reduced_columns = ir_builder.graphblas.reduce_to_vector(matrix, "count", 0)
 
-    zero_scalar = ir_builder.constant(0, mlir_type)
+    zero_scalar = ir_builder.arith.constant(0, mlir_type)
     reduced_rows_clamped = ir_builder.graphblas.apply(
         reduced_rows, "min", right=zero_scalar
     )

--- a/mlir_graphblas/tests/test_mlir_builder_bad_inputs.py
+++ b/mlir_graphblas/tests/test_mlir_builder_bad_inputs.py
@@ -12,14 +12,14 @@ def test_ir_builder_bad_input_multi_value_mlir_variable():
     ir_builder = MLIRFunctionBuilder("some_func", input_types=[], return_types=("i8",))
 
     iter_i8_var = ir_builder.new_var("i8")
-    lower_i8_var = ir_builder.constant(1, "i8")
+    lower_i8_var = ir_builder.arith.constant(1, "i8")
     iter_i64_var = ir_builder.new_var("i64")
-    lower_i64_var = ir_builder.constant(1, "i64")
+    lower_i64_var = ir_builder.arith.constant(1, "i64")
     with ir_builder.for_loop(
         0, 1, 1, iter_vars=[(iter_i8_var, lower_i8_var), (iter_i64_var, lower_i64_var)]
     ) as for_vars:
-        constant_i8_var = ir_builder.constant(8, "i8")
-        constant_i64_var = ir_builder.constant(64, "i64")
+        constant_i8_var = ir_builder.arith.constant(8, "i8")
+        constant_i64_var = ir_builder.arith.constant(64, "i64")
 
         # Raise when yielding too few values
         with pytest.raises(ValueError, match="Expected 2 yielded values, but got 1."):
@@ -41,26 +41,26 @@ def test_ir_builder_bad_input_multi_value_mlir_variable():
 
     # Raise when using multiple valued variable as operand
     assigned_to_i8_var = ir_builder.new_var("i8")
-    c1_i8_var = ir_builder.constant(1, "i8")
+    c1_i8_var = ir_builder.arith.constant(1, "i8")
     with pytest.raises(
         TypeError,
         match="Cannot access MLIRTuple .+ directly. Use index notation to access an element.",
     ):
         ir_builder.add_statement(
-            f"{assigned_to_i8_var.assign} = addi {c1_i8_var}, {for_vars.returned_variable} : i8"
+            f"{assigned_to_i8_var.assign} = arith.addi {c1_i8_var}, {for_vars.returned_variable} : i8"
         )
 
     with pytest.raises(
         TypeError,
         match="Cannot access MLIRTuple .+ directly. Use index notation to access an element.",
     ):
-        ir_builder.addi(c1_i8_var, for_vars.returned_variable)
+        ir_builder.arith.addi(c1_i8_var, for_vars.returned_variable)
 
     with pytest.raises(
         TypeError,
         match="Cannot access MLIRTuple .+ directly. Use index notation to access an element.",
     ):
-        ir_builder.addi(for_vars.returned_variable, c1_i8_var)
+        ir_builder.arith.addi(for_vars.returned_variable, c1_i8_var)
 
     # Raise when using multiple valued variable indexed via out-of-bound int index as operand
     with pytest.raises(IndexError):
@@ -77,9 +77,10 @@ def test_ir_builder_bad_input_multi_value_mlir_variable():
         ir_builder.return_vars(10)
 
     # Raise when returning value incompatible with return type.
-    c1_i64_var = ir_builder.constant(1, "i64")
+    c1_i64_var = ir_builder.arith.constant(1, "i64")
     with pytest.raises(
-        TypeError, match="Return type of MLIRVar\(name=.+, type=i64\) does not match i8"
+        TypeError,
+        match=r"Return type of MLIRVar\(name=.+, type=i64\) does not match i8",
     ):
         ir_builder.return_vars(c1_i64_var)
 


### PR DESCRIPTION
This updates to MLIR from last week.  Major change is the split of numerical operations from `std` dialect into the `arith` dialect and `math` dialect (just `std.absf` -> `math.abs`).