### PR TITLE
graphblas.cast

### DIFF
--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
@@ -163,6 +163,28 @@ def GraphBLAS_ConvertLayoutOp : GraphBLAS_Op<"convert_layout", [NoSideEffect]> {
     let verifier = [{ return ::verify(*this); }];
 }
 
+def GraphBLAS_CastOp : GraphBLAS_Op<"cast", [NoSideEffect]> {
+    let summary = "Changes graph storage parameters: dtype and bitwidths.";
+    let description = [{
+        Rewrite the contents of a sparse tensor to use a new dtype or a new pointer or index bitwidth.
+        Layout changes (ex. CSR->CSC) are not supported by this operation. Use `convert_layout` instead.
+
+        Example:
+        ```mlir
+          %a_int = graphblas.cast %a : tensor<?x?xf64, #CSR64> to tensor<?x?xi32, #CSR64>
+        ```
+    }];
+
+    let arguments = (ins GraphBlasMatrixOrVectorOperand:$input);
+    let results = (outs GraphBlasMatrixOrVectorOperand:$output);
+
+    let assemblyFormat = [{
+           $input attr-dict `:` type($input) `to` type($output)
+    }];
+
+    let verifier = [{ return ::verify(*this); }];
+}
+
 def GraphBLAS_TransposeOp : GraphBLAS_Op<"transpose", [NoSideEffect]> {
     let summary = "Transpose operation.";
     let description = [{

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOps.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOps.cpp
@@ -900,9 +900,6 @@ static LogicalResult verify(ConvertLayoutOp op) {
   if (errMsg)
     return op.emitError("result " + errMsg.getValue());
 
-  // TODO intelligently handle arbitrarily shaped tensors, i.e. tensors with
-  // shapes using "?"
-
   if (inputType.getElementType() != resultType.getElementType())
     return op.emitError(
         "Input and output tensors must have same element type.");
@@ -916,6 +913,50 @@ static LogicalResult verify(ConvertLayoutOp op) {
   errMsg = checkBitWidthMatch(inputType, resultType);
   if (errMsg)
     return op.emitError("Input and output " + errMsg.getValue());
+
+  return success();
+}
+
+static LogicalResult verify(CastOp op) {
+  RankedTensorType inputType = op.input().getType().cast<RankedTensorType>();
+  RankedTensorType resultType =
+      op.getResult().getType().cast<RankedTensorType>();
+
+  unsigned rank = inputType.getRank();
+  if (resultType.getRank() != rank)
+    return op.emitError("Input and output ranks must match.");
+
+  ArrayRef<int64_t> shape = inputType.getShape();
+  if (resultType.getShape() != shape)
+    return op.emitError("Input and output shapes must match.");
+
+  llvm::Optional<std::string> errMsg;
+  if (rank == 2) {
+    errMsg = checkMatrixEncoding(inputType, EITHER);
+    if (errMsg)
+      return op.emitError("operand " + errMsg.getValue());
+
+    // Result must be ordered the same as input
+    errMsg =
+        checkMatrixEncoding(resultType, hasRowOrdering(inputType) ? CSR : CSC);
+    if (errMsg)
+      return op.emitError("result " + errMsg.getValue());
+  } else {
+    errMsg = checkVectorEncoding(inputType);
+    if (errMsg)
+      return op.emitError("operand " + errMsg.getValue());
+
+    errMsg = checkVectorEncoding(resultType);
+    if (errMsg)
+      return op.emitError("operand " + errMsg.getValue());
+  }
+
+  // TODO: remove this check once we support bit width changes
+  errMsg = checkBitWidthMatch(inputType, resultType);
+  if (errMsg)
+    return op.emitError(
+        "Changing bit width is not yet supported. Input and output " +
+        errMsg.getValue());
 
   return success();
 }

--- a/mlir_graphblas/src/test/GraphBLAS/check_ops.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/check_ops.mlir
@@ -34,6 +34,18 @@ module {
 
 module {
 
+    // CHECK: func @cast_wrapper(%[[ARG0:.*]]: [[CSR_F_TYPE:tensor<.*->.*>]]) -> [[CSR_I_TYPE:tensor<.*->.*>]] {
+    func @cast_wrapper(%sparse_tensor: tensor<?x?xf64, #CSR64>) -> tensor<?x?xi64, #CSR64> {
+        // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.cast %[[ARG0]] : [[CSR_F_TYPE]] to [[CSR_I_TYPE]]
+        %answer = graphblas.cast %sparse_tensor : tensor<?x?xf64, #CSR64> to tensor<?x?xi64, #CSR64>
+        // CHECK-NEXT: return %[[ANSWER]] : [[CSR_I_TYPE]]
+        return %answer : tensor<?x?xi64, #CSR64>
+    }
+
+}
+
+module {
+
     // CHECK: func @transpose_wrapper(%[[ARG0:.*]]: [[CSR_TYPE:tensor<.*->.*>]]) -> [[CSC_TYPE:tensor<.*->.*>]] {
     func @transpose_wrapper(%sparse_tensor: tensor<2x3xf64, #CSR64>) -> tensor<3x2xf64, #CSC64> {
         // CHECK-NEXT: %[[ANSWER:.*]] = graphblas.transpose %[[ARG0]] : [[CSR_TYPE]] to [[CSC_TYPE]]

--- a/mlir_graphblas/src/test/GraphBLAS/invalid_cast.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/invalid_cast.mlir
@@ -1,0 +1,43 @@
+// RUN: graphblas-opt %s -split-input-file -verify-diagnostics
+
+#CSR64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "dense", "compressed" ],
+  dimOrdering = affine_map<(i,j) -> (i,j)>,
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+#CSC64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "dense", "compressed" ],
+  dimOrdering = affine_map<(i,j) -> (j,i)>,
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+module {
+    func @cast(%m: tensor<?x?xi64, #CSR64>) -> tensor<?x?xi64, #CSC64> {
+        %answer = graphblas.cast %m : tensor<?x?xi64, #CSR64> to tensor<?x?xi64, #CSC64> // expected-error {{result must have CSR compression.}}
+        return %answer : tensor<?x?xi64, #CSC64>
+    }
+}
+
+// -----
+
+#CV64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "compressed" ],
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+#CV32 = #sparse_tensor.encoding<{
+  dimLevelType = [ "compressed" ],
+  pointerBitWidth = 32,
+  indexBitWidth = 32
+}>
+
+module {
+    func @cast(%v: tensor<?xf64, #CV64>) -> tensor<?xf64, #CV32> {
+        %answer = graphblas.cast %v : tensor<?xf64, #CV64> to tensor<?xf64, #CV32> // expected-error {{Changing bit width is not yet supported. Input and output pointer bit widths do not match: 64!=32}}
+        return %answer : tensor<?xf64, #CV32>
+    }
+}


### PR DESCRIPTION
Allows conversion of dtype for sparse tensor.
The layout must remain unchanged.

This is written in MLIR, not a new function in SparseUtils.cpp. So the casting is based on whatever LLVM does.