### PR TITLE
Add masks to operations

### DIFF
--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASArrayUtils.h
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASArrayUtils.h
@@ -22,6 +22,12 @@ ValueRange buildMaskComplement(PatternRewriter &rewriter, Location loc,
                                Value fullSize, Value maskIndices,
                                Value maskStart, Value maskEnd);
 
+ValueRange sparsifyDensePointers(PatternRewriter &rewriter, Location loc,
+                                 Value size, Value pointers);
+
+ValueRange buildIndexOverlap(PatternRewriter &rewriter, Location loc,
+                             Value aSize, Value a, Value bSize, Value b);
+
 Value computeNumOverlaps(PatternRewriter &rewriter, Location loc, Value nk,
                          Value fixedIndices, Value fixedIndexStart,
                          Value fixedIndexEnd, Value iterPointers,

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASOps.td
@@ -116,7 +116,7 @@ def GraphBLAS_NumValsOp : GraphBLAS_Op<"num_vals", [NoSideEffect]> {
 def GraphBLAS_DupOp : GraphBLAS_Op<"dup", [NoSideEffect, AllTypesMatch<["input", "output"]>]> {
     let summary = "Returns a duplicate of the input sparse tensor.";
     let description = [{
-        Returns a duplicate copy of the input CSC matrix, CSR matrix, or sparse tensor.
+        Returns a duplicate copy of the input sparse tensor.
 
         Example:
         ```mlir
@@ -193,9 +193,6 @@ def GraphBLAS_TransposeOp : GraphBLAS_Op<"transpose", [NoSideEffect]> {
         The given tensor must have a CSR sparsity or a CSC sparsity.
         The output type must be CSR or CSC.
 
-        Note that the behavior of this op differs depending on the sparse
-        encoding of the specified output tensor type.
-
         Example:
         ```mlir
         %a = graphblas.transpose %sparse_tensor : tensor<?x?xf64, #CSR64> to tensor<?x?xf64, #CSC64>
@@ -218,11 +215,11 @@ def GraphBLAS_SelectOp : GraphBLAS_Op<"select", [NoSideEffect]> {
     let description = [{
         Returns a new sparse tensor with a subset of elements from the given tensor.
 
-        The elements included in the resulting sparse tensor vary depending on the selectors given
-        (one of "triu", "tril", "ge", "gt", or "probability").
+        An element is only included in the resulting sparse tensor if the selector returns true.
+        Selectors may be unary or binary, but must return boolean type.
 
-        Some selectors, e.g. "gt", require a thunk.
-        Some selectors, e.g. "probability" require a thunk and random number generator context.
+        Boolean selectors, e.g. "gt", require a thunk.
+        Some custom selectors, e.g. "probability" require a thunk and random number generator context.
 
         The given tensor must be a sparse vector or a matrix with CSR or CSC sparsity.
         The resulting sparse tensors will have the same encoding as the input tensor.
@@ -303,10 +300,10 @@ def GraphBLAS_ReduceToVectorOp : GraphBLAS_Op<"reduce_to_vector", [NoSideEffect]
         Reduces a CSR or CSC matrix to a vector according to the given aggregator and axis.
 
         The resulting sparse vector's element type varies according to the given aggregator.
-        The supported aggregators are "plus", "count", "argmin", and "argmax". Aggregating via
-        "plus" and "count" will cause the output's element type to match that of the input
-        tensor. Aggregating via "argmin" and "argmax" will cause the output's element to be a
-        64-bit integer.
+        All monoids are allowed as aggregators. Additional custom aggregators are "count",
+        "argmin", "argmax", "first", and "last". The output's element type is normally the
+        same as the input, but "count", "argmin", and "argmax" will cause the output's element
+        to be a 64-bit integer.
 
         If the axis attribute is 0, the input tensor will be reduced column-wise, so the
         resulting vector's size must be the number of columns in the input tensor.
@@ -314,19 +311,26 @@ def GraphBLAS_ReduceToVectorOp : GraphBLAS_Op<"reduce_to_vector", [NoSideEffect]
         If the axis attribute is 1, the input tensor will be reduced row-wise, so the resulting
         vector's size must be the number of rows in the input tensor.
 
+        A vector mask is allowed to limit the output.
+
         Example:
         ```mlir
         %vec1 = graphblas.reduce_to_vector %matrix_1 { aggregator = "plus", axis = 0 } : tensor<7x9xf16, #CSR64> to tensor<9xf16, #CV64>
         %vec2 = graphblas.reduce_to_vector %matrix_2 { aggregator = "count", axis = 1 } : tensor<7x9xf16, #CSR64> to tensor<7xf16, #CV64>
-        %vec3 = graphblas.reduce_to_vector %matrix_3 { aggregator = "argmin", axis = 1 } : tensor<7x9xf32, #CSR64> to tensor<7xi64, #CV64>
+        %vec3 = graphblas.reduce_to_vector %matrix_3, %mask { aggregator = "plus", axis = 1, mask_complement = false } : tensor<7x9xf32, #CSR64>, tensor<7xi64, #CV64> to tensor<7xi64, #CV64>
         ```
     }];
 
-    let arguments = (ins GraphBlasMatrixOperand:$input, StrAttr:$aggregator, I64Attr:$axis);
+    let arguments = (ins
+      GraphBlasMatrixOperand:$input,
+      Optional<GraphBlasVectorOperand>:$mask,
+      StrAttr:$aggregator,
+      I64Attr:$axis,
+      DefaultValuedAttr<BoolAttr, "false">:$mask_complement);
     let results = (outs GraphBlasVectorOperand:$output);
 
     let assemblyFormat = [{
-           $input attr-dict `:` type($input) `to` type($output)
+           $input (`,` $mask^)? attr-dict `:` type($input) (`,` type($mask)^)? `to` type($output)
     }];
 
     let verifier = [{ return ::verify(*this); }];
@@ -344,6 +348,8 @@ def GraphBLAS_ReduceToVectorGenericOp : GraphBLAS_Op<"reduce_to_vector_generic",
         If the axis attribute is 1, the input tensor will be reduced row-wise, so the resulting
         vector's size must be the number of rows in the input tensor.
 
+        A vector mask is allowed to limit the output.
+
         Example:
         ```mlir
         %vec1 = graphblas.reduce_to_vector %matrix_1 { axis = 0 } : tensor<7x9xf16, #CSR64> to tensor<9xf16, #CV64> {
@@ -353,7 +359,7 @@ def GraphBLAS_ReduceToVectorGenericOp : GraphBLAS_Op<"reduce_to_vector_generic",
               %result = arith.addf %a, %b : f16
               graphblas.yield agg %result : f16
           }
-        %vec2 = graphblas.reduce_to_vector %matrix_2 { axis = 1 } : tensor<7x9xi64, #CSR64> to tensor<7xi64, #CV64> {
+        %vec2 = graphblas.reduce_to_vector %matrix_2, %mask { axis = 1, mask_complement = true } : tensor<7x9xi64, #CSR64>, tensor<7xi64, #CV64> to tensor<7xi64, #CV64> {
               graphblas.yield agg_identity %ci0 : i64
           },  {
             ^bb0(%a : i64, %b : i64):
@@ -364,12 +370,16 @@ def GraphBLAS_ReduceToVectorGenericOp : GraphBLAS_Op<"reduce_to_vector_generic",
         ```
     }];
 
-    let arguments = (ins GraphBlasMatrixOperand:$input, I64Attr:$axis);
+    let arguments = (ins
+      GraphBlasMatrixOperand:$input,
+      Optional<GraphBlasVectorOperand>:$mask,
+      I64Attr:$axis,
+      DefaultValuedAttr<BoolAttr, "false">:$mask_complement);
     let results = (outs GraphBlasVectorOperand:$output);
     let regions = (region VariadicRegion<SizedRegion<1>>:$extensions);
 
     let assemblyFormat = [{
-           $input attr-dict `:` type($input) `to` type($output) $extensions
+           $input (`,` $mask^)? attr-dict `:` type($input) (`,` type($mask)^)? `to` type($output) $extensions
     }];
 
     let verifier = [{ return ::verify(*this); }];
@@ -382,12 +392,9 @@ def GraphBLAS_ReduceToScalarOp : GraphBLAS_Op<"reduce_to_scalar", [NoSideEffect]
         according to the given aggregator. Matrices must have a CSR sparsity or a CSC
         sparsity.
 
-        The resulting scalar's type will depend on the type of the input tensor.
-
-        The supported aggregators are "plus", "count", "argmin", and "argmax".
-
-        When using the aggregators "argmin" and "argmax", the output must be a 64-bit integer,
-        and the input type must be a vector.
+        The resulting scalar's type will depend on the type of the input tensor, except
+        for the cast of custom aggregators "count", "argmin", and "argmax". For these cases,
+        the output type is a 64-bit integer.
 
         Example:
         ```mlir
@@ -412,7 +419,6 @@ def GraphBLAS_ReduceToScalarGenericOp : GraphBLAS_Op<"reduce_to_scalar_generic",
         Reduces a sparse tensor to a scalar according to the given aggregator
         block.  If the tensor is a matrix, it must have a CSR sparsity or a CSC sparsity.
         The resulting scalar's type will depend on the type of the input tensor.
-        Only one aggregator block is allowed.
 
         Example:
         ```mlir
@@ -443,10 +449,7 @@ def GraphBLAS_ApplyOp : GraphBLAS_Op<"apply", [NoSideEffect]> {
     let description = [{
         Applies in an element-wise fashion the function indicated by the ``apply_operator``
         attribute to each element of the given sparse tensor. The operator can be unary or
-        binary. Binary operators require a thunk. The supported binary operators are "min",
-        "div", "first", and "second". Unary operators cannot take a thunk. The supported
-        unary operators are "abs", "minv" (i.e. multiplicative inverse or *1/x*),
-        "ainv" (i.e. additive inverse or *-x*), and "identity".
+        binary or the custom operator "identity". Binary operators require a thunk.
 
         The given sparse tensor must either be a CSR matrix, CSC matrix, or a sparse vector.
 
@@ -465,7 +468,6 @@ def GraphBLAS_ApplyOp : GraphBLAS_Op<"apply", [NoSideEffect]> {
         As another example, to divide 10 by each element of a sparse vector, use the
         following:
 
-
         ```mlir
         %thunk = constant 10 : i64
         %vector_answer = graphblas.apply %thunk, %sparse_vector { apply_operator = "div" } : (i64, tensor<?xi64, #CV64>) to tensor<?xi64, #CV64>
@@ -478,7 +480,6 @@ def GraphBLAS_ApplyOp : GraphBLAS_Op<"apply", [NoSideEffect]> {
         Note that using the "identity" operator does not create a copy of the input tensor.
 
         The shape of the output tensor will match that of the input tensor.
-
 
         Example:
         ```mlir
@@ -542,18 +543,15 @@ def GraphBLAS_MatrixMultiplyOp : GraphBLAS_Op<"matrix_multiply", [NoSideEffect]>
         mask. The structural mask specifies which values in the output are to be computed
         and thus must have the same shape as the expected output.
 
-        The semiring must be a string of the form "<ADD_NAME>_<MUL_NAME>", e.g. "plus_times".
-        The options for "<ADD_NAME>" are "plus", "any", and "min". The options for "<MUL_NAME>"
-        are "pair", "times", "plus", "firsti", "secondi", "overlapi", "first", and "second".
+        The semiring must be a string of the form "<ADD_NAME>_<MUL_NAME>", e.g. "plus_times" or "min_plus".
 
-        If the first input is a matrix, it must be CSR format. If the second input is a matrix,
-        it must be CSC format. Matrix times vector will return a vector. Vector times matrix
+        Matrix times vector will return a vector. Vector times matrix
         will return a vector. Matrix times matrix will return a CSR matrix. Vector times
         vector will return a scalar.
 
         The mask (if provided) must be the same format as the returned object. There's an
         optional boolean `mask_complement` attribute (which has a default value of `false`)
-        that will make the op use the complement of the mask.
+        that will use the structural complement of the mask.
 
         It should be noted that masks are not allowed for vector times vector multiplication.
 
@@ -568,7 +566,7 @@ def GraphBLAS_MatrixMultiplyOp : GraphBLAS_Op<"matrix_multiply", [NoSideEffect]>
         %answer = graphblas.matrix_multiply %mat, %vec, %mask { semiring = "any_first", mask_complement = true } : (tensor<?x?xf64, #CSR64>, tensor<?xf64, #CV64>, tensor<?xf64, #CV64>) to tensor<?xf64, #CV64>
         ```
         ```mlir
-        %answer = graphblas.matrix_multiply %vec, %mat { semiring = "min_second", mask_complement = true } : (tensor<?xf64, #CV64>, tensor<?x?xf64, #CSC64>) to tensor<?xf64, #CV64>
+        %answer = graphblas.matrix_multiply %vec, %mat { semiring = "min_second" } : (tensor<?xf64, #CV64>, tensor<?x?xf64, #CSC64>) to tensor<?xf64, #CV64>
         ```
         ```mlir
         %answer = graphblas.matrix_multiply %vecA, %vecB { semiring = "any_pair" } : (tensor<?xf64, #CV64>, tensor<?xf64, #CV64>) to tensor<?xf64, #CV64>
@@ -626,9 +624,8 @@ def GraphBLAS_MatrixMultiplyGenericOp : GraphBLAS_Op<"matrix_multiply_generic", 
         takes one argument and returns one value via the ``graphblas.yield`` terminator op (with
         the "kind" attribute set to "transform_out").
 
-        The mask (if provided) must be the same format as the returned object. There's an optional
-        boolean `mask_complement` attribute (which has a default value of `false`) that will make
-        the op use the complement of the mask.
+        The mask (if provided) must be the same format as the returned object. A required boolean
+        `mask_complement` attribute indicates whether to use the structural complement of the mask.
 
 
         Example:
@@ -720,22 +717,33 @@ def GraphBLAS_UnionOp : GraphBLAS_Op<"union", [NoSideEffect]> {
         The resulting sparse structure will be the union of the two input structures.
         When either object has a non-overlapping element, it is copied to the output.
         When both objects have an overlapping element in a cell, an operation combines the result.
-        The supported values for this operation are "plus", "times", "min", "max", "first",
-        and "second".
+
+        The allowable operators are monoids and the custom operators "first" and "second".
+
+        The mask (if provided) must be the same format as the returned object. There's an
+        optional boolean `mask_complement` attribute (which has a default value of `false`)
+        that will use the structural complement of the mask.
 
         Example:
         ```mlir
         %combined = graphblas.union %A, %B { union_operator = "plus" } : (
             tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSR64>) to tensor<?x?xf64, #CSR64>
+
+        %combined = graphblas.union %A, %B, %mask { union_operator = "plus", mask_complement = true } : (
+            tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSR64>, tensor<?x?xi32, #CSR64>) to tensor<?x?xf64, #CSR64>
         ```
     }];
 
-    let arguments = (ins GraphBlasMatrixOrVectorOperand:$a,
-                         GraphBlasMatrixOrVectorOperand:$b, StrAttr:$union_operator);
+    let arguments = (ins
+      GraphBlasMatrixOrVectorOperand:$a,
+      GraphBlasMatrixOrVectorOperand:$b,
+      Optional<GraphBlasMatrixOrVectorOperand>:$mask,
+      StrAttr:$union_operator,
+      DefaultValuedAttr<BoolAttr, "false">:$mask_complement);
     let results = (outs GraphBlasMatrixOrVectorOperand:$output);
 
     let assemblyFormat = [{
-           $a `,` $b attr-dict `:` `(` type($a) `,` type($b)  `)` `to` type($output)
+           $a `,` $b (`,` $mask^)? attr-dict `:` `(` type($a) `,` type($b) (`,` type($mask)^)? `)` `to` type($output)
     }];
 
     let verifier = [{ return ::verify(*this); }];
@@ -779,24 +787,34 @@ def GraphBLAS_IntersectOp : GraphBLAS_Op<"intersect", [NoSideEffect]> {
         Performs an element-wise intersection between two matrices or two vectors.
         The resulting sparse tensor will be the intersection of the two input structures.
         When both objects have an overlapping element in a cell, an operation
-        combines the result according to the given operator. The supported
-        values for the intersect operator are "plus", "minus", "times", "div",
-        "min", "max", "first", and "second".
+        combines the result according to the given operator. All binary operators
+        are supported.
+
+        The mask (if provided) must be the same format as the returned object. There's an
+        optional boolean `mask_complement` attribute (which has a default value of `false`)
+        that will use the structural complement of the mask.
 
         Example:
         ```mlir
         %combined = graphblas.intersect %A, %B { intersect_operator = "mult" } : (
             tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSR64>) to tensor<?x?xf64, #CSR64>
+
+        %combined = graphblas.intersect %A, %B, %mask { intersect_operator = "mult", mask_complement = true } : (
+            tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSR64>, tensor<?x?xi32, #CSR64>) to tensor<?x?xf64, #CSR64>
         ```
 
     }];
 
-    let arguments = (ins GraphBlasMatrixOrVectorOperand:$a,
-                         GraphBlasMatrixOrVectorOperand:$b, StrAttr:$intersect_operator);
+    let arguments = (ins
+      GraphBlasMatrixOrVectorOperand:$a,
+      GraphBlasMatrixOrVectorOperand:$b,
+      Optional<GraphBlasMatrixOrVectorOperand>:$mask,
+      StrAttr:$intersect_operator,
+      DefaultValuedAttr<BoolAttr, "false">:$mask_complement);
     let results = (outs GraphBlasMatrixOrVectorOperand:$output);
 
     let assemblyFormat = [{
-           $a `,` $b attr-dict `:` `(` type($a) `,` type($b)  `)` `to` type($output)
+           $a `,` $b (`,` $mask^)? attr-dict `:` `(` type($a) `,` type($b) (`,` type($mask)^)? `)` `to` type($output)
     }];
 
     let verifier = [{ return ::verify(*this); }];
@@ -838,11 +856,11 @@ def GraphBLAS_UpdateOp : GraphBLAS_Op<"update", []> {
     let description = [{
         Updates the output tensor based on the input and desired accumulation,
         mask, and replacement.  This returns zero values and modifies the output in
-        place.  The supported accumulate operators are "plus", "times", "min", and "max".
-        The given tensors must be sparse.
+        place.  The supported accumulate operators are "plus", "times", "min", "max",
+        "first", and "second". The given tensors must be sparse.
 
         There's an optional boolean *mask_complement* attribute (which has a default
-        value of *false*) that will make the op use the complement of the mask.
+        value of *false*) that will make the op use the structural complement of the mask.
 
         Example:
         ```mlir
@@ -912,6 +930,37 @@ def GraphBLAS_UpdateGenericOp : GraphBLAS_Op<"update_generic", []> {
 
     let assemblyFormat = [{
            $input `->` $output (`(` $mask^ `)`)? attr-dict `:` type($input) `->` type($output) (`(` type($mask)^ `)`)? $extensions
+    }];
+
+    let verifier = [{ return ::verify(*this); }];
+}
+
+def GraphBLAS_SelectMaskOp : GraphBLAS_Op<"select_mask", [NoSideEffect]> {
+    let summary = "Select part of a sparse tensor using a mask.";
+    let description = [{
+        Given a sparse tensor and a mask of the same dimensions, returns a
+        new sparse tensor with elements from the original tensor that have
+        an entry present in the mask (i.e. return the intersection of the
+        sparse structures).
+
+        There's an optional boolean *mask_complement* attribute (which has a default
+        value of *false*) that will make the op use the complement of the mask.
+
+        Example:
+        ```mlir
+        %vector_answer = graphblas.select_mask %vec, %msk : tensor<?xf64, #CV64>, tensor<?xi64, #CV64> to tensor<?xf64, #CV64>
+        %matrix_answer = grpahblas.select_mask %mat, %msk {mask_complement = true} : tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSR64> to tensor<?x?xf64, #CSR64>
+        ```
+    }];
+
+    let arguments = (ins
+     GraphBlasMatrixOrVectorOperand:$input,
+     GraphBlasMatrixOrVectorOperand:$mask,
+     DefaultValuedAttr<BoolAttr, "false">:$mask_complement);
+    let results = (outs GraphBlasMatrixOrVectorOperand:$output);
+
+    let assemblyFormat = [{
+            $input `,` $mask attr-dict `:` type($input) `,` type($mask) `to` type($output)
     }];
 
     let verifier = [{ return ::verify(*this); }];

--- a/mlir_graphblas/src/include/GraphBLAS/GraphBLASPasses.td
+++ b/mlir_graphblas/src/include/GraphBLAS/GraphBLASPasses.td
@@ -47,6 +47,7 @@ def GraphBLASStructuralize : Pass<"graphblas-structuralize", "ModuleOp"> {
   let summary = "TODO add documentation";
   let constructor = "mlir::createGraphBLASStructuralizePass()";
   let dependentDialects = [
+    "memref::MemRefDialect",
     "math::MathDialect",
     "arith::ArithmeticDialect",
     "scf::SCFDialect"

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASArrayUtils.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASArrayUtils.cpp
@@ -238,15 +238,15 @@ ValueRange buildIndexOverlap(PatternRewriter &rewriter, Location loc,
       TypeRange{indexType, indexType, indexType, int64Type, int64Type, boolType, boolType},
       ValueRange{c0, c0, c0, ci0, ci0, ctrue, ctrue});
   Block *before =
-      rewriter.createBlock(&whileLoop.before(), {},
+      rewriter.createBlock(&whileLoop.getBefore(), {},
                            TypeRange{indexType, indexType, indexType, int64Type,
                                      int64Type, boolType, boolType});
   Block *after =
-      rewriter.createBlock(&whileLoop.after(), {},
+      rewriter.createBlock(&whileLoop.getAfter(), {},
                            TypeRange{indexType, indexType, indexType, int64Type,
                                      int64Type, boolType, boolType});
   // "while" portion of the loop
-  rewriter.setInsertionPointToStart(&whileLoop.before().front());
+  rewriter.setInsertionPointToStart(&whileLoop.getBefore().front());
   Value posA = before->getArgument(0);
   Value posB = before->getArgument(1);
   Value validPosA = rewriter.create<arith::CmpIOp>(
@@ -258,7 +258,7 @@ ValueRange buildIndexOverlap(PatternRewriter &rewriter, Location loc,
   rewriter.create<scf::ConditionOp>(loc, continueLoop, before->getArguments());
 
   // "do" portion of while loop
-  rewriter.setInsertionPointToStart(&whileLoop.after().front());
+  rewriter.setInsertionPointToStart(&whileLoop.getAfter().front());
   posA = after->getArgument(0);
   posB = after->getArgument(1);
   Value posO = after->getArgument(2);

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASArrayUtils.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASArrayUtils.cpp
@@ -96,8 +96,8 @@ ValueRange buildMaskComplement(PatternRewriter &rewriter, Location loc,
         Value newMaskIndex =
             rewriter.create<arith::IndexCastOp>(loc, newMaskIndex64, indexType);
         rewriter.create<scf::YieldOp>(loc, newMaskIndex);
-        rewriter.setInsertionPointAfter(if_atEnd);
       }
+      rewriter.setInsertionPointAfter(if_atEnd);
       rewriter.create<scf::YieldOp>(
           loc, ValueRange{compPos, nextMaskPos, if_atEnd.getResult(0)});
     }
@@ -110,13 +110,244 @@ ValueRange buildMaskComplement(PatternRewriter &rewriter, Location loc,
       Value nextCompPos = rewriter.create<arith::AddIOp>(loc, compPos, c1);
       rewriter.create<scf::YieldOp>(
           loc, ValueRange{nextCompPos, maskPos, maskIndex});
-      rewriter.setInsertionPointAfter(if_match);
     }
+    rewriter.setInsertionPointAfter(if_match);
     rewriter.create<scf::YieldOp>(loc, if_match.getResults());
     rewriter.setInsertionPointAfter(loop);
   }
 
   return ValueRange{compIndices, compSize};
+}
+
+ValueRange sparsifyDensePointers(PatternRewriter &rewriter, Location loc,
+                                 Value size, Value pointers) {
+  // From a memref of dense pointers (length size+1),
+  // Returns:
+  // 1. a memref containing the indices of the non-empty rows (or columns)
+  // 2. the size of the memref
+
+  // Types used in this function
+  Type indexType = rewriter.getIndexType();
+  Type int64Type = rewriter.getIntegerType(64);
+  MemRefType memref1DI64Type = MemRefType::get({-1}, int64Type);
+
+  // Initial constants
+  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+
+  // Step 1: compute the number of non-empty rows
+  scf::ForOp nnzCountLoop =
+      rewriter.create<scf::ForOp>(loc, c0, size, c1, ValueRange{c0});
+  {
+    rewriter.setInsertionPointToStart(nnzCountLoop.getBody());
+    Value count = nnzCountLoop.getLoopBody().getArgument(1);
+    Value rowIndex = nnzCountLoop.getInductionVar();
+    Value nextRowIndex = rewriter.create<arith::AddIOp>(loc, rowIndex, c1);
+    Value firstPtr64 =
+        rewriter.create<memref::LoadOp>(loc, pointers, rowIndex);
+    Value secondPtr64 =
+        rewriter.create<memref::LoadOp>(loc, pointers, nextRowIndex);
+    Value rowIsEmpty = rewriter.create<arith::CmpIOp>(
+        loc, arith::CmpIPredicate::eq, firstPtr64, secondPtr64);
+    scf::IfOp ifRowIsEmptyBlock = rewriter.create<scf::IfOp>(
+        loc, TypeRange{indexType}, rowIsEmpty, true);
+    {
+      rewriter.setInsertionPointToStart(ifRowIsEmptyBlock.thenBlock());
+      rewriter.create<scf::YieldOp>(loc, ValueRange{count});
+    }
+    {
+      rewriter.setInsertionPointToStart(ifRowIsEmptyBlock.elseBlock());
+      Value count_plus1 = rewriter.create<arith::AddIOp>(loc, count, c1);
+      rewriter.create<scf::YieldOp>(loc, ValueRange{count_plus1});
+    }
+    rewriter.setInsertionPointAfter(ifRowIsEmptyBlock);
+    Value newCount = ifRowIsEmptyBlock.getResult(0);
+    rewriter.create<scf::YieldOp>(loc, ValueRange{newCount});
+    rewriter.setInsertionPointAfter(nnzCountLoop);
+  }
+  Value nnz = nnzCountLoop.getResult(0);
+
+  // Step 2: build the indices of the non-empty rows
+  Value indices =
+      rewriter.create<memref::AllocOp>(loc, memref1DI64Type, nnz);
+  scf::ForOp nnzIdxLoop =
+      rewriter.create<scf::ForOp>(loc, c0, size, c1, ValueRange{c0});
+  {
+    rewriter.setInsertionPointToStart(nnzIdxLoop.getBody());
+    Value pos = nnzIdxLoop.getLoopBody().getArgument(1);
+    Value rowIndex = nnzIdxLoop.getInductionVar();
+    Value nextRowIndex = rewriter.create<arith::AddIOp>(loc, rowIndex, c1);
+    Value firstPtr64 =
+        rewriter.create<memref::LoadOp>(loc, pointers, rowIndex);
+    Value secondPtr64 =
+        rewriter.create<memref::LoadOp>(loc, pointers, nextRowIndex);
+    Value rowIsEmpty = rewriter.create<arith::CmpIOp>(
+        loc, arith::CmpIPredicate::eq, firstPtr64, secondPtr64);
+    scf::IfOp ifRowIsEmptyBlock = rewriter.create<scf::IfOp>(
+        loc, TypeRange{indexType}, rowIsEmpty, true);
+    {
+      rewriter.setInsertionPointToStart(ifRowIsEmptyBlock.thenBlock());
+      rewriter.create<scf::YieldOp>(loc, ValueRange{pos});
+    }
+    {
+      rewriter.setInsertionPointToStart(ifRowIsEmptyBlock.elseBlock());
+      Value rowIndex64 = rewriter.create<arith::IndexCastOp>(loc, rowIndex, int64Type);
+      rewriter.create<memref::StoreOp>(loc, rowIndex64, indices, pos);
+      Value pos_plus1 = rewriter.create<arith::AddIOp>(loc, pos, c1);
+      rewriter.create<scf::YieldOp>(loc, ValueRange{pos_plus1});
+    }
+    rewriter.setInsertionPointAfter(ifRowIsEmptyBlock);
+    Value newPos = ifRowIsEmptyBlock.getResult(0);
+    rewriter.create<scf::YieldOp>(loc, ValueRange{newPos});
+    rewriter.setInsertionPointAfter(nnzIdxLoop);
+  }
+
+  return ValueRange{indices, nnz};
+}
+
+ValueRange buildIndexOverlap(PatternRewriter &rewriter, Location loc,
+                             Value aSize, Value a, Value bSize, Value b) {
+  // Takes two memrefs containing a list of indices and performs an intersection
+  // Returns:
+  // 1. a memref containing the overlapping indices
+  // 2. the size of the memref
+
+  // Types used in this function
+  Type boolType = rewriter.getIntegerType(1);
+  Type indexType = rewriter.getIndexType();
+  Type int64Type = rewriter.getIntegerType(64);
+  MemRefType memref1DI64Type = MemRefType::get({-1}, int64Type);
+
+  // Initial constants
+  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+  Value ci0 = rewriter.create<arith::ConstantIntOp>(loc, 0, int64Type);
+  Value cfalse = rewriter.create<arith::ConstantIntOp>(loc, 0, boolType);
+  Value ctrue = rewriter.create<arith::ConstantIntOp>(loc, 1, boolType);
+
+  // Allocate a memref matching the smaller size
+  // This will sacrifice memory for less computation
+  Value aIsSmaller = rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ult, aSize, bSize);
+  Value smallerSize = rewriter.create<SelectOp>(loc, aIsSmaller, aSize, bSize);
+  Value output = rewriter.create<memref::AllocOp>(loc, memref1DI64Type, smallerSize);
+
+  // Find matching indices
+  // While Loop (exit when either array is exhausted)
+  scf::WhileOp whileLoop = rewriter.create<scf::WhileOp>(
+      loc,
+      TypeRange{indexType, indexType, indexType, int64Type, int64Type, boolType, boolType},
+      ValueRange{c0, c0, c0, ci0, ci0, ctrue, ctrue});
+  Block *before =
+      rewriter.createBlock(&whileLoop.before(), {},
+                           TypeRange{indexType, indexType, indexType, int64Type,
+                                     int64Type, boolType, boolType});
+  Block *after =
+      rewriter.createBlock(&whileLoop.after(), {},
+                           TypeRange{indexType, indexType, indexType, int64Type,
+                                     int64Type, boolType, boolType});
+  // "while" portion of the loop
+  rewriter.setInsertionPointToStart(&whileLoop.before().front());
+  Value posA = before->getArgument(0);
+  Value posB = before->getArgument(1);
+  Value validPosA = rewriter.create<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::ult, posA, aSize);
+  Value validPosB = rewriter.create<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::ult, posB, bSize);
+  Value continueLoop =
+      rewriter.create<arith::AndIOp>(loc, validPosA, validPosB);
+  rewriter.create<scf::ConditionOp>(loc, continueLoop, before->getArguments());
+
+  // "do" portion of while loop
+  rewriter.setInsertionPointToStart(&whileLoop.after().front());
+  posA = after->getArgument(0);
+  posB = after->getArgument(1);
+  Value posO = after->getArgument(2);
+  Value idxA = after->getArgument(3);
+  Value idxB = after->getArgument(4);
+  Value needsUpdateA = after->getArgument(5);
+  Value needsUpdateB = after->getArgument(6);
+
+  // Update A's index based on flag
+  scf::IfOp if_updateA =
+      rewriter.create<scf::IfOp>(loc, int64Type, needsUpdateA, true);
+  {
+    rewriter.setInsertionPointToStart(if_updateA.thenBlock());
+    Value updatedIdxA = rewriter.create<memref::LoadOp>(loc, a, posA);
+    rewriter.create<scf::YieldOp>(loc, updatedIdxA);
+  }
+  {
+    rewriter.setInsertionPointToStart(if_updateA.elseBlock());
+    rewriter.create<scf::YieldOp>(loc, idxA);
+  }
+  rewriter.setInsertionPointAfter(if_updateA);
+
+  // Update B's index based on flag
+  scf::IfOp if_updateB =
+      rewriter.create<scf::IfOp>(loc, int64Type, needsUpdateB, true);
+  {
+    rewriter.setInsertionPointToStart(if_updateB.thenBlock());
+    Value updatedIdxB = rewriter.create<memref::LoadOp>(loc, b, posB);
+    rewriter.create<scf::YieldOp>(loc, updatedIdxB);
+  }
+  {
+    rewriter.setInsertionPointToStart(if_updateB.elseBlock());
+    rewriter.create<scf::YieldOp>(loc, idxB);
+  }
+  rewriter.setInsertionPointAfter(if_updateB);
+
+  Value newIdxA = if_updateA.getResult(0);
+  Value newIdxB = if_updateB.getResult(0);
+  Value idxA_lt_idxB = rewriter.create<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::ult, newIdxA, newIdxB);
+  Value idxA_gt_idxB = rewriter.create<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::ugt, newIdxA, newIdxB);
+  Value posAplus1 = rewriter.create<arith::AddIOp>(loc, posA, c1);
+  Value posBplus1 = rewriter.create<arith::AddIOp>(loc, posB, c1);
+
+  Value posOplus1 = rewriter.create<arith::AddIOp>(loc, posO, c1);
+
+  scf::IfOp if_onlyA = rewriter.create<scf::IfOp>(
+      loc, TypeRange{indexType, indexType, indexType, boolType, boolType},
+      idxA_lt_idxB, true);
+  {
+    rewriter.setInsertionPointToStart(if_onlyA.thenBlock());
+    rewriter.create<scf::YieldOp>(
+        loc, ValueRange{posAplus1, posB, posO, ctrue, cfalse});
+  }
+  {
+    rewriter.setInsertionPointToStart(if_onlyA.elseBlock());
+    scf::IfOp if_onlyB = rewriter.create<scf::IfOp>(
+        loc, TypeRange{indexType, indexType, indexType, boolType, boolType},
+        idxA_gt_idxB, true);
+    {
+      rewriter.setInsertionPointToStart(if_onlyB.thenBlock());
+      rewriter.create<scf::YieldOp>(
+          loc, ValueRange{posA, posBplus1, posO, cfalse, ctrue});
+    }
+    {
+      rewriter.setInsertionPointToStart(if_onlyB.elseBlock());
+      // At this point, we know newIdxA == newIdxB
+      rewriter.create<memref::StoreOp>(loc, newIdxA, output, posO);
+      rewriter.create<scf::YieldOp>(
+          loc, ValueRange{posAplus1, posBplus1, posOplus1, ctrue, ctrue});
+    }
+    rewriter.setInsertionPointAfter(if_onlyB);
+    rewriter.create<scf::YieldOp>(loc, if_onlyB.getResults());
+  }
+  rewriter.setInsertionPointAfter(if_onlyA);
+  Value newPosA = if_onlyA.getResult(0);
+  Value newPosB = if_onlyA.getResult(1);
+  Value newPosO = if_onlyA.getResult(2);
+  needsUpdateA = if_onlyA.getResult(3);
+  needsUpdateB = if_onlyA.getResult(4);
+
+  rewriter.create<scf::YieldOp>(loc, ValueRange{newPosA, newPosB, newPosO,
+                                                newIdxA, newIdxB,
+                                                needsUpdateA, needsUpdateB});
+  rewriter.setInsertionPointAfter(whileLoop);
+
+  Value finalPosO = whileLoop.getResult(2);
+  return ValueRange{output, finalPosO};
 }
 
 Value computeNumOverlaps(PatternRewriter &rewriter, Location loc, Value nk,

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASLowerPass.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASLowerPass.cpp
@@ -886,6 +886,8 @@ public:
       NamedAttrList attributes = {};
       attributes.append(StringRef("axis"),
                         rewriter.getIntegerAttr(i64Type, op.axis()));
+      attributes.append(StringRef("mask_complement"),
+                        rewriter.getBoolAttr(op.mask_complement()));
       graphblas::ReduceToVectorGenericOp newReduceOp =
           rewriter.create<graphblas::ReduceToVectorGenericOp>(
               loc, op->getResultTypes(), input, attributes.getAttrs(), 2);
@@ -915,7 +917,9 @@ public:
 
     // Inputs
     Value input = op.input();
+    Value mask = op.mask();
     int axis = op.axis();
+    bool maskComplement = op.mask_complement();
 
     // Types
     Type indexType = rewriter.getIndexType();
@@ -930,13 +934,41 @@ public:
     Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
     Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
 
+    // Sparse pointers
+    Value Ip = rewriter.create<sparse_tensor::ToPointersOp>(
+        loc, memrefPointerType, input, c1);
+    Value Ii = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memrefIndexType,
+                                                           input, c1);
+    Value Ix = rewriter.create<sparse_tensor::ToValuesOp>(loc, memrefIValueType,
+                                                          input);
+
     // Compute output sizes
     Value size;
     if (axis == 1)
       size = rewriter.create<graphblas::NumRowsOp>(loc, input);
     else
       size = rewriter.create<graphblas::NumColsOp>(loc, input);
-    Value nnz = computeNNZ(rewriter, loc, input, size);
+
+    // Compute sparse array of valid output indices
+    ValueRange sdpRet = sparsifyDensePointers(rewriter, loc, size, Ip);
+    Value sparsePointers = sdpRet[0];
+    Value nnz = sdpRet[1];
+    if (mask) {
+      Value Mi = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memrefIndexType, mask, c0);
+      Value mNnz = rewriter.create<graphblas::NumValsOp>(loc, mask);
+      if (maskComplement) {
+        ValueRange bmcRet = buildMaskComplement(rewriter, loc, size, Mi, c0, mNnz);
+        Mi = bmcRet[0];
+        mNnz = bmcRet[1];
+      }
+      Value prevSparsePointers = sparsePointers;
+      ValueRange bioRet = buildIndexOverlap(rewriter, loc, nnz, prevSparsePointers, mNnz, Mi);
+      sparsePointers = bioRet[0];
+      nnz = bioRet[1];
+      if (maskComplement)
+        rewriter.create<memref::DeallocOp>(loc, Mi);
+      rewriter.create<memref::DeallocOp>(loc, prevSparsePointers);
+    }
     Value nnz64 = rewriter.create<arith::IndexCastOp>(loc, nnz, i64Type);
 
     // Build output vector
@@ -945,14 +977,6 @@ public:
 
     callResizeIndex(rewriter, module, loc, output, c0, nnz);
     callResizeValues(rewriter, module, loc, output, nnz);
-
-    // Sparse pointers
-    Value Ip = rewriter.create<sparse_tensor::ToPointersOp>(
-        loc, memrefPointerType, input, c1);
-    Value Ii = rewriter.create<sparse_tensor::ToIndicesOp>(loc, memrefIndexType,
-                                                           input, c1);
-    Value Ix = rewriter.create<sparse_tensor::ToValuesOp>(loc, memrefIValueType,
-                                                          input);
 
     Value Op = rewriter.create<sparse_tensor::ToPointersOp>(
         loc, memrefPointerType, output, c0);
@@ -964,97 +988,43 @@ public:
     // Populate output
     rewriter.create<memref::StoreOp>(loc, nnz64, Op, c1);
 
+    // Loop over sparse array of valid output indices
     scf::ForOp reduceLoop =
-        rewriter.create<scf::ForOp>(loc, c0, size, c1, ValueRange{c0});
+        rewriter.create<scf::ForOp>(loc, c0, nnz, c1);
     {
       rewriter.setInsertionPointToStart(reduceLoop.getBody());
-      Value outputPos = reduceLoop.getLoopBody().getArgument(1);
-      Value rowIndex = reduceLoop.getInductionVar();
+      Value outputPos = reduceLoop.getInductionVar();
+      Value rowIndex64 = rewriter.create<memref::LoadOp>(loc, sparsePointers, outputPos);
+      Value rowIndex = rewriter.create<arith::IndexCastOp>(loc, rowIndex64, indexType);
       Value nextRowIndex =
           rewriter.create<arith::AddIOp>(loc, rowIndex, c1).getResult();
       Value ptr64 = rewriter.create<memref::LoadOp>(loc, Ip, rowIndex);
       Value nextPtr64 = rewriter.create<memref::LoadOp>(loc, Ip, nextRowIndex);
 
-      Value rowIsNonEmpty = rewriter.create<arith::CmpIOp>(
-          loc, arith::CmpIPredicate::ne, ptr64, nextPtr64);
-      scf::IfOp ifRowIsNonEmptyBlock = rewriter.create<scf::IfOp>(
-          loc, TypeRange{indexType}, rowIsNonEmpty, true);
-      rewriter.setInsertionPointToStart(ifRowIsNonEmptyBlock.thenBlock());
-      {
-        Value ptr = rewriter.create<arith::IndexCastOp>(loc, ptr64, indexType);
-        Value nextPtr =
-            rewriter.create<arith::IndexCastOp>(loc, nextPtr64, indexType);
+      // At this point, we know the row is not empty, so nextPtr64 > ptr64
+      Value ptr = rewriter.create<arith::IndexCastOp>(loc, ptr64, indexType);
+      Value nextPtr =
+          rewriter.create<arith::IndexCastOp>(loc, nextPtr64, indexType);
 
-        // Inject code from func
-        Value aggVal = nullptr;
-        LogicalResult funcResult =
-            func(op, rewriter, loc, aggVal, ptr, nextPtr, Ii, Ix);
-        if (funcResult.failed()) {
-          return funcResult;
-        }
-
-        rewriter.create<memref::StoreOp>(loc, aggVal, Ox, outputPos);
-        Value rowIndex64 =
-            rewriter.create<arith::IndexCastOp>(loc, rowIndex, i64Type);
-        rewriter.create<memref::StoreOp>(loc, rowIndex64, Oi, outputPos);
-        Value updatedOutputPos =
-            rewriter.create<arith::AddIOp>(loc, outputPos, c1);
-        rewriter.create<scf::YieldOp>(loc, ValueRange{updatedOutputPos});
+      // Inject code from func
+      Value aggVal = nullptr;
+      LogicalResult funcResult =
+          func(op, rewriter, loc, aggVal, ptr, nextPtr, Ii, Ix);
+      if (funcResult.failed()) {
+        return funcResult;
       }
-      rewriter.setInsertionPointToStart(ifRowIsNonEmptyBlock.elseBlock());
-      { rewriter.create<scf::YieldOp>(loc, ValueRange{outputPos}); }
-      rewriter.setInsertionPointAfter(ifRowIsNonEmptyBlock);
 
-      Value nextOutputPos = ifRowIsNonEmptyBlock.getResult(0);
-      rewriter.create<scf::YieldOp>(loc, ValueRange{nextOutputPos});
-
-      rewriter.setInsertionPointAfter(reduceLoop);
+      rewriter.create<memref::StoreOp>(loc, aggVal, Ox, outputPos);
+      rewriter.create<memref::StoreOp>(loc, rowIndex64, Oi, outputPos);
     }
-
+    rewriter.setInsertionPointAfter(reduceLoop);
+    rewriter.create<memref::DeallocOp>(loc, sparsePointers);
     rewriter.replaceOp(op, output);
 
     cleanupIntermediateTensor(rewriter, module, loc, output);
 
     return success();
   };
-
-  static Value computeNNZ(PatternRewriter &rewriter, Location loc, Value input,
-                          Value size) {
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-    Type indexType = rewriter.getIndexType();
-    RankedTensorType inputType = input.getType().cast<RankedTensorType>();
-    MemRefType memref1DPointerType = getMemrefPointerType(inputType);
-    Value pointers = rewriter.create<sparse_tensor::ToPointersOp>(
-        loc, memref1DPointerType, input, c1);
-    // Compute number of nonzero elements in result
-    scf::ForOp nnzLoop =
-        rewriter.create<scf::ForOp>(loc, c0, size, c1, ValueRange{c0});
-    {
-      rewriter.setInsertionPointToStart(nnzLoop.getBody());
-      Value count = nnzLoop.getLoopBody().getArgument(1);
-      Value rowIndex = nnzLoop.getInductionVar();
-      Value nextRowIndex = rewriter.create<arith::AddIOp>(loc, rowIndex, c1);
-      Value firstPtr64 =
-          rewriter.create<memref::LoadOp>(loc, pointers, rowIndex);
-      Value secondPtr64 =
-          rewriter.create<memref::LoadOp>(loc, pointers, nextRowIndex);
-      Value rowIsEmpty = rewriter.create<arith::CmpIOp>(
-          loc, arith::CmpIPredicate::eq, firstPtr64, secondPtr64);
-      scf::IfOp ifRowIsEmptyBlock = rewriter.create<scf::IfOp>(
-          loc, TypeRange{indexType}, rowIsEmpty, true);
-      rewriter.setInsertionPointToStart(ifRowIsEmptyBlock.thenBlock());
-      rewriter.create<scf::YieldOp>(loc, ValueRange{count});
-      rewriter.setInsertionPointToStart(ifRowIsEmptyBlock.elseBlock());
-      Value count_plus1 = rewriter.create<arith::AddIOp>(loc, count, c1);
-      rewriter.create<scf::YieldOp>(loc, ValueRange{count_plus1});
-      rewriter.setInsertionPointAfter(ifRowIsEmptyBlock);
-      Value newCount = ifRowIsEmptyBlock.getResult(0);
-      rewriter.create<scf::YieldOp>(loc, ValueRange{newCount});
-      rewriter.setInsertionPointAfter(nnzLoop);
-    }
-    return nnzLoop.getResult(0);
-  }
 
 private:
   static LogicalResult countBlock(graphblas::ReduceToVectorOp op,
@@ -2818,13 +2788,24 @@ public:
                                 PatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
 
-    Type valueType = op.a().getType().cast<RankedTensorType>().getElementType();
+    Value a = op.a();
+    Value b = op.b();
+    Value mask = op.mask();
+    Type valueType = a.getType().cast<RankedTensorType>().getElementType();
+
+    if (mask) {
+      NamedAttrList attributes = {};
+      attributes.append(StringRef("mask_complement"),
+                        rewriter.getBoolAttr(op.mask_complement()));
+      a = rewriter.create<graphblas::SelectMaskOp>(loc, a.getType(), ValueRange{a, mask}, attributes.getAttrs());
+      b = rewriter.create<graphblas::SelectMaskOp>(loc, b.getType(), ValueRange{b, mask}, attributes.getAttrs());
+    }
 
     // New op
     NamedAttrList attributes = {};
     graphblas::UnionGenericOp newUnionOp =
         rewriter.create<graphblas::UnionGenericOp>(loc, op->getResultTypes(),
-                                                   op.getOperands(),
+                                                   ValueRange{a, b},
                                                    attributes.getAttrs(), 1);
 
     if (failed(populateBinary(rewriter, loc, op.union_operator(), valueType,
@@ -2894,24 +2875,45 @@ public:
   LogicalResult matchAndRewrite(graphblas::IntersectOp op,
                                 PatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
+    Value a = op.a();
+    Value b = op.b();
+    Value mask = op.mask();
+    Type valueType = a.getType().cast<RankedTensorType>().getElementType();
+    StringRef opstr = op.intersect_operator();
 
-    Type valueType = op.a().getType().cast<RankedTensorType>().getElementType();
+    if (mask) {
+      NamedAttrList attributes = {};
+      attributes.append(StringRef("mask_complement"),
+                        rewriter.getBoolAttr(op.mask_complement()));
+      a = rewriter.create<graphblas::SelectMaskOp>(loc, a.getType(), ValueRange{a, mask}, attributes.getAttrs());
+      b = rewriter.create<graphblas::SelectMaskOp>(loc, b.getType(), ValueRange{b, mask}, attributes.getAttrs());
+    }
 
-    // New op
-    NamedAttrList attributes = {};
-    graphblas::IntersectGenericOp newIntersectOp =
-        rewriter.create<graphblas::IntersectGenericOp>(
-            loc, op->getResultTypes(), op.getOperands(), attributes.getAttrs(),
-            1);
+    // Special handling for "first" and "second"
+    if (opstr == "first") {
+      graphblas::SelectMaskOp newIntersectOp =
+          rewriter.create<graphblas::SelectMaskOp>(loc, op->getResultTypes(), ValueRange{a, b});
+      rewriter.replaceOp(op, newIntersectOp.getResult());
+    } else if (opstr == "second") {
+      graphblas::SelectMaskOp newIntersectOp =
+          rewriter.create<graphblas::SelectMaskOp>(loc, op->getResultTypes(), ValueRange{b, a});
+      rewriter.replaceOp(op, newIntersectOp.getResult());
+    } else {
+      // New op
+      NamedAttrList attributes = {};
+      graphblas::IntersectGenericOp newIntersectOp =
+          rewriter.create<graphblas::IntersectGenericOp>(
+              loc, op->getResultTypes(), ValueRange{a, b}, attributes.getAttrs(),
+              1);
 
-    if (failed(populateBinary(rewriter, loc, op.intersect_operator(), valueType,
-                              newIntersectOp.getRegions().slice(0, 1),
-                              graphblas::YieldKind::MULT)))
-      return failure();
+      if (failed(populateBinary(rewriter, loc, op.intersect_operator(), valueType,
+                                newIntersectOp.getRegions().slice(0, 1),
+                                graphblas::YieldKind::MULT)))
+        return failure();
 
-    rewriter.setInsertionPointAfter(newIntersectOp);
-
-    rewriter.replaceOp(op, newIntersectOp.getResult());
+      rewriter.setInsertionPointAfter(newIntersectOp);
+      rewriter.replaceOp(op, newIntersectOp.getResult());
+    }
 
     return success();
   };
@@ -3021,15 +3023,8 @@ public:
       if (replace) {
         // input -> output(mask) { replace }
 
-        // Step 1: apply the mask to the input
-        Value maskedInput = callEmptyLike(rewriter, module, loc, input);
-        computeEwise(rewriter, loc, module, input, mask, maskedInput, nullptr,
+        computeEwise(rewriter, loc, module, input, mask, output, nullptr,
                      maskBehavior);
-        // Step 2: swap masked input with output
-        callSwapPointers(rewriter, module, loc, maskedInput, output);
-        callSwapIndices(rewriter, module, loc, maskedInput, output);
-        callSwapValues(rewriter, module, loc, maskedInput, output);
-        rewriter.create<sparse_tensor::ReleaseOp>(loc, maskedInput);
       } else {
         // input -> output(mask)
 
@@ -3286,6 +3281,40 @@ public:
     Value isEqual = ifOuter.getResult(0);
 
     rewriter.replaceOp(op, isEqual);
+
+    return success();
+  };
+};
+
+class LowerSelectMaskRewrite : public OpRewritePattern<graphblas::SelectMaskOp> {
+public:
+  using OpRewritePattern<graphblas::SelectMaskOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(graphblas::SelectMaskOp op,
+                                PatternRewriter &rewriter) const override {
+    ModuleOp module = op->getParentOfType<ModuleOp>();
+    Location loc = op->getLoc();
+
+    //Inputs
+    Value input = op.input();
+    Value mask = op.mask();
+    bool maskComplement = op.mask_complement();
+    RankedTensorType inputTensorType = input.getType().dyn_cast<RankedTensorType>();
+
+    Value output = callEmptyLike(rewriter, module, loc, input);
+    EwiseBehavior maskBehavior = (maskComplement ? MASK_COMPLEMENT : MASK);
+
+    unsigned rank = inputTensorType.getRank();
+    if (rank == 2) {
+      computeMatrixElementWise(rewriter, loc, module, input, mask, output,
+                               nullptr, maskBehavior);
+    } else {
+      computeVectorElementWise(rewriter, loc, module, input, mask, output,
+                               nullptr, maskBehavior);
+    }
+
+    rewriter.replaceOp(op, output);
+
+    cleanupIntermediateTensor(rewriter, module, loc, output);
 
     return success();
   };
@@ -4317,7 +4346,8 @@ void populateGraphBLASLoweringPatterns(RewritePatternSet &patterns) {
                LowerUnionRewrite, LowerUnionGenericRewrite,
                LowerIntersectRewrite, LowerIntersectGenericRewrite,
                LowerUpdateRewrite, LowerUpdateGenericRewrite, LowerEqualRewrite,
-               LowerDiagOpRewrite, LowerCommentRewrite, LowerPrintRewrite,
+               LowerDiagOpRewrite, LowerSelectMaskRewrite,
+               LowerCommentRewrite, LowerPrintRewrite,
                LowerPrintTensorRewrite, LowerSizeRewrite, LowerNumRowsRewrite,
                LowerNumColsRewrite, LowerNumValsRewrite, LowerDupRewrite,
                LowerFromCoordinatesRewrite, LowerToCoordinatesRewrite>(

--- a/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOps.cpp
+++ b/mlir_graphblas/src/lib/GraphBLAS/GraphBLASOps.cpp
@@ -674,11 +674,12 @@ static LogicalResult verify(UpdateGenericOp op) {
 }
 
 static LogicalResult verify(SelectMaskOp op) {
-  if (failed(verifyEwise<SelectMaskOp>(op, op.input(), op.getResult(),
-                                       "input", "output", /* verifyType */ true)))
+  if (failed(verifyEwise<SelectMaskOp>(op, op.input(), op.getResult(), "input",
+                                       "output", /* verifyType */ true)))
     return failure();
 
-  if (failed(verifyEwise<SelectMaskOp>(op, op.output(), op.mask(), "output", "mask",
+  if (failed(verifyEwise<SelectMaskOp>(op, op.output(), op.mask(), "output",
+                                       "mask",
                                        /* verifyType */ false)))
     return failure();
 
@@ -718,7 +719,7 @@ static LogicalResult verify(UnionOp op) {
   if (mask) {
     if (failed(verifyEwise<UnionOp>(op, op.getResult(), mask, "output", "mask",
                                     /* verifyType */ false)))
-    return failure();
+      return failure();
   }
 
   return success();
@@ -758,9 +759,10 @@ static LogicalResult verify(IntersectOp op) {
 
   Value mask = op.mask();
   if (mask) {
-    if (failed(verifyEwise<IntersectOp>(op, op.getResult(), mask, "output", "mask",
-                                      /* verifyType */ false)))
-    return failure();
+    if (failed(verifyEwise<IntersectOp>(op, op.getResult(), mask, "output",
+                                        "mask",
+                                        /* verifyType */ false)))
+      return failure();
   }
 
   return success();

--- a/mlir_graphblas/src/test/GraphBLAS/test_select_mask.mlir
+++ b/mlir_graphblas/src/test/GraphBLAS/test_select_mask.mlir
@@ -1,0 +1,117 @@
+// RUN: graphblas-opt %s | graphblas-exec entry | FileCheck %s
+
+#CSR64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "dense", "compressed" ],
+  dimOrdering = affine_map<(i,j) -> (i,j)>,
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+#CSC64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "dense", "compressed" ],
+  dimOrdering = affine_map<(i,j) -> (j,i)>,
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+#CV64 = #sparse_tensor.encoding<{
+  dimLevelType = [ "compressed" ],
+  pointerBitWidth = 64,
+  indexBitWidth = 64
+}>
+
+module {
+  func @entry() {
+
+    ///////////////
+    // Test Matrix
+    ///////////////
+
+    %m = arith.constant sparse<[
+      [0, 1], [0, 2],
+      [1, 0], [1, 3], [1, 4],
+      [3, 2]
+    ], [1., 2., 3., 4., 5., 6.]> : tensor<4x5xf64>
+    %m_csr = sparse_tensor.convert %m : tensor<4x5xf64> to tensor<?x?xf64, #CSR64>
+    %m_csc = sparse_tensor.convert %m : tensor<4x5xf64> to tensor<?x?xf64, #CSC64>
+
+    // CSR select mask
+    //
+    // CHECK:      shape=(4, 5)
+    // CHECK:      pointers=(0, 1, 2, 2, 3)
+    // CHECK-NEXT: indices=(1, 3, 2)
+    // CHECK-NEXT: values=(1, 4, 6)
+    //
+    %mask = arith.constant sparse<[
+      [0, 1], [0, 3], [0, 4],
+      [1, 3],
+      [2, 2],
+      [3, 2]
+    ], [100., 200., 300., 400., 500., 600.]> : tensor<4x5xf64>
+    %mask_csr = sparse_tensor.convert %mask : tensor<4x5xf64> to tensor<?x?xf64, #CSR64>
+    %0 = graphblas.select_mask %m_csr, %mask_csr : tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSR64> to tensor<?x?xf64, #CSR64>
+    graphblas.print_tensor %0 { level=4 } : tensor<?x?xf64, #CSR64>
+
+    // CSR select mask complement
+    //
+    // CHECK:      shape=(4, 5)
+    // CHECK:      pointers=(0, 1, 3, 3, 3)
+    // CHECK-NEXT: indices=(2, 0, 4)
+    // CHECK-NEXT: values=(2, 3, 5)
+    %1 = graphblas.select_mask %m_csr, %mask_csr {mask_complement=true} : tensor<?x?xf64, #CSR64>, tensor<?x?xf64, #CSR64> to tensor<?x?xf64, #CSR64>
+    graphblas.print_tensor %1 { level=4 } : tensor<?x?xf64, #CSR64>
+
+    // CSC select mask different element type
+    //
+    // CHECK:      rev=(1, 0)
+    // CHECK:      shape=(4, 5)
+    // CHECK:      pointers=(0, 0, 1, 2, 3, 3)
+    // CHECK-NEXT: indices=(0, 3, 1)
+    // CHECK-NEXT: values=(1, 6, 4)
+    //
+    %mask2 = arith.constant sparse<[
+      [0, 1], [0, 3], [0, 4],
+      [1, 3],
+      [2, 2],
+      [3, 2]
+    ], [100, 200, 300, 400, 500, 600]> : tensor<4x5xi32>
+    %mask_csc = sparse_tensor.convert %mask2 : tensor<4x5xi32> to tensor<?x?xi32, #CSC64>
+    %10 = graphblas.select_mask %m_csc, %mask_csc : tensor<?x?xf64, #CSC64>, tensor<?x?xi32, #CSC64> to tensor<?x?xf64, #CSC64>
+    graphblas.print_tensor %10 { level=5 } : tensor<?x?xf64, #CSC64>
+
+    ///////////////
+    // Test Vector
+    ///////////////
+
+    %v = arith.constant sparse<[
+      [1], [2], [4], [7]
+    ], [1., 2., 3., 4.]> : tensor<9xf64>
+    %v_cv = sparse_tensor.convert %v : tensor<9xf64> to tensor<?xf64, #CV64>
+
+    // Vector select mask
+    //
+    // CHECK:      shape=(9)
+    // CHECK:      pointers=(0, 2)
+    // CHECK-NEXT: indices=(2, 4)
+    // CHECK-NEXT: values=(2, 3)
+    //
+    %mask3 = arith.constant sparse<[
+      [2], [3], [4]
+    ], [200., 300., 400.]> : tensor<9xf64>
+    %mask_cv = sparse_tensor.convert %mask3 : tensor<9xf64> to tensor<?xf64, #CV64>
+    %20 = graphblas.select_mask %v_cv, %mask_cv : tensor<?xf64, #CV64>, tensor<?xf64, #CV64> to tensor<?xf64, #CV64>
+    graphblas.print_tensor %20 { level=4 } : tensor<?xf64, #CV64>
+
+    // Vector select mask complement
+    //
+    // CHECK:      shape=(9)
+    // CHECK:      pointers=(0, 2)
+    // CHECK-NEXT: indices=(1, 7)
+    // CHECK-NEXT: values=(1, 4)
+    //
+    %21 = graphblas.select_mask %v_cv, %mask_cv {mask_complement=true} : tensor<?xf64, #CV64>, tensor<?xf64, #CV64> to tensor<?xf64, #CV64>
+    graphblas.print_tensor %21 { level=4 } : tensor<?xf64, #CV64>
+
+    return
+  }
+}


### PR DESCRIPTION
- ReduceToVector (accepts a vector mask)
- Intersect
- Union

Includes a new `select_mask` operation which selects from a tensor given a mask (or mask complement).
This allows manually performing an input mask for things like `apply`.