### PR TITLE
Need to pin markupsafe if we restrict jinja2 version

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -26,7 +26,7 @@ dependencies:
       - rst2pdf
 
 # dependencies (so setup.py develop doesn't pip install them)
-  - metagraph/label/dev::mlir # temp restriction to use metagraph dev label
+  - metagraph/label/dev::mlir-ac=14.0=*_0 # temp restriction to use metagraph dev label
   - metagraph::pymlir
   - scipy
   - conda-forge::grblas

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -15,8 +15,6 @@ dependencies:
 
 # documentation
   - sphinx=3.0.4
-  #- jinja2<3.0.0
-  #- markupsafe=2.0.1
   - nbsphinx
   - notebook
   - conda-forge::pydata-sphinx-theme

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -15,8 +15,8 @@ dependencies:
 
 # documentation
   - sphinx=3.0.4
-  - jinja2<3.0.0
-  - markupsafe=2.0.1
+  #- jinja2<3.0.0
+  #- markupsafe=2.0.1
   - nbsphinx
   - notebook
   - conda-forge::pydata-sphinx-theme

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -16,6 +16,7 @@ dependencies:
 # documentation
   - sphinx=3.0.4
   - jinja2<3.0.0
+  - markupsafe=2.0.1
   - nbsphinx
   - notebook
   - conda-forge::pydata-sphinx-theme


### PR DESCRIPTION
See https://github.com/pallets/markupsafe/issues/284 for issue